### PR TITLE
feat: YouTube URL support (frontend + backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ blob/
 .DS_Store
 .vscode/
 .idea/
+LINEAR_TICKETS.md
+STUDY_GUIDE.md
+PRD.md

--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -29,7 +29,7 @@ def get_blob_store() -> LocalBlobStore:
 def get_runner() -> PipelineRunner:
     blob = get_blob_store()
     return PipelineRunner(
-        ingest=IngestService(),
+        ingest=IngestService(blob_store=blob),
         transcribe=TranscribeService(),
         arrange=ArrangeService(),
         humanize=HumanizeService(),

--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -28,6 +28,112 @@ from backend.contracts import (
 log = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# YouTube URL helpers — stubs, implementation TBD
+# ---------------------------------------------------------------------------
+
+_YOUTUBE_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "music.youtube.com", "youtu.be"}
+
+
+def is_youtube_url(value: str | None) -> bool:
+    """Return True if *value* looks like a YouTube video URL."""
+    if not value:
+        return False
+    return extract_youtube_id(value) is not None
+
+
+def extract_youtube_id(url: str) -> str | None:
+    """Extract the 11-character video ID from a YouTube URL, or None."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    host = (parsed.hostname or "").lower()
+    if host not in _YOUTUBE_HOSTS:
+        return None
+    # youtu.be/<id>
+    if host == "youtu.be":
+        video_id = parsed.path.lstrip("/").split("/")[0]
+    else:
+        # youtube.com/watch?v=<id>
+        from urllib.parse import parse_qs
+        video_id = parse_qs(parsed.query).get("v", [None])[0]
+    if video_id and len(video_id) == 11:
+        return video_id
+    return None
+
+
+def _download_youtube_sync(url: str, blob_store) -> RemoteAudioFile:
+    """Download audio from a YouTube URL via yt-dlp, store in blob_store.
+
+    Returns a RemoteAudioFile pointing to the stored WAV.
+    This is called via asyncio.to_thread() so it can block.
+    """
+    import hashlib
+    import tempfile
+
+    try:
+        import yt_dlp
+    except ImportError:
+        raise RuntimeError(
+            "yt-dlp is required for YouTube downloads. "
+            "Install with: pip install ohsheet[youtube]"
+        )
+
+    video_id = extract_youtube_id(url)
+    if video_id is None:
+        raise ValueError(f"Could not extract video ID from URL: {url}")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_template = str(Path(tmp_dir) / "%(id)s.%(ext)s")
+
+        ydl_opts = {
+            "format": "bestaudio/best",
+            "postprocessors": [{
+                "key": "FFmpegExtractAudio",
+                "preferredcodec": "wav",
+                "preferredquality": "0",
+            }],
+            "outtmpl": output_template,
+            "quiet": True,
+            "no_warnings": True,
+            "socket_timeout": 30,
+        }
+
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=True)
+        except Exception as exc:
+            raise RuntimeError(f"yt-dlp download failed for {url}: {exc}") from exc
+
+        # Find the downloaded WAV file
+        wav_path = Path(tmp_dir) / f"{info['id']}.wav"
+        if not wav_path.exists():
+            # yt-dlp may use a different naming — find any .wav in the dir
+            wav_files = list(Path(tmp_dir).glob("*.wav"))
+            if not wav_files:
+                raise RuntimeError(f"No WAV file produced by yt-dlp for {url}")
+            wav_path = wav_files[0]
+
+        audio_bytes = wav_path.read_bytes()
+        content_hash = hashlib.sha256(audio_bytes).hexdigest()
+
+        blob_key = f"youtube/{video_id}.wav"
+        uri = blob_store.put_bytes(blob_key, audio_bytes)
+
+        duration = float(info.get("duration", 0))
+        sample_rate = int(info.get("asr", 44100) or 44100)
+
+        return RemoteAudioFile(
+            uri=uri,
+            format="wav",
+            sample_rate=sample_rate,
+            duration_sec=duration,
+            channels=2,
+            content_hash=content_hash,
+        )
+
+
 def _file_path(uri: str) -> Path | None:
     """Return a local Path for ``file://`` URIs, or None for anything else."""
     parsed = urlparse(uri)
@@ -86,9 +192,25 @@ def _probe_midi_sync(midi: RemoteMidiFile) -> RemoteMidiFile:
 class IngestService:
     name = "ingest"
 
+    def __init__(self, blob_store=None):
+        self._blob_store = blob_store
+
     async def run(self, payload: InputBundle) -> InputBundle:
         audio = payload.audio
         midi = payload.midi
+
+        # YouTube URL detection: if no audio/midi and title is a YouTube URL,
+        # download the audio and attach it to the bundle.
+        if (
+            audio is None
+            and midi is None
+            and payload.metadata.source == "title_lookup"
+            and is_youtube_url(payload.metadata.title)
+        ):
+            audio = await asyncio.to_thread(
+                _download_youtube_sync, payload.metadata.title, self._blob_store,
+            )
+
         if audio is not None:
             audio = await asyncio.to_thread(_probe_audio_sync, audio)
         if midi is not None:

--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -97,6 +97,7 @@ def _download_youtube_sync(url: str, blob_store) -> RemoteAudioFile:
             "outtmpl": output_template,
             "quiet": True,
             "no_warnings": True,
+            "noplaylist": True,
             "socket_timeout": 30,
         }
 

--- a/frontend/lib/screens/upload_screen.dart
+++ b/frontend/lib/screens/upload_screen.dart
@@ -10,7 +10,7 @@ import '../api/client.dart';
 import '../api/models.dart';
 import 'progress_screen.dart';
 
-enum _SourceMode { audio, midi, title }
+enum _SourceMode { audio, midi, title, youtube }
 
 class UploadScreen extends StatefulWidget {
   const UploadScreen({super.key, required this.api});
@@ -24,15 +24,30 @@ class _UploadScreenState extends State<UploadScreen> {
   _SourceMode _mode = _SourceMode.audio;
   final _titleController = TextEditingController();
   final _artistController = TextEditingController();
+  final _youtubeController = TextEditingController();
 
   PlatformFile? _pickedFile;
   bool _submitting = false;
   String? _error;
 
+  static final _youtubeRegex = RegExp(
+    r'^https?://(www\.|music\.|m\.)?youtu(\.be/|be\.com/watch\?v=)([\w-]{11})',
+  );
+
+  bool get _isValidYoutubeUrl => _youtubeRegex.hasMatch(_youtubeController.text.trim());
+
+  String? get _youtubeValidationError {
+    final text = _youtubeController.text.trim();
+    if (text.isEmpty) return null;
+    if (!_isValidYoutubeUrl) return 'Enter a valid YouTube URL';
+    return null;
+  }
+
   @override
   void dispose() {
     _titleController.dispose();
     _artistController.dispose();
+    _youtubeController.dispose();
     super.dispose();
   }
 
@@ -107,6 +122,17 @@ class _UploadScreenState extends State<UploadScreen> {
                 : _artistController.text.trim(),
           );
           break;
+        case _SourceMode.youtube:
+          final url = _youtubeController.text.trim();
+          if (url.isEmpty) throw StateError('Enter a YouTube URL');
+          if (!_isValidYoutubeUrl) throw StateError('Enter a valid YouTube URL');
+          job = await widget.api.createJob(
+            title: url,
+            artist: _artistController.text.trim().isEmpty
+                ? null
+                : _artistController.text.trim(),
+          );
+          break;
       }
 
       if (!mounted) return;
@@ -124,11 +150,13 @@ class _UploadScreenState extends State<UploadScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final needsFile = _mode != _SourceMode.title;
+    final needsFile = _mode == _SourceMode.audio || _mode == _SourceMode.midi;
     final canSubmit = !_submitting &&
-        (_mode == _SourceMode.title
-            ? _titleController.text.trim().isNotEmpty
-            : _pickedFile != null);
+        switch (_mode) {
+          _SourceMode.title => _titleController.text.trim().isNotEmpty,
+          _SourceMode.youtube => _isValidYoutubeUrl,
+          _ => _pickedFile != null,
+        };
 
     return Scaffold(
       appBar: AppBar(title: const Text('Oh Sheet')),
@@ -142,6 +170,7 @@ class _UploadScreenState extends State<UploadScreen> {
                 ButtonSegment(value: _SourceMode.audio, label: Text('Audio')),
                 ButtonSegment(value: _SourceMode.midi, label: Text('MIDI')),
                 ButtonSegment(value: _SourceMode.title, label: Text('Title')),
+                ButtonSegment(value: _SourceMode.youtube, label: Text('YouTube')),
               ],
               selected: {_mode},
               onSelectionChanged: (s) => setState(() {
@@ -165,24 +194,46 @@ class _UploadScreenState extends State<UploadScreen> {
               ),
               const SizedBox(height: 16),
             ],
-            TextField(
-              controller: _titleController,
-              decoration: InputDecoration(
-                labelText: _mode == _SourceMode.title
-                    ? 'Song title (required)'
-                    : 'Title (optional)',
-                border: const OutlineInputBorder(),
+            if (_mode == _SourceMode.youtube) ...[
+              TextField(
+                controller: _youtubeController,
+                decoration: InputDecoration(
+                  labelText: 'YouTube URL',
+                  hintText: 'https://youtube.com/watch?v=...',
+                  errorText: _youtubeValidationError,
+                  prefixIcon: const Icon(Icons.play_circle_outline),
+                  border: const OutlineInputBorder(),
+                ),
+                onChanged: (_) => setState(() {}),
               ),
-              onChanged: (_) => setState(() {}),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _artistController,
-              decoration: const InputDecoration(
-                labelText: 'Artist (optional)',
-                border: OutlineInputBorder(),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _artistController,
+                decoration: const InputDecoration(
+                  labelText: 'Artist (optional)',
+                  border: OutlineInputBorder(),
+                ),
               ),
-            ),
+            ] else ...[
+              TextField(
+                controller: _titleController,
+                decoration: InputDecoration(
+                  labelText: _mode == _SourceMode.title
+                      ? 'Song title (required)'
+                      : 'Title (optional)',
+                  border: const OutlineInputBorder(),
+                ),
+                onChanged: (_) => setState(() {}),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _artistController,
+                decoration: const InputDecoration(
+                  labelText: 'Artist (optional)',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
             const SizedBox(height: 24),
             FilledButton.icon(
               onPressed: canSubmit ? _submit : null,

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  boolean_selector:
+    dependency: transitive
+    description:
+      name: boolean_selector
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
@@ -17,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -41,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -78,6 +102,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.34"
+  flutter_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -99,6 +128,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.2"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -107,6 +160,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  matcher:
+    dependency: transitive
+    description:
+      name: matcher
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -152,6 +213,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  stack_trace:
+    dependency: transitive
+    description:
+      name: stack_trace
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
@@ -176,6 +245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -256,6 +333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.2"
   web:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^4.0.0
+  flutter_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/frontend/test/upload_screen_youtube_test.dart
+++ b/frontend/test/upload_screen_youtube_test.dart
@@ -1,0 +1,154 @@
+/// TDD: Tests for YouTube URL input mode on UploadScreen.
+/// Written FIRST, before implementation.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'dart:convert';
+
+import 'package:ohsheet_app/api/client.dart';
+import 'package:ohsheet_app/screens/upload_screen.dart';
+
+/// Mock API that returns a canned JobSummary for any createJob call.
+OhSheetApi _mockApi() {
+  final mockClient = http_testing.MockClient((request) async {
+    if (request.url.path == '/v1/jobs') {
+      return http.Response(
+        jsonEncode({
+          'job_id': 'test-123',
+          'status': 'queued',
+          'variant': 'full',
+          'title': 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+        }),
+        202,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('Not found', 404);
+  });
+  return OhSheetApi(client: mockClient);
+}
+
+Widget _app(OhSheetApi api) => MaterialApp(
+      home: UploadScreen(api: api),
+    );
+
+void main() {
+  group('YouTube segment button', () {
+    testWidgets('YouTube segment is visible in the SegmentedButton',
+        (tester) async {
+      await tester.pumpWidget(_app(_mockApi()));
+      // There should be a "YouTube" segment label
+      expect(find.text('YouTube'), findsOneWidget);
+    });
+
+    testWidgets('selecting YouTube mode shows URL text field', (tester) async {
+      await tester.pumpWidget(_app(_mockApi()));
+      // Tap the YouTube segment
+      await tester.tap(find.text('YouTube'));
+      await tester.pumpAndSettle();
+
+      // Should show a URL input field with YouTube-specific hint
+      expect(find.widgetWithText(TextField, 'YouTube URL'), findsOneWidget);
+    });
+
+    testWidgets('selecting YouTube mode hides the file picker', (tester) async {
+      await tester.pumpWidget(_app(_mockApi()));
+      await tester.tap(find.text('YouTube'));
+      await tester.pumpAndSettle();
+
+      // File picker button should NOT be visible in YouTube mode
+      expect(find.text('Pick audio file (mp3/wav/flac/m4a)'), findsNothing);
+      expect(find.text('Pick MIDI file (.mid/.midi)'), findsNothing);
+    });
+  });
+
+  group('YouTube URL validation', () {
+    testWidgets('submit button is disabled when URL field is empty',
+        (tester) async {
+      await tester.pumpWidget(_app(_mockApi()));
+      await tester.tap(find.text('YouTube'));
+      await tester.pumpAndSettle();
+
+      // Transcribe button should exist but be disabled
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('submit button is enabled with a valid YouTube URL',
+        (tester) async {
+      await tester.pumpWidget(_app(_mockApi()));
+      await tester.tap(find.text('YouTube'));
+      await tester.pumpAndSettle();
+
+      // Type a valid YouTube URL
+      await tester.enterText(
+        find.widgetWithText(TextField, 'YouTube URL'),
+        'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      );
+      await tester.pumpAndSettle();
+
+      // Transcribe button should be enabled
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('shows error for invalid URL format', (tester) async {
+      await tester.pumpWidget(_app(_mockApi()));
+      await tester.tap(find.text('YouTube'));
+      await tester.pumpAndSettle();
+
+      // Type an invalid URL
+      await tester.enterText(
+        find.widgetWithText(TextField, 'YouTube URL'),
+        'not-a-youtube-url',
+      );
+      await tester.pumpAndSettle();
+
+      // Should show validation error
+      expect(find.textContaining('valid YouTube URL'), findsOneWidget);
+    });
+  });
+
+  group('YouTube job submission', () {
+    testWidgets('submitting a YouTube URL sends title field to API',
+        (tester) async {
+      String? capturedTitle;
+      final mockClient = http_testing.MockClient((request) async {
+        if (request.url.path == '/v1/jobs') {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          capturedTitle = body['title'] as String?;
+          return http.Response(
+            jsonEncode({
+              'job_id': 'yt-test-456',
+              'status': 'queued',
+              'variant': 'full',
+              'title': capturedTitle,
+            }),
+            202,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      final api = OhSheetApi(client: mockClient);
+
+      await tester.pumpWidget(_app(api));
+      await tester.tap(find.text('YouTube'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'YouTube URL'),
+        'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      );
+      await tester.pumpAndSettle();
+
+      // Tap Transcribe
+      await tester.tap(find.text('Transcribe'));
+      await tester.pumpAndSettle();
+
+      // The API should have received the YouTube URL as the title
+      expect(capturedTitle, 'https://youtube.com/watch?v=dQw4w9WgXcQ');
+    });
+  });
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dev = [
     "pytest>=8.0",
     "httpx>=0.26",
 ]
+youtube = [
+    "yt-dlp>=2024.1",
+]
 # Pretrained MT3 baseline (backend.vendor.mr_mt3). Heavy ML deps — installed
 # only when you actually want to run the model. Without these the
 # TranscribeService falls back to a stub TranscriptionResult.

--- a/tests/test_ingest_youtube.py
+++ b/tests/test_ingest_youtube.py
@@ -1,0 +1,228 @@
+"""Tests for YouTube URL ingestion in IngestService.
+
+TDD: these tests are written FIRST, before the implementation.
+They define the expected behavior for YouTube URL detection and download.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.contracts import (
+    SCHEMA_VERSION,
+    InputBundle,
+    InputMetadata,
+    RemoteAudioFile,
+)
+from backend.services.ingest import IngestService, is_youtube_url, extract_youtube_id
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: YouTube URL detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsYoutubeUrl:
+    """is_youtube_url() should match common YouTube URL formats and reject
+    everything else — plain song titles, Spotify links, empty strings, etc."""
+
+    def test_standard_watch_url(self):
+        assert is_youtube_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is True
+
+    def test_short_url(self):
+        assert is_youtube_url("https://youtu.be/dQw4w9WgXcQ") is True
+
+    def test_no_www(self):
+        assert is_youtube_url("https://youtube.com/watch?v=dQw4w9WgXcQ") is True
+
+    def test_http_without_s(self):
+        assert is_youtube_url("http://youtube.com/watch?v=dQw4w9WgXcQ") is True
+
+    def test_with_extra_params(self):
+        assert is_youtube_url("https://youtube.com/watch?v=dQw4w9WgXcQ&t=42") is True
+
+    def test_music_youtube(self):
+        assert is_youtube_url("https://music.youtube.com/watch?v=dQw4w9WgXcQ") is True
+
+    def test_plain_title_is_not_youtube(self):
+        assert is_youtube_url("Yesterday") is False
+
+    def test_empty_string_is_not_youtube(self):
+        assert is_youtube_url("") is False
+
+    def test_spotify_url_is_not_youtube(self):
+        assert is_youtube_url("https://open.spotify.com/track/abc123") is False
+
+    def test_none_is_not_youtube(self):
+        assert is_youtube_url(None) is False
+
+
+class TestExtractYoutubeId:
+    """extract_youtube_id() should pull the 11-character video ID from any
+    supported YouTube URL format."""
+
+    def test_standard_watch_url(self):
+        assert extract_youtube_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_short_url(self):
+        assert extract_youtube_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_with_extra_params(self):
+        assert extract_youtube_id("https://youtube.com/watch?v=dQw4w9WgXcQ&t=42") == "dQw4w9WgXcQ"
+
+    def test_music_youtube(self):
+        assert extract_youtube_id("https://music.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_returns_none_for_non_youtube(self):
+        assert extract_youtube_id("Yesterday") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: IngestService with YouTube URLs
+# ---------------------------------------------------------------------------
+
+
+class TestIngestServiceYoutube:
+    """When IngestService.run() receives a title_lookup bundle where the title
+    is a YouTube URL, it should download the audio and return a bundle with
+    audio populated."""
+
+    def _make_youtube_bundle(self, url: str = "https://youtube.com/watch?v=dQw4w9WgXcQ") -> InputBundle:
+        return InputBundle(
+            schema_version=SCHEMA_VERSION,
+            audio=None,
+            midi=None,
+            metadata=InputMetadata(title=url, artist=None, source="title_lookup"),
+        )
+
+    @pytest.fixture
+    def blob_store(self, tmp_path):
+        from backend.storage.local import LocalBlobStore
+        return LocalBlobStore(tmp_path / "blob")
+
+    @pytest.fixture
+    def service(self, blob_store):
+        return IngestService(blob_store=blob_store)
+
+    def test_youtube_url_populates_audio_on_bundle(self, service, blob_store):
+        """After ingesting a YouTube URL, the returned bundle should have
+        audio set to a RemoteAudioFile with a valid BlobStore URI."""
+        bundle = self._make_youtube_bundle()
+
+        with patch("backend.services.ingest._download_youtube_sync") as mock_dl:
+            # Simulate yt-dlp returning a small WAV file
+            mock_dl.return_value = RemoteAudioFile(
+                uri="file:///tmp/blob/yt_dQw4w9WgXcQ.wav",
+                format="wav",
+                sample_rate=44100,
+                duration_sec=180.0,
+                channels=2,
+                content_hash="abc123",
+            )
+
+            result = asyncio.run(service.run(bundle))
+
+        assert result.audio is not None
+        assert result.audio.format == "wav"
+        assert result.audio.duration_sec == 180.0
+        mock_dl.assert_called_once()
+
+    def test_youtube_url_preserves_metadata(self, service):
+        """The original title (YouTube URL) and artist should be preserved
+        in metadata after ingestion."""
+        url = "https://youtube.com/watch?v=dQw4w9WgXcQ"
+        bundle = self._make_youtube_bundle(url)
+
+        with patch("backend.services.ingest._download_youtube_sync") as mock_dl:
+            mock_dl.return_value = RemoteAudioFile(
+                uri="file:///tmp/fake.wav",
+                format="wav",
+                sample_rate=44100,
+                duration_sec=60.0,
+                channels=2,
+            )
+            result = asyncio.run(service.run(bundle))
+
+        assert result.metadata.title == url
+        assert result.metadata.source == "title_lookup"
+
+    def test_non_youtube_title_passes_through_unchanged(self, service):
+        """A plain song title (not a YouTube URL) should pass through
+        without attempting a download — audio stays None."""
+        bundle = InputBundle(
+            schema_version=SCHEMA_VERSION,
+            audio=None,
+            midi=None,
+            metadata=InputMetadata(title="Yesterday", artist="The Beatles", source="title_lookup"),
+        )
+
+        with patch("backend.services.ingest._download_youtube_sync") as mock_dl:
+            result = asyncio.run(service.run(bundle))
+
+        mock_dl.assert_not_called()
+        assert result.audio is None
+
+    def test_audio_upload_skips_youtube_detection(self, service):
+        """If the bundle already has audio (audio_upload variant), YouTube
+        detection should not run — even if title looks like a URL."""
+        existing_audio = RemoteAudioFile(
+            uri="file:///tmp/uploaded.wav",
+            format="wav",
+            sample_rate=44100,
+            duration_sec=120.0,
+            channels=2,
+        )
+        bundle = InputBundle(
+            schema_version=SCHEMA_VERSION,
+            audio=existing_audio,
+            midi=None,
+            metadata=InputMetadata(
+                title="https://youtube.com/watch?v=dQw4w9WgXcQ",
+                artist=None,
+                source="audio_upload",
+            ),
+        )
+
+        with patch("backend.services.ingest._download_youtube_sync") as mock_dl:
+            result = asyncio.run(service.run(bundle))
+
+        mock_dl.assert_not_called()
+        assert result.audio.uri == "file:///tmp/uploaded.wav"
+
+
+# ---------------------------------------------------------------------------
+# E2E test: YouTube URL through full job API
+# ---------------------------------------------------------------------------
+
+
+def test_youtube_url_job_runs_full_variant(client):
+    """Submitting a YouTube URL as the title should trigger the 'full'
+    pipeline variant and run to completion (with mocked yt-dlp)."""
+    with patch("backend.services.ingest._download_youtube_sync") as mock_dl:
+        mock_dl.return_value = RemoteAudioFile(
+            uri="file:///tmp/fake.wav",
+            format="wav",
+            sample_rate=44100,
+            duration_sec=60.0,
+            channels=2,
+        )
+
+        resp = client.post("/v1/jobs", json={
+            "title": "https://youtube.com/watch?v=dQw4w9WgXcQ",
+        })
+        assert resp.status_code == 202
+        job = resp.json()
+        assert job["variant"] == "full"
+
+        import time
+        deadline = time.time() + 5
+        status = None
+        while time.time() < deadline:
+            status = client.get(f"/v1/jobs/{job['job_id']}").json()
+            if status["status"] in ("succeeded", "failed"):
+                break
+            time.sleep(0.05)
+
+        assert status["status"] == "succeeded", status


### PR DESCRIPTION
## Summary
- Add YouTube URL detection and yt-dlp audio download to the ingest service (zero contract/API changes — uses existing `title` field)
- Add YouTube input mode to Flutter upload screen with client-side URL validation
- Fix blob_store injection for IngestService and prevent playlist downloads

## What changed

**Backend (`backend/services/ingest.py`)**
- `is_youtube_url()` and `extract_youtube_id()` helpers for URL parsing
- `_download_youtube_sync()` downloads audio via yt-dlp, stores in BlobStore
- `IngestService.run()` detects YouTube URLs in title field and downloads audio transparently
- `noplaylist: True` prevents downloading entire playlists/radio mixes

**Frontend (`frontend/lib/screens/upload_screen.dart`)**
- Fourth segment "YouTube" added to upload screen
- YouTube URL text field with regex validation and inline error display
- Submits URL via existing `title` field on `POST /v1/jobs` — no API changes

**Infra**
- `yt-dlp` added as optional `[youtube]` dependency in `pyproject.toml`
- `flutter_test` added to frontend dev dependencies
- `deps.py` passes `blob_store` to `IngestService`

## Test plan
- [x] 20 new backend tests (URL parsing, service integration, e2e job flow)
- [x] 7 new Flutter widget tests (segment visibility, URL validation, job submission)
- [x] All 36 backend + 7 Flutter tests pass
- [x] Tested locally in browser — YouTube URL downloads and runs through full pipeline
- [ ] Requires `ffmpeg` installed on system (needed for yt-dlp audio conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)