### PR TITLE
fix: use correct gcloud flag for Cloud Run startup probe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
             --cpu ${{ vars.CLOUD_RUN_CPU || '1' }} \
             --min-instances 0 \
             --max-instances 3 \
-            --health-check-path /v1/health \
+            --http-startup-probe /v1/health \
             --set-env-vars "OHSHEET_CORS_ORIGINS=*"
 
       - name: Show deployment URL


### PR DESCRIPTION
## Summary
- Replace `--health-check-path` (not a valid gcloud flag) with `--http-startup-probe` in the deploy workflow
- This fixes the failed deploy after PR #10 was merged

## Test plan
- [ ] Deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)