### PR TITLE
fix: correct startup-probe flag syntax for Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
             --cpu ${{ vars.CLOUD_RUN_CPU || '1' }} \
             --min-instances 0 \
             --max-instances 3 \
-            --http-startup-probe /v1/health \
+            --startup-probe=httpGet.path=/v1/health \
             --set-env-vars "OHSHEET_CORS_ORIGINS=*"
 
       - name: Show deployment URL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
             --cpu ${{ vars.CLOUD_RUN_CPU || '1' }} \
             --min-instances 0 \
             --max-instances 3 \
-            --health-check-path /v1/health \
+            --http-startup-probe /v1/health \
             --set-env-vars "OHSHEET_CORS_ORIGINS=*"
 
       - name: Show deployment URL


### PR DESCRIPTION
## Summary
- Fix `gcloud run deploy` flag: `--startup-probe=httpGet.path=/v1/health` (key=value format)
- Previous attempts used non-existent flags (`--health-check-path`, `--http-startup-probe`)

## Test plan
- [ ] Deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)