### PR TITLE
fix: pass CORS origins as JSON array for pydantic-settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
             --min-instances 0 \
             --max-instances 3 \
             --startup-probe=httpGet.path=/v1/health \
-            --set-env-vars "OHSHEET_CORS_ORIGINS=*"
+            --set-env-vars 'OHSHEET_CORS_ORIGINS=["*"]'
 
       - name: Show deployment URL
         run: |


### PR DESCRIPTION
## Summary
- The container was crashing on startup because `OHSHEET_CORS_ORIGINS=*` can't be parsed by pydantic-settings — `cors_origins` is `list[str]`, so it expects JSON
- Changed to `OHSHEET_CORS_ORIGINS=["*"]`

## Test plan
- [ ] Deploy workflow succeeds and app is accessible on Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)