### PR TITLE
feat(transcribe): post-process Basic Pitch with cleanup + melody split

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -30,7 +30,7 @@ def get_runner() -> PipelineRunner:
     blob = get_blob_store()
     return PipelineRunner(
         ingest=IngestService(blob_store=blob),
-        transcribe=TranscribeService(),
+        transcribe=TranscribeService(blob_store=blob),
         arrange=ArrangeService(),
         humanize=HumanizeService(),
         engrave=EngraveService(blob_store=blob),

--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -18,13 +18,14 @@ from backend.storage.local import LocalBlobStore
 
 router = APIRouter()
 
-ArtifactKind = Literal["pdf", "musicxml", "midi"]
+ArtifactKind = Literal["pdf", "musicxml", "midi", "transcription_midi"]
 
 # kind → (uri attribute on EngravedOutput, media type, downloaded filename suffix)
 _KIND_INFO: dict[str, tuple[str, str, str]] = {
-    "pdf":      ("pdf_uri",            "application/pdf",                       "sheet.pdf"),
-    "musicxml": ("musicxml_uri",       "application/vnd.recordare.musicxml+xml", "score.musicxml"),
-    "midi":     ("humanized_midi_uri", "audio/midi",                            "humanized.mid"),
+    "pdf":                ("pdf_uri",                "application/pdf",                       "sheet.pdf"),
+    "musicxml":           ("musicxml_uri",           "application/vnd.recordare.musicxml+xml", "score.musicxml"),
+    "midi":               ("humanized_midi_uri",     "audio/midi",                            "humanized.mid"),
+    "transcription_midi": ("transcription_midi_uri", "audio/midi",                            "transcription.mid"),
 }
 
 
@@ -53,6 +54,15 @@ def download_artifact(
 
     attr, media_type, suffix = _KIND_INFO[kind]
     uri = getattr(record.result, attr)
+    if uri is None:
+        # Optional artifacts (e.g. transcription_midi) won't exist for
+        # every variant — midi_upload skips transcription, and the stub
+        # fallback doesn't persist a MIDI file. Return 404 so clients can
+        # distinguish "never produced" from "job failed".
+        raise HTTPException(
+            status_code=404,
+            detail=f"Job {job_id} has no {kind!r} artifact.",
+        )
 
     try:
         data = blob.get_bytes(uri)

--- a/backend/config.py
+++ b/backend/config.py
@@ -59,5 +59,35 @@ class Settings(BaseSettings):
     melody_max_transition_bins: int = 12         # ≈ 4 semitones / frame
     melody_match_fraction: float = 0.6
 
+    # Back-fill of stable Viterbi runs with no matching Basic Pitch note.
+    # See _backfill_missed_melody_notes in melody_extraction.py.
+    melody_backfill_enabled: bool = True
+    melody_backfill_min_duration_sec: float = 0.12
+    melody_backfill_overlap_fraction: float = 0.5
+    melody_backfill_min_amp: float = 0.15
+    melody_backfill_max_amp: float = 0.60
+
+    # ---- Bass extraction (Phase 3 post-processing) ------------------------
+    # Same Viterbi trick as melody extraction, run over the low-register
+    # slice of the contour matrix. Accepts the non-melody events from
+    # Phase 2 and splits them into BASS / remaining buckets. Defaults
+    # mirror bass_extraction.DEFAULT_* so config and tests agree.
+    bass_extraction_enabled: bool = True
+    bass_low_midi: int = 28                      # E1
+    bass_high_midi: int = 55                     # G3
+    bass_voicing_floor: float = 0.12
+    bass_transition_weight: float = 0.40
+    bass_max_transition_bins: int = 9            # ≈ 3 semitones / frame
+    bass_match_fraction: float = 0.55
+
+    # ---- Chord recognition (Phase 3 post-processing) ----------------------
+    # librosa chroma_cqt + 24 triad templates, beat-synced via the same
+    # beat tracker that drives the tempo map. Labels attach to
+    # ``HarmonicAnalysis.chords``; notes are unaffected. Disable via
+    # ``OHSHEET_CHORD_RECOGNITION_ENABLED=false``.
+    chord_recognition_enabled: bool = True
+    chord_min_template_score: float = 0.55
+    chord_hpss_margin: float = 3.0               # librosa.effects.harmonic margin
+
 
 settings = Settings()

--- a/backend/config.py
+++ b/backend/config.py
@@ -34,5 +34,30 @@ class Settings(BaseSettings):
     basic_pitch_frame_threshold: float = 0.3
     basic_pitch_minimum_note_length_ms: float = 127.7
 
+    # ---- Transcription cleanup (Phase 1 post-processing) -------------------
+    # Heuristic thresholds applied to Basic Pitch's note_events before we
+    # rebuild pretty_midi. See backend/services/transcription_cleanup.py for
+    # the semantics; these pass through as keyword args to cleanup_note_events.
+    cleanup_merge_gap_sec: float = 0.03
+    cleanup_octave_amp_ratio: float = 0.6
+    cleanup_octave_onset_tol_sec: float = 0.05
+    cleanup_ghost_max_duration_sec: float = 0.06
+    cleanup_ghost_amp_median_scale: float = 0.5
+
+    # ---- Melody extraction (Phase 2 post-processing) -----------------------
+    # Viterbi-based melody / chord split driven by Basic Pitch's
+    # ``model_output["contour"]`` salience matrix. See
+    # backend/services/melody_extraction.py for semantics. Disable via
+    # ``OHSHEET_MELODY_EXTRACTION_ENABLED=false`` to keep the legacy
+    # single-PIANO output. Defaults mirror the DEFAULT_* constants in the
+    # extraction module so config and tests agree.
+    melody_extraction_enabled: bool = True
+    melody_low_midi: int = 55                    # G3
+    melody_high_midi: int = 90                   # F#6
+    melody_voicing_floor: float = 0.15
+    melody_transition_weight: float = 0.25
+    melody_max_transition_bins: int = 12         # ≈ 4 semitones / frame
+    melody_match_fraction: float = 0.6
+
 
 settings = Settings()

--- a/backend/contracts.py
+++ b/backend/contracts.py
@@ -183,6 +183,11 @@ class TranscriptionResult(BaseModel):
     midi_tracks: list[MidiTrack]
     analysis: HarmonicAnalysis
     quality: QualitySignal
+    # URI of the raw MIDI bytes emitted by the transcription backend (e.g.
+    # Basic Pitch's pretty_midi output), saved to blob storage so callers can
+    # inspect the pre-arrangement pitch stream. Optional because stub/fallback
+    # results and non-audio inputs don't produce a meaningful MIDI file.
+    transcription_midi_uri: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -308,6 +313,10 @@ class EngravedOutput(BaseModel):
     musicxml_uri: str
     humanized_midi_uri: str
     audio_preview_uri: str | None = None
+    # Raw transcription MIDI (pre-arrangement) carried through from
+    # TranscriptionResult so the finished job exposes both the humanized
+    # output and the untouched transcribed pitch stream.
+    transcription_midi_uri: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/jobs/runner.py
+++ b/backend/jobs/runner.py
@@ -228,7 +228,7 @@ class PipelineRunner:
                 bundle = await self.ingest.run(bundle)
 
             elif step == "transcribe":
-                txr = await self.transcribe.run(bundle)
+                txr = await self.transcribe.run(bundle, job_id=job_id)
 
             elif step == "arrange":
                 if txr is None and bundle.midi is not None:
@@ -264,4 +264,12 @@ class PipelineRunner:
 
         if result is None:
             raise RuntimeError("pipeline finished without producing an EngravedOutput")
+
+        # Carry the raw transcription MIDI URI (if any) onto the final
+        # output so the artifacts route can serve it without needing a
+        # separate handle on TranscriptionResult.
+        if txr is not None and txr.transcription_midi_uri:
+            result = result.model_copy(
+                update={"transcription_midi_uri": txr.transcription_midi_uri},
+            )
         return result

--- a/backend/services/bass_extraction.py
+++ b/backend/services/bass_extraction.py
@@ -1,0 +1,209 @@
+"""Phase 3 post-processing — waveform-guided bass-line extraction.
+
+Mirrors :mod:`backend.services.melody_extraction` but operates on the
+low-register slice of Basic Pitch's ``model_output["contour"]`` matrix.
+The same Viterbi F0 tracer (``_trace_f0_contour``) is reused with a
+different band mask, stricter transition penalty, and bass-tuned
+thresholds — real bass lines are more stepwise than leads and rarely
+leap far in a single 11.6 ms frame.
+
+The pipeline is:
+
+    cleaned_events
+        → extract_melody()        -> (melody, non_melody, …)
+        → extract_bass(non_melody) -> (bass,   remaining,  …)
+        → remaining is tagged CHORDS by the transcribe wiring
+
+No new model weights, no new dependencies — everything here runs on
+``numpy`` which is already pulled in by the ``basic-pitch`` extra.
+
+This module deliberately imports the private tracer helpers from
+``melody_extraction`` rather than duplicating them: they're already
+voice-agnostic (band mask + transition weight are parameters), and a
+separate ``_viterbi_tracer`` module would just spread the Viterbi
+implementation across two places for no benefit.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from backend.services.melody_extraction import (
+    N_CONTOUR_BINS,
+    _split_notes_by_path_agreement,
+    _trace_f0_contour,
+    midi_to_bin,
+)
+from backend.services.transcription_cleanup import NoteEvent
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults — tuned for real bass-line material. Wider voicing floor than
+# melody because low-register contour bins are typically dimmer, and a
+# stronger transition weight because bass rarely leaps.
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASS_LOW_MIDI = 28            # E1
+DEFAULT_BASS_HIGH_MIDI = 55           # G3  (overlaps melody_low_midi=55)
+DEFAULT_BASS_VOICING_FLOOR = 0.12
+DEFAULT_BASS_TRANSITION_WEIGHT = 0.40
+DEFAULT_BASS_MAX_TRANSITION_BINS = 9  # ≈ 3 semitones / frame
+DEFAULT_BASS_VOICED_ENTER_COST = 1.0
+DEFAULT_BASS_UNVOICED_ENTER_COST = 1.0
+DEFAULT_BASS_MATCH_TOL_SEMITONES = 1.0
+DEFAULT_BASS_MATCH_FRACTION = 0.55
+
+# Bass and melody bands intentionally share their boundary bin (G3 / 55).
+# If a note straddles both, the first extractor to claim it wins; bass
+# runs *after* melody, so this degenerates to "melody always keeps its
+# G3 claim". That matches the usual musical case — melody leads routinely
+# dip to G3, bass lines rarely climb there.
+
+
+# ---------------------------------------------------------------------------
+# Stats — telemetry surfaced back to the caller for QualitySignal warnings
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BassExtractionStats:
+    """Per-run summary of what the bass extractor decided."""
+    input_note_count: int = 0
+    bass_note_count: int = 0
+    remaining_note_count: int = 0
+    voiced_frame_fraction: float = 0.0
+    warnings: list[str] = field(default_factory=list)
+    skipped: bool = False
+
+    def as_warnings(self) -> list[str]:
+        if self.skipped:
+            return ["bass extraction skipped (numpy or contour unavailable)"]
+        out: list[str] = []
+        if self.bass_note_count or self.remaining_note_count:
+            out.append(
+                f"bass split: {self.bass_note_count} bass / "
+                f"{self.remaining_note_count} chord notes "
+                f"({self.voiced_frame_fraction * 100:.0f}% voiced)"
+            )
+        out.extend(self.warnings)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def extract_bass(
+    contour: Any,  # np.ndarray (frames, 264) or None
+    note_events: list[NoteEvent],
+    *,
+    bass_low_midi: int = DEFAULT_BASS_LOW_MIDI,
+    bass_high_midi: int = DEFAULT_BASS_HIGH_MIDI,
+    voicing_floor: float = DEFAULT_BASS_VOICING_FLOOR,
+    transition_weight: float = DEFAULT_BASS_TRANSITION_WEIGHT,
+    max_transition_bins: int = DEFAULT_BASS_MAX_TRANSITION_BINS,
+    voiced_enter_cost: float = DEFAULT_BASS_VOICED_ENTER_COST,
+    unvoiced_enter_cost: float = DEFAULT_BASS_UNVOICED_ENTER_COST,
+    match_tolerance_semitones: float = DEFAULT_BASS_MATCH_TOL_SEMITONES,
+    match_fraction: float = DEFAULT_BASS_MATCH_FRACTION,
+    frame_rate_hz: float | None = None,
+) -> tuple[list[NoteEvent], list[NoteEvent], BassExtractionStats]:
+    """Run Phase 3 bass extraction over a list of candidate note events.
+
+    ``note_events`` should be whatever the preceding melody extractor
+    left un-tagged (i.e. ``chord_events`` from ``extract_melody``). The
+    function runs the Viterbi F0 tracer over the low-register slice of
+    the contour matrix and tags each input note as ``bass`` iff its
+    pitch + time window agrees with the traced path.
+
+    Returns ``(bass_events, remaining_events, stats)``. Remaining
+    events are the ones that didn't match the bass path — in the
+    transcribe wiring they become the CHORDS bucket.
+
+    When numpy is unavailable, the contour matrix is missing /
+    malformed, or the tracer raises, we return
+    ``([], note_events, stats)`` with ``stats.skipped = True`` so the
+    caller can fall back cleanly.
+    """
+    # Late import to avoid circular dep with melody_extraction's own
+    # FRAME_RATE_HZ re-export (it's the same value, we just don't want
+    # bass_extraction to pin itself to melody_extraction at import time).
+    from backend.services.melody_extraction import FRAME_RATE_HZ  # noqa: PLC0415
+
+    if frame_rate_hz is None:
+        frame_rate_hz = FRAME_RATE_HZ
+
+    stats = BassExtractionStats(input_note_count=len(note_events))
+
+    if contour is None:
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    try:
+        import numpy as np  # noqa: PLC0415
+    except ImportError:
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    contour_arr = np.asarray(contour)
+    if contour_arr.ndim != 2 or contour_arr.shape[1] != N_CONTOUR_BINS:
+        stats.warnings.append(
+            f"contour has unexpected shape {contour_arr.shape}; skipping"
+        )
+        stats.skipped = True
+        return [], list(note_events), stats
+    if contour_arr.shape[0] < 2:
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    low_bin = midi_to_bin(bass_low_midi)
+    high_bin = midi_to_bin(bass_high_midi)
+    if low_bin >= high_bin:
+        stats.warnings.append(
+            f"invalid bass band [{bass_low_midi}, {bass_high_midi}]"
+        )
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    try:
+        path = _trace_f0_contour(
+            contour_arr,
+            low_bin=low_bin,
+            high_bin=high_bin,
+            voicing_floor=voicing_floor,
+            transition_weight=transition_weight,
+            max_transition_bins=max_transition_bins,
+            voiced_enter_cost=voiced_enter_cost,
+            unvoiced_enter_cost=unvoiced_enter_cost,
+        )
+    except Exception as exc:  # noqa: BLE001 — tracer must never sink transcribe
+        log.warning("bass Viterbi tracer failed: %s", exc)
+        stats.warnings.append(f"viterbi failed: {exc}")
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    voiced_frac = float((path >= 0).mean()) if len(path) else 0.0
+    stats.voiced_frame_fraction = voiced_frac
+
+    bass, remaining = _split_notes_by_path_agreement(
+        note_events,
+        path,
+        low_midi=bass_low_midi,
+        high_midi=bass_high_midi,
+        frame_rate_hz=frame_rate_hz,
+        match_tolerance_semitones=match_tolerance_semitones,
+        match_fraction=match_fraction,
+    )
+
+    stats.bass_note_count = len(bass)
+    stats.remaining_note_count = len(remaining)
+    log.debug(
+        "bass extraction: %d notes → %d bass / %d remaining (%.0f%% voiced)",
+        len(note_events),
+        len(bass),
+        len(remaining),
+        voiced_frac * 100.0,
+    )
+    return bass, remaining, stats

--- a/backend/services/chord_recognition.py
+++ b/backend/services/chord_recognition.py
@@ -1,0 +1,349 @@
+"""Phase 3 post-processing — chroma-based chord recognition.
+
+Basic Pitch hands us a clean polyphonic pitch stream but no harmonic
+labels, so ``HarmonicAnalysis.chords`` stays empty through Phases 1
+and 2. This module fills the gap by running a standard chroma + template
+matching pass over the source waveform:
+
+1. HPSS-harmonic the audio (``librosa.effects.harmonic``) so percussive
+   transients don't smear the chroma vector.
+2. ``chroma_cqt`` with ``bins_per_octave=36`` for finer pitch precision
+   than the default STFT chroma.
+3. Beat tracking (the same ``librosa.beat.beat_track`` call the tempo
+   map uses) + ``librosa.util.sync`` to aggregate chroma across beats
+   — chord changes naturally align to beat boundaries in most music.
+4. Dot-product match against 24 normalized templates (12 major + 12
+   minor triads) and pick the best label per beat span.
+5. Collapse consecutive identical labels into ``RealtimeChordEvent``
+   spans and emit them into the existing ``HarmonicAnalysis.chords``
+   contract field.
+
+Everything is late-imported so the module can be imported (and
+unit-tested with ``pytest.importorskip``) on machines without librosa.
+The transcribe wiring treats chord recognition as best-effort: on any
+failure we fall back to an empty label list.
+
+This is deliberately v1 scope:
+  * Triads only — no 7ths, sus, dim. Ambiguous harmonies fall through
+    to whichever triad the chroma looks most like, which is usually
+    the right triad anyway.
+  * No key-aware smoothing — a purely local template match. A future
+    pass could add an HMM over a key-conditioned template set.
+  * No inversion tracking — the root we return is the template root,
+    not necessarily the lowest note.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from backend.contracts import RealtimeChordEvent
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults — iteration will want to tune these against real audio fixtures.
+# ---------------------------------------------------------------------------
+
+DEFAULT_CHORD_MIN_SCORE = 0.55
+DEFAULT_CHORD_HPSS_MARGIN = 3.0
+DEFAULT_CHORD_SAMPLE_RATE = 22_050
+DEFAULT_CHORD_HOP_LENGTH = 512
+DEFAULT_CHORD_BINS_PER_OCTAVE = 36
+
+# Pitch class index → Harte note name (major roots; minor roots follow
+# the same 12 names with a ``:min`` suffix).
+_PITCH_NAMES: tuple[str, ...] = (
+    "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+)
+
+
+@dataclass
+class ChordRecognitionStats:
+    """Per-run summary of what the chord recognizer decided."""
+    detected_count: int = 0        # number of labeled spans (excluding "N")
+    no_chord_count: int = 0        # number of spans below the score threshold
+    unique_labels: int = 0
+    warnings: list[str] = field(default_factory=list)
+    skipped: bool = False
+
+    def as_warnings(self) -> list[str]:
+        if self.skipped:
+            return ["chord recognition skipped (librosa or audio unavailable)"]
+        out: list[str] = []
+        if self.detected_count:
+            out.append(
+                f"chords: {self.detected_count} spans "
+                f"({self.unique_labels} unique labels)"
+            )
+        elif self.no_chord_count:
+            out.append("chords: no spans above score threshold")
+        out.extend(self.warnings)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Template construction — 24 triads
+# ---------------------------------------------------------------------------
+
+def _build_triad_templates() -> tuple[Any, list[str], list[int]]:
+    """Return (templates (24, 12), labels, roots).
+
+    Templates weight root and fifth at 1.0 and the third at 0.85 — a
+    compromise that nudges ambiguous vectors toward the right quality.
+    Each template is L2-normalized so the match score is a cosine.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    templates = np.zeros((24, 12), dtype=np.float32)
+    labels: list[str] = []
+    roots: list[int] = []
+
+    for root in range(12):
+        # Major triad: root, +4 semitones, +7 semitones.
+        templates[root, root % 12] = 1.0
+        templates[root, (root + 4) % 12] = 0.85
+        templates[root, (root + 7) % 12] = 1.0
+        labels.append(f"{_PITCH_NAMES[root]}:maj")
+        roots.append(root)
+
+    for root in range(12):
+        # Minor triad: root, +3 semitones, +7 semitones.
+        idx = 12 + root
+        templates[idx, root % 12] = 1.0
+        templates[idx, (root + 3) % 12] = 0.85
+        templates[idx, (root + 7) % 12] = 1.0
+        labels.append(f"{_PITCH_NAMES[root]}:min")
+        roots.append(root)
+
+    norms = np.linalg.norm(templates, axis=1, keepdims=True)
+    templates = templates / np.clip(norms, 1e-9, None)
+    return templates, labels, roots
+
+
+# ---------------------------------------------------------------------------
+# Core recognizer — operates on a preloaded waveform for testability
+# ---------------------------------------------------------------------------
+
+def recognize_chords_from_waveform(
+    y: Any,                               # np.ndarray (samples,)
+    sr: int,
+    *,
+    min_score: float = DEFAULT_CHORD_MIN_SCORE,
+    hpss_margin: float = DEFAULT_CHORD_HPSS_MARGIN,
+    hop_length: int = DEFAULT_CHORD_HOP_LENGTH,
+    bins_per_octave: int = DEFAULT_CHORD_BINS_PER_OCTAVE,
+) -> tuple[list[RealtimeChordEvent], ChordRecognitionStats]:
+    """Recognize chords directly from a loaded mono waveform.
+
+    This is the unit-testable core — feed it a synthetic signal and it
+    runs the same chroma / template pipeline as the file-path entry
+    point without touching disk. Returns the list of labeled spans and
+    a stats summary.
+
+    Chord labels use Harte notation (``"C:maj"`` / ``"A:min"``) so they
+    drop straight into ``RealtimeChordEvent.label``. The ``root`` field
+    holds the pitch class index (0–11, C=0).
+    """
+    stats = ChordRecognitionStats()
+
+    try:
+        import librosa  # noqa: PLC0415
+        import numpy as np  # noqa: PLC0415
+    except ImportError:
+        stats.skipped = True
+        return [], stats
+
+    if y is None or len(y) == 0:
+        stats.skipped = True
+        return [], stats
+
+    # Duration guard: ≥ 0.25 s is roughly the minimum chroma_cqt needs
+    # before it starts complaining about short input.
+    duration = float(len(y) / sr) if sr else 0.0
+    if duration < 0.25:
+        stats.skipped = True
+        return [], stats
+
+    # HPSS the signal *for chroma only*. Beat tracking happens on the
+    # raw waveform below — HPSS strips the percussive transients that
+    # librosa.beat.beat_track actually locks onto, so feeding HPSS'd
+    # audio into the beat tracker returns zero beats on material where
+    # the raw tracker finds a clean pulse.
+    try:
+        y_h = librosa.effects.harmonic(y, margin=hpss_margin)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("HPSS failed for chord recognition: %s", exc)
+        stats.warnings.append(f"hpss failed: {exc}")
+        y_h = y
+
+    try:
+        chroma = librosa.feature.chroma_cqt(
+            y=y_h, sr=sr,
+            hop_length=hop_length,
+            bins_per_octave=bins_per_octave,
+        )
+    except Exception as exc:  # noqa: BLE001 — short / degenerate audio
+        log.warning("chroma_cqt failed: %s", exc)
+        stats.warnings.append(f"chroma_cqt failed: {exc}")
+        stats.skipped = True
+        return [], stats
+
+    if chroma.size == 0 or chroma.shape[1] < 2:
+        stats.skipped = True
+        return [], stats
+
+    # Beat-sync the chroma so each column corresponds to one beat span.
+    # When beat tracking fails or finds <2 beats, fall back to a single
+    # global span across the whole clip.
+    try:
+        _tempo, beat_frames = librosa.beat.beat_track(
+            y=y, sr=sr, hop_length=hop_length,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("beat_track failed during chord recognition: %s", exc)
+        beat_frames = np.array([], dtype=int)
+
+    beat_frames = np.atleast_1d(beat_frames).astype(int)
+    if beat_frames.size >= 2:
+        # librosa.util.sync wants a Python sequence, not ndarray.
+        beat_list: list[int] = [int(b) for b in beat_frames.tolist()]
+        synced = librosa.util.sync(chroma, beat_list, aggregate=np.mean)
+        span_times = librosa.frames_to_time(
+            beat_frames, sr=sr, hop_length=hop_length,
+        )
+        # Append a trailing time for the last span = end of audio.
+        span_times = np.concatenate([span_times, [duration]])
+    else:
+        synced = np.mean(chroma, axis=1, keepdims=True)
+        span_times = np.array([0.0, duration], dtype=float)
+
+    # synced shape is (12, N_spans). span_times has length N_spans + 1
+    # when we have beats (one entry per span boundary including the
+    # trailing end time), so make sure the two agree on N.
+    n_spans = synced.shape[1]
+    if span_times.size < n_spans + 1:
+        # Degenerate: pad the trailing time.
+        span_times = np.concatenate([
+            span_times,
+            np.full(n_spans + 1 - span_times.size, duration),
+        ])
+    elif span_times.size > n_spans + 1:
+        span_times = span_times[: n_spans + 1]
+
+    # Normalize chroma columns and score against templates.
+    templates, labels, roots = _build_triad_templates()
+    col_norms = np.linalg.norm(synced, axis=0, keepdims=True)
+    synced_n = synced / np.clip(col_norms, 1e-9, None)
+    scores = templates @ synced_n  # (24, N_spans)
+    best_idx = np.argmax(scores, axis=0)
+    best_score = scores[best_idx, np.arange(n_spans)]
+
+    # Build raw per-span labels (or "N" for below-threshold spans).
+    raw_labels: list[tuple[float, float, str, int, float]] = []
+    for i in range(n_spans):
+        start = float(span_times[i])
+        end = float(span_times[i + 1])
+        if end <= start or not math.isfinite(end - start):
+            continue
+        score_i = float(best_score[i])
+        if score_i < min_score:
+            raw_labels.append((start, end, "N", -1, score_i))
+        else:
+            idx = int(best_idx[i])
+            raw_labels.append((start, end, labels[idx], roots[idx], score_i))
+
+    # Collapse consecutive identical labels.
+    collapsed: list[tuple[float, float, str, int, float]] = []
+    for entry in raw_labels:
+        if collapsed and collapsed[-1][2] == entry[2] and collapsed[-1][3] == entry[3]:
+            prev = collapsed[-1]
+            collapsed[-1] = (
+                prev[0],
+                entry[1],
+                prev[2],
+                prev[3],
+                max(prev[4], entry[4]),
+            )
+        else:
+            collapsed.append(entry)
+
+    # Emit contract events for labeled spans only (skip "N").
+    out: list[RealtimeChordEvent] = []
+    seen_labels: set[str] = set()
+    no_chord_count = 0
+    for start, end, label, root, score in collapsed:
+        if label == "N":
+            no_chord_count += 1
+            continue
+        out.append(
+            RealtimeChordEvent(
+                time_sec=start,
+                duration_sec=end - start,
+                label=label,
+                root=root,
+                confidence=round(min(max(score, 0.0), 1.0), 3),
+            )
+        )
+        seen_labels.add(label)
+
+    stats.detected_count = len(out)
+    stats.no_chord_count = no_chord_count
+    stats.unique_labels = len(seen_labels)
+    log.debug(
+        "chord recognition: %d spans (%d unique, %d below threshold)",
+        stats.detected_count,
+        stats.unique_labels,
+        stats.no_chord_count,
+    )
+    return out, stats
+
+
+# ---------------------------------------------------------------------------
+# File-path entry point — what the transcribe wiring calls
+# ---------------------------------------------------------------------------
+
+def recognize_chords(
+    audio_path: Path,
+    *,
+    min_score: float = DEFAULT_CHORD_MIN_SCORE,
+    hpss_margin: float = DEFAULT_CHORD_HPSS_MARGIN,
+    sample_rate: int = DEFAULT_CHORD_SAMPLE_RATE,
+    hop_length: int = DEFAULT_CHORD_HOP_LENGTH,
+    bins_per_octave: int = DEFAULT_CHORD_BINS_PER_OCTAVE,
+) -> tuple[list[RealtimeChordEvent], ChordRecognitionStats]:
+    """Load ``audio_path`` and return a chord label stream.
+
+    Mirrors the graceful-degradation contract of the other Phase 3
+    extractors: any failure (missing librosa, unreadable audio, short
+    audio, chroma failure, …) returns an empty label list with
+    ``stats.skipped = True`` so the caller can carry on with no chord
+    annotations.
+    """
+    stats = ChordRecognitionStats()
+
+    try:
+        import librosa  # noqa: PLC0415
+    except ImportError:
+        stats.skipped = True
+        return [], stats
+
+    try:
+        y, file_sr = librosa.load(str(audio_path), sr=sample_rate, mono=True)
+    except Exception as exc:  # noqa: BLE001 — bad audio shouldn't crash worker
+        log.warning("librosa.load failed for chord recognition: %s", exc)
+        stats.warnings.append(f"librosa.load failed: {exc}")
+        stats.skipped = True
+        return [], stats
+
+    return recognize_chords_from_waveform(
+        y, int(file_sr),
+        min_score=min_score,
+        hpss_margin=hpss_margin,
+        hop_length=hop_length,
+        bins_per_octave=bins_per_octave,
+    )

--- a/backend/services/melody_extraction.py
+++ b/backend/services/melody_extraction.py
@@ -82,6 +82,20 @@ DEFAULT_MIN_NOTE_FRAMES = 4          # ≈ 46 ms
 DEFAULT_MATCH_TOL_SEMITONES = 1.0
 DEFAULT_MATCH_FRACTION = 0.6
 
+# ---------------------------------------------------------------------------
+# Back-fill defaults — recover stable Viterbi runs that the upstream Basic
+# Pitch note tracker never emitted (soft sustained melody notes drowned out
+# by louder accompaniment). Deliberately conservative: only long, clean
+# runs are back-filled, and the synthesized amplitude is clipped low so
+# recovery notes don't outshine real ones in the downstream velocity map.
+# ---------------------------------------------------------------------------
+
+DEFAULT_BACKFILL_ENABLED = True
+DEFAULT_BACKFILL_MIN_DURATION_SEC = 0.12
+DEFAULT_BACKFILL_OVERLAP_FRACTION = 0.5
+DEFAULT_BACKFILL_MIN_AMP = 0.15
+DEFAULT_BACKFILL_MAX_AMP = 0.60
+
 
 # ---------------------------------------------------------------------------
 # Stats surfaced back to the caller for telemetry / QualitySignal
@@ -94,6 +108,10 @@ class MelodyExtractionStats:
     melody_note_count: int = 0
     chord_note_count: int = 0
     voiced_frame_fraction: float = 0.0  # share of frames on the Viterbi path
+    # Count of melody notes synthesized from the Viterbi path because no
+    # matching upstream note event existed (back-fill of soft sustained
+    # melody lines the Basic Pitch note tracker missed).
+    backfilled_note_count: int = 0
     warnings: list[str] = field(default_factory=list)
     # True when numpy (or contour input) was unavailable and we skipped
     # extraction entirely. Callers should fall back to a single-track
@@ -109,6 +127,11 @@ class MelodyExtractionStats:
                 f"melody split: {self.melody_note_count} melody / "
                 f"{self.chord_note_count} chord notes "
                 f"({self.voiced_frame_fraction * 100:.0f}% voiced)"
+            )
+        if self.backfilled_note_count:
+            out.append(
+                f"melody: back-filled {self.backfilled_note_count} "
+                f"missed notes from Viterbi path"
             )
         out.extend(self.warnings)
         return out
@@ -301,10 +324,10 @@ def _path_to_midi_runs(path: Any) -> list[tuple[int, int, int]]:
 
 
 # ---------------------------------------------------------------------------
-# Note tagging against Basic Pitch events
+# Note tagging against a Viterbi path
 # ---------------------------------------------------------------------------
 
-def _split_notes_by_melody_agreement(
+def _split_notes_by_path_agreement(
     events: list[NoteEvent],
     path: Any,
     *,
@@ -314,35 +337,35 @@ def _split_notes_by_melody_agreement(
     match_tolerance_semitones: float,
     match_fraction: float,
 ) -> tuple[list[NoteEvent], list[NoteEvent]]:
-    """Tag each Basic Pitch note as melody or chord.
+    """Tag each note tuple as in-voice or out-of-voice w.r.t. a Viterbi path.
 
-    A note becomes MELODY when:
+    A note becomes *in-voice* (first return list) when:
       1. Its pitch lies inside ``[low_midi, high_midi]``.
       2. At least ``match_fraction`` of its frames overlap a voiced
          Viterbi path frame within ``match_tolerance_semitones``.
 
-    Everything else flows to the CHORDS bucket, including legitimate
-    below-range notes (bass lines) and above-range ones (very high
-    harmonies). Those could be split further in Phase 3.
+    Everything else flows to the *out-of-voice* (second return list)
+    bucket. The function is voice-agnostic — Phase 2 (melody) and Phase
+    3 (bass) call it with different bands and paths.
     """
     if not events:
         return [], []
 
     n_frames = len(path)
-    melody: list[NoteEvent] = []
-    chords: list[NoteEvent] = []
+    in_voice: list[NoteEvent] = []
+    out_of_voice: list[NoteEvent] = []
     tol_bins = match_tolerance_semitones * BINS_PER_SEMITONE
 
     for ev in events:
         start_sec, end_sec, pitch, amp, bends = ev
         if pitch < low_midi or pitch > high_midi:
-            chords.append(ev)
+            out_of_voice.append(ev)
             continue
 
         f0 = max(0, int(round(start_sec * frame_rate_hz)))
         f1 = min(n_frames, int(round(end_sec * frame_rate_hz)))
         if f1 <= f0:
-            chords.append(ev)
+            out_of_voice.append(ev)
             continue
 
         target_bin = midi_to_bin(pitch)
@@ -356,11 +379,105 @@ def _split_notes_by_melody_agreement(
                 match += 1
 
         if total > 0 and (match / total) >= match_fraction:
-            melody.append(ev)
+            in_voice.append(ev)
         else:
-            chords.append(ev)
+            out_of_voice.append(ev)
 
-    return melody, chords
+    return in_voice, out_of_voice
+
+
+# ---------------------------------------------------------------------------
+# Back-fill — synthesize notes for stable Viterbi runs with no matching event
+# ---------------------------------------------------------------------------
+
+def _backfill_missed_melody_notes(
+    melody_events: list[NoteEvent],
+    contour: Any,  # np.ndarray (frames, N_CONTOUR_BINS)
+    path: Any,     # np.ndarray (frames,), int; -1 = unvoiced
+    *,
+    frame_rate_hz: float,
+    min_duration_sec: float,
+    overlap_fraction: float,
+    min_amp: float,
+    max_amp: float,
+    match_tolerance_semitones: float,
+) -> tuple[list[NoteEvent], int]:
+    """Synthesize melody note events for stable Viterbi runs with no match.
+
+    The Viterbi F0 tracer sees the contour salience matrix directly, so
+    it finds stable melody fundamentals that the upstream Basic Pitch
+    note tracker sometimes misses — typically soft sustained lines under
+    louder accompaniment. When we find a run of ≥ ``min_duration_sec``
+    frames at a single pitch that does not overlap any existing melody
+    event (within ``match_tolerance_semitones`` and by at least
+    ``overlap_fraction`` of the run's duration), we build a synthetic
+    ``NoteEvent`` from it.
+
+    The synthesized amplitude is the mean contour salience inside the
+    run at the target bin, **clipped** to ``[min_amp, max_amp]``. The
+    upper clip matters: these are recovery notes, not hero notes, and
+    uncapped they'd arrive at the downstream velocity formula with
+    values that rival real detections.
+
+    **Do not re-run** :func:`cleanup_note_events` over a back-filled
+    list — the low clipped amplitude makes synthesized notes look like
+    ghost tails and they get dropped, defeating the purpose.
+
+    Returns ``(combined_events, added_count)``.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    runs = _path_to_midi_runs(path)
+    if not runs:
+        return list(melody_events), 0
+
+    min_frames = max(1, int(round(min_duration_sec * frame_rate_hz)))
+    added: list[NoteEvent] = []
+
+    for start_f, end_f, midi in runs:
+        if end_f - start_f < min_frames:
+            continue
+
+        start_sec = start_f / frame_rate_hz
+        end_sec = end_f / frame_rate_hz
+        run_duration = end_sec - start_sec
+        if run_duration <= 0:
+            continue
+
+        # Skip the run if any existing melody event already covers it.
+        has_match = False
+        for ev in melody_events:
+            ev_start, ev_end, ev_pitch, _, _ = ev
+            if abs(ev_pitch - midi) > match_tolerance_semitones:
+                continue
+            overlap_start = max(start_sec, ev_start)
+            overlap_end = min(end_sec, ev_end)
+            overlap = overlap_end - overlap_start
+            if overlap >= overlap_fraction * run_duration:
+                has_match = True
+                break
+        if has_match:
+            continue
+
+        # Synthesize. Amplitude = clipped mean salience at the target
+        # bin across the run. Casting to float keeps the tuple layout
+        # consistent with the Basic Pitch-sourced entries.
+        target_bin = midi_to_bin(midi)
+        if 0 <= target_bin < contour.shape[1]:
+            bin_slice = contour[start_f:end_f, target_bin]
+            mean_salience = float(np.mean(bin_slice)) if bin_slice.size else 0.0
+        else:
+            mean_salience = 0.0
+        amp = max(min_amp, min(max_amp, mean_salience))
+
+        added.append((start_sec, end_sec, int(midi), amp, None))
+
+    if not added:
+        return list(melody_events), 0
+
+    combined = list(melody_events) + added
+    combined.sort(key=lambda e: (e[0], e[2]))
+    return combined, len(added)
 
 
 # ---------------------------------------------------------------------------
@@ -381,6 +498,11 @@ def extract_melody(
     match_tolerance_semitones: float = DEFAULT_MATCH_TOL_SEMITONES,
     match_fraction: float = DEFAULT_MATCH_FRACTION,
     frame_rate_hz: float = FRAME_RATE_HZ,
+    backfill_enabled: bool = DEFAULT_BACKFILL_ENABLED,
+    backfill_min_duration_sec: float = DEFAULT_BACKFILL_MIN_DURATION_SEC,
+    backfill_overlap_fraction: float = DEFAULT_BACKFILL_OVERLAP_FRACTION,
+    backfill_min_amp: float = DEFAULT_BACKFILL_MIN_AMP,
+    backfill_max_amp: float = DEFAULT_BACKFILL_MAX_AMP,
 ) -> tuple[list[NoteEvent], list[NoteEvent], MelodyExtractionStats]:
     """Run Phase 2 melody extraction over Basic Pitch output.
 
@@ -388,6 +510,12 @@ def extract_melody(
     unavailable or the contour matrix is missing / malformed, returns
     ``([], note_events, stats)`` with ``stats.skipped = True`` so the
     caller can fall back to a single-track result without losing notes.
+
+    When ``backfill_enabled``, stable Viterbi runs with no matching
+    Basic Pitch note are synthesized into the melody list before
+    return. See :func:`_backfill_missed_melody_notes` for the semantics
+    — in short, this recovers soft sustained lead notes the polyphonic
+    tracker lost under accompaniment.
 
     Tuning: the defaults are conservative. For songs with a strong
     vocal lead, raising ``match_fraction`` to ~0.75 and narrowing
@@ -447,7 +575,7 @@ def extract_melody(
     voiced_frac = float((path >= 0).mean()) if len(path) else 0.0
     stats.voiced_frame_fraction = voiced_frac
 
-    melody, chords = _split_notes_by_melody_agreement(
+    melody, chords = _split_notes_by_path_agreement(
         note_events,
         path,
         low_midi=melody_low_midi,
@@ -457,13 +585,45 @@ def extract_melody(
         match_fraction=match_fraction,
     )
 
+    # Back-fill stable Viterbi runs that no Basic Pitch event covers.
+    # Runs whose rounded-integer MIDI falls outside the melody band are
+    # filtered here (via ``low/high_midi``) so a low-band peak the tracer
+    # catches doesn't get back-filled as a melody note.
+    if backfill_enabled:
+        try:
+            melody, backfill_count = _backfill_missed_melody_notes(
+                melody,
+                contour_arr,
+                path,
+                frame_rate_hz=frame_rate_hz,
+                min_duration_sec=backfill_min_duration_sec,
+                overlap_fraction=backfill_overlap_fraction,
+                min_amp=backfill_min_amp,
+                max_amp=backfill_max_amp,
+                match_tolerance_semitones=match_tolerance_semitones,
+            )
+            # Restrict added notes to the melody band — the Viterbi path
+            # is already band-masked, but be defensive in case a future
+            # caller widens it.
+            if backfill_count:
+                melody = [
+                    ev for ev in melody
+                    if melody_low_midi <= ev[2] <= melody_high_midi
+                ]
+            stats.backfilled_note_count = backfill_count
+        except Exception as exc:  # noqa: BLE001 — never let back-fill sink transcribe
+            log.warning("melody back-fill failed: %s", exc)
+            stats.warnings.append(f"back-fill failed: {exc}")
+
     stats.melody_note_count = len(melody)
     stats.chord_note_count = len(chords)
     log.debug(
-        "melody extraction: %d notes → %d melody / %d chords (%.0f%% voiced)",
+        "melody extraction: %d notes → %d melody / %d chords "
+        "(+%d back-filled, %.0f%% voiced)",
         len(note_events),
         len(melody),
         len(chords),
+        stats.backfilled_note_count,
         voiced_frac * 100.0,
     )
     return melody, chords, stats

--- a/backend/services/melody_extraction.py
+++ b/backend/services/melody_extraction.py
@@ -351,6 +351,8 @@ def _split_notes_by_path_agreement(
     if not events:
         return [], []
 
+    import numpy as np  # noqa: PLC0415
+
     n_frames = len(path)
     in_voice: list[NoteEvent] = []
     out_of_voice: list[NoteEvent] = []
@@ -369,14 +371,10 @@ def _split_notes_by_path_agreement(
             continue
 
         target_bin = midi_to_bin(pitch)
-        match = 0
         total = f1 - f0
-        for f in range(f0, f1):
-            pb = int(path[f])
-            if pb < 0:
-                continue
-            if abs(pb - target_bin) <= tol_bins:
-                match += 1
+        segment = path[f0:f1]
+        voiced = segment >= 0
+        match = int(np.sum(voiced & (np.abs(segment - target_bin) <= tol_bins)))
 
         if total > 0 and (match / total) >= match_fraction:
             in_voice.append(ev)

--- a/backend/services/melody_extraction.py
+++ b/backend/services/melody_extraction.py
@@ -1,0 +1,469 @@
+"""Phase 2 post-processing — waveform-guided melody / harmony split.
+
+Basic Pitch's polyphonic pitch tracker emits one flat stream of notes
+with no instrument or role tagging. The downstream arrange stage has a
+MELODY → right-hand routing (see ``arrange._assign_hands``) that goes
+unused because the transcribe stage only ever emits a single ``PIANO``
+track. This module fills that gap by exploiting a piece of Basic Pitch's
+own output we weren't using: ``model_output["contour"]``.
+
+``contour`` is a ``(frames, 264)`` salience matrix at 86.13 Hz, with 3
+bins per semitone (``CONTOURS_BINS_PER_SEMITONE = 3``) covering MIDI 21
+through 108. That's a pre-computed front end for a monophonic F0
+tracker — we just weren't using the fine-grained salience, only the
+coarser ``note`` grid. Running a Viterbi path over the masked contour
+yields a smooth, temporally-coherent lead-voice F0 contour at roughly
+33-cent resolution, which we then use to tag each Basic Pitch note as
+``MELODY`` (agreement with the path) or ``CHORDS`` (disagreement).
+
+No extra model weights, no extra dependencies — everything here runs
+on ``numpy`` which is already pulled in by the ``basic-pitch`` extra.
+
+The module is deliberately decoupled from the rest of the transcribe
+pipeline: the entry point ``extract_melody`` takes a numpy contour
+matrix + a list of Basic Pitch ``NoteEvent`` tuples and returns a
+``(melody_events, chord_events, stats)`` triple. That makes it easy to
+unit-test against hand-built synthetic contour matrices.
+
+Bin ↔ MIDI mapping (derived from ``basic_pitch.note_creation``):
+
+    bin = 12 * CONTOURS_BINS_PER_SEMITONE * log2(freq / BASE_FREQ)
+        = 3 * (midi - 21)
+
+so integer MIDI pitch ``m`` lives at bin ``3 * (m - 21)``, and each
+semitone spans 3 consecutive bins (``3k``, ``3k+1``, ``3k+2``).
+"""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+from backend.services.transcription_cleanup import NoteEvent
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants mirrored from basic_pitch.constants so the module can be
+# imported / unit-tested without pulling basic_pitch in.
+# ---------------------------------------------------------------------------
+
+BASE_MIDI = 21                       # A0 — bin 0 of the contour matrix
+BINS_PER_SEMITONE = 3                # CONTOURS_BINS_PER_SEMITONE
+N_CONTOUR_BINS = 264                 # 88 semitones × 3 bins = 264
+FRAME_RATE_HZ = 22050.0 / 256.0      # AUDIO_SAMPLE_RATE / FFT_HOP ≈ 86.13 Hz
+
+
+def midi_to_bin(midi: float) -> int:
+    """Nearest contour bin for a (possibly fractional) MIDI pitch."""
+    return int(round(BINS_PER_SEMITONE * (midi - BASE_MIDI)))
+
+
+def bin_to_midi(bin_idx: int) -> int:
+    """Round a contour bin back to the nearest integer MIDI pitch."""
+    return BASE_MIDI + int(round(bin_idx / BINS_PER_SEMITONE))
+
+
+# ---------------------------------------------------------------------------
+# Defaults — conservative, tuned against the synthetic test fixtures. Real
+# audio will want iteration; see the docstring on ``extract_melody``.
+# ---------------------------------------------------------------------------
+
+DEFAULT_MELODY_LOW_MIDI = 55         # G3
+DEFAULT_MELODY_HIGH_MIDI = 90        # F#6
+DEFAULT_VOICING_FLOOR = 0.15
+DEFAULT_TRANSITION_WEIGHT = 0.25     # cost per bin of pitch change
+DEFAULT_MAX_TRANSITION_BINS = 12     # ≈ 4 semitones per 11.6 ms frame
+DEFAULT_VOICED_ENTER_COST = 1.0      # entering voiced from unvoiced
+DEFAULT_UNVOICED_ENTER_COST = 1.0    # leaving voiced to unvoiced
+DEFAULT_MIN_NOTE_FRAMES = 4          # ≈ 46 ms
+DEFAULT_MATCH_TOL_SEMITONES = 1.0
+DEFAULT_MATCH_FRACTION = 0.6
+
+
+# ---------------------------------------------------------------------------
+# Stats surfaced back to the caller for telemetry / QualitySignal
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MelodyExtractionStats:
+    """Per-run summary of what the melody extractor decided."""
+    input_note_count: int = 0
+    melody_note_count: int = 0
+    chord_note_count: int = 0
+    voiced_frame_fraction: float = 0.0  # share of frames on the Viterbi path
+    warnings: list[str] = field(default_factory=list)
+    # True when numpy (or contour input) was unavailable and we skipped
+    # extraction entirely. Callers should fall back to a single-track
+    # TranscriptionResult in that case.
+    skipped: bool = False
+
+    def as_warnings(self) -> list[str]:
+        if self.skipped:
+            return ["melody extraction skipped (numpy or contour unavailable)"]
+        out: list[str] = []
+        if self.melody_note_count or self.chord_note_count:
+            out.append(
+                f"melody split: {self.melody_note_count} melody / "
+                f"{self.chord_note_count} chord notes "
+                f"({self.voiced_frame_fraction * 100:.0f}% voiced)"
+            )
+        out.extend(self.warnings)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Core Viterbi tracer
+# ---------------------------------------------------------------------------
+
+def _trace_f0_contour(
+    contour: Any,  # np.ndarray (frames, N_CONTOUR_BINS)
+    *,
+    low_bin: int,
+    high_bin: int,
+    voicing_floor: float,
+    transition_weight: float,
+    max_transition_bins: int,
+    voiced_enter_cost: float,
+    unvoiced_enter_cost: float,
+) -> Any:  # np.ndarray (frames,), int — -1 for unvoiced
+    """Run a Viterbi path over the masked contour matrix.
+
+    The state space is ``N_CONTOUR_BINS + 1`` — one state per contour
+    bin plus a single "unvoiced" state. Voiced emission cost is
+    ``-log(contour[t, b] + eps)`` within the melody band, ``+inf``
+    outside it. The unvoiced state has a constant emission cost
+    ``-log(voicing_floor + eps)`` — a frame prefers unvoiced iff no bin
+    inside the band is at least as salient as ``voicing_floor``.
+
+    Transition costs:
+      * voiced → voiced (Δb bins): ``transition_weight * |Δb|``, capped
+        at ``max_transition_bins``
+      * voiced → unvoiced: ``unvoiced_enter_cost``
+      * unvoiced → voiced: ``voiced_enter_cost``
+      * self-loops: free
+
+    Implementation notes:
+      * Vectorized as ``2 * max_transition_bins + 1`` shift-and-min ops
+        per frame via ``np.roll`` with boundary masking — O(T * W * N).
+      * Back-pointers are packed into ``int16`` — the delta is in
+        ``[-W, W]`` and the "came from unvoiced" marker is stored as the
+        sentinel ``-W - 1``.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    n_frames, n_bins = contour.shape
+    if n_bins != N_CONTOUR_BINS:
+        raise ValueError(
+            f"contour has {n_bins} bins, expected {N_CONTOUR_BINS}"
+        )
+
+    eps = 1e-6
+    inf = np.float32(1e18)
+
+    # Band mask — bins outside [low_bin, high_bin] get +inf emission.
+    band_mask = np.zeros(n_bins, dtype=bool)
+    lo = max(0, low_bin)
+    hi = min(n_bins, high_bin + 1)
+    band_mask[lo:hi] = True
+
+    # Precompute emission for voiced states: shape (T, N)
+    voiced_emission = -np.log(np.clip(contour, eps, None).astype(np.float32))
+    voiced_emission[:, ~band_mask] = inf
+    # Unvoiced emission — constant scalar, but vectorized per-frame.
+    unvoiced_emission = float(-math.log(voicing_floor + eps))
+
+    W = int(max_transition_bins)
+    delta_range = np.arange(-W, W + 1, dtype=np.int32)
+    transition = (transition_weight * np.abs(delta_range)).astype(np.float32)
+
+    # dp_voiced[b] = best cost to end at voiced state b at time t
+    dp_voiced = np.full(n_bins, inf, dtype=np.float32)
+
+    # Initial frame: start from any state uniformly. dp_unvoiced stays a
+    # plain Python float throughout — it's a scalar and mixing it with
+    # numpy scalars just confuses type checking for no runtime benefit.
+    dp_voiced[:] = voiced_emission[0]
+    dp_unvoiced: float = float(unvoiced_emission)
+
+    # Back-pointers: for each frame t > 0 and each state, what delta
+    # (from voiced) or "came from unvoiced" produced the min.
+    # Voiced back-ptr sentinels: delta ∈ [-W, W] plus the "from unvoiced"
+    # marker -W - 1. Unvoiced back-ptr is 0 for "self" and 1 for "from
+    # voiced (the argmin bin of dp_prev)".
+    bp_voiced = np.zeros((n_frames, n_bins), dtype=np.int16)
+    bp_unvoiced = np.zeros(n_frames, dtype=np.int16)
+    bp_unvoiced_arg = np.zeros(n_frames, dtype=np.int32)
+
+    for t in range(1, n_frames):
+        # ---------- voiced ← voiced (shift-and-min over ±W bins) -----
+        best_voiced_cost = np.full(n_bins, inf, dtype=np.float32)
+        best_delta = np.zeros(n_bins, dtype=np.int16)
+
+        for di, d_arr in enumerate(delta_range):
+            # dp_prev[b - d] = cost of being at bin b-d at t-1,
+            # then moving by +d to bin b at t.
+            d = int(d_arr)
+            shifted = np.full(n_bins, inf, dtype=np.float32)
+            if d >= 0:
+                shifted[d:] = dp_voiced[: n_bins - d]
+            else:
+                shifted[: n_bins + d] = dp_voiced[-d:]
+            candidate = shifted + transition[di]
+            improved = candidate < best_voiced_cost
+            best_voiced_cost = np.where(improved, candidate, best_voiced_cost)
+            best_delta = np.where(improved, np.int16(d), best_delta)
+
+        # ---------- voiced ← unvoiced ---------------------------------
+        from_unv = dp_unvoiced + voiced_enter_cost
+        take_unv = from_unv < best_voiced_cost
+        best_voiced_cost = np.where(take_unv, from_unv, best_voiced_cost)
+        best_delta = np.where(take_unv, np.int16(-W - 1), best_delta)
+
+        new_voiced = voiced_emission[t] + best_voiced_cost
+
+        # ---------- unvoiced ← {self, voiced} -------------------------
+        voiced_argmin = int(np.argmin(dp_voiced))
+        from_voiced = float(dp_voiced[voiced_argmin]) + unvoiced_enter_cost
+        if dp_unvoiced <= from_voiced:
+            new_unvoiced_scalar: float = unvoiced_emission + dp_unvoiced
+            bp_unvoiced[t] = 0  # stayed unvoiced
+        else:
+            new_unvoiced_scalar = unvoiced_emission + from_voiced
+            bp_unvoiced[t] = 1  # came from voiced
+            bp_unvoiced_arg[t] = voiced_argmin
+
+        bp_voiced[t] = best_delta
+        dp_voiced = new_voiced
+        dp_unvoiced = new_unvoiced_scalar
+
+    # ---------- Backtrack -------------------------------------------------
+    path = np.full(n_frames, -1, dtype=np.int32)
+    final_voiced_argmin = int(np.argmin(dp_voiced))
+    final_voiced_cost = float(dp_voiced[final_voiced_argmin])
+    if final_voiced_cost <= float(dp_unvoiced):
+        state: int = final_voiced_argmin
+        voiced = True
+    else:
+        state = -1
+        voiced = False
+
+    for t in range(n_frames - 1, -1, -1):
+        if voiced:
+            path[t] = state
+            if t == 0:
+                break
+            bt_delta = int(bp_voiced[t, state])
+            if bt_delta == -W - 1:
+                voiced = False
+            else:
+                state = state - bt_delta
+        else:
+            path[t] = -1
+            if t == 0:
+                break
+            if bp_unvoiced[t] == 1:
+                voiced = True
+                state = int(bp_unvoiced_arg[t])
+            # else stay unvoiced
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Path → note-range segmentation
+# ---------------------------------------------------------------------------
+
+def _path_to_midi_runs(path: Any) -> list[tuple[int, int, int]]:
+    """Group consecutive voiced frames at the same integer MIDI pitch.
+
+    Returns a list of ``(start_frame, end_frame_exclusive, midi_pitch)``
+    tuples. Unvoiced frames (path value < 0) break runs. We round each
+    voiced bin to its nearest integer MIDI pitch via :func:`bin_to_midi`
+    — the sub-semitone precision is thrown away here because the
+    downstream tagging only needs semitone resolution.
+    """
+    runs: list[tuple[int, int, int]] = []
+    n = len(path)
+    i = 0
+    while i < n:
+        if path[i] < 0:
+            i += 1
+            continue
+        midi = bin_to_midi(int(path[i]))
+        j = i + 1
+        while j < n and path[j] >= 0 and bin_to_midi(int(path[j])) == midi:
+            j += 1
+        runs.append((i, j, midi))
+        i = j
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# Note tagging against Basic Pitch events
+# ---------------------------------------------------------------------------
+
+def _split_notes_by_melody_agreement(
+    events: list[NoteEvent],
+    path: Any,
+    *,
+    low_midi: int,
+    high_midi: int,
+    frame_rate_hz: float,
+    match_tolerance_semitones: float,
+    match_fraction: float,
+) -> tuple[list[NoteEvent], list[NoteEvent]]:
+    """Tag each Basic Pitch note as melody or chord.
+
+    A note becomes MELODY when:
+      1. Its pitch lies inside ``[low_midi, high_midi]``.
+      2. At least ``match_fraction`` of its frames overlap a voiced
+         Viterbi path frame within ``match_tolerance_semitones``.
+
+    Everything else flows to the CHORDS bucket, including legitimate
+    below-range notes (bass lines) and above-range ones (very high
+    harmonies). Those could be split further in Phase 3.
+    """
+    if not events:
+        return [], []
+
+    n_frames = len(path)
+    melody: list[NoteEvent] = []
+    chords: list[NoteEvent] = []
+    tol_bins = match_tolerance_semitones * BINS_PER_SEMITONE
+
+    for ev in events:
+        start_sec, end_sec, pitch, amp, bends = ev
+        if pitch < low_midi or pitch > high_midi:
+            chords.append(ev)
+            continue
+
+        f0 = max(0, int(round(start_sec * frame_rate_hz)))
+        f1 = min(n_frames, int(round(end_sec * frame_rate_hz)))
+        if f1 <= f0:
+            chords.append(ev)
+            continue
+
+        target_bin = midi_to_bin(pitch)
+        match = 0
+        total = f1 - f0
+        for f in range(f0, f1):
+            pb = int(path[f])
+            if pb < 0:
+                continue
+            if abs(pb - target_bin) <= tol_bins:
+                match += 1
+
+        if total > 0 and (match / total) >= match_fraction:
+            melody.append(ev)
+        else:
+            chords.append(ev)
+
+    return melody, chords
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def extract_melody(
+    contour: Any,  # np.ndarray (frames, 264) or None
+    note_events: list[NoteEvent],
+    *,
+    melody_low_midi: int = DEFAULT_MELODY_LOW_MIDI,
+    melody_high_midi: int = DEFAULT_MELODY_HIGH_MIDI,
+    voicing_floor: float = DEFAULT_VOICING_FLOOR,
+    transition_weight: float = DEFAULT_TRANSITION_WEIGHT,
+    max_transition_bins: int = DEFAULT_MAX_TRANSITION_BINS,
+    voiced_enter_cost: float = DEFAULT_VOICED_ENTER_COST,
+    unvoiced_enter_cost: float = DEFAULT_UNVOICED_ENTER_COST,
+    match_tolerance_semitones: float = DEFAULT_MATCH_TOL_SEMITONES,
+    match_fraction: float = DEFAULT_MATCH_FRACTION,
+    frame_rate_hz: float = FRAME_RATE_HZ,
+) -> tuple[list[NoteEvent], list[NoteEvent], MelodyExtractionStats]:
+    """Run Phase 2 melody extraction over Basic Pitch output.
+
+    Returns ``(melody_events, chord_events, stats)``. When numpy is
+    unavailable or the contour matrix is missing / malformed, returns
+    ``([], note_events, stats)`` with ``stats.skipped = True`` so the
+    caller can fall back to a single-track result without losing notes.
+
+    Tuning: the defaults are conservative. For songs with a strong
+    vocal lead, raising ``match_fraction`` to ~0.75 and narrowing
+    ``melody_high_midi`` cuts false positives; for instrumental tracks
+    with a quieter lead, lowering ``voicing_floor`` to ~0.08 picks up
+    softer melody notes at the cost of more spurious voicing.
+    """
+    stats = MelodyExtractionStats(input_note_count=len(note_events))
+
+    if contour is None:
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    try:
+        import numpy as np  # noqa: PLC0415
+    except ImportError:
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    contour_arr = np.asarray(contour)
+    if contour_arr.ndim != 2 or contour_arr.shape[1] != N_CONTOUR_BINS:
+        stats.warnings.append(
+            f"contour has unexpected shape {contour_arr.shape}; skipping"
+        )
+        stats.skipped = True
+        return [], list(note_events), stats
+    if contour_arr.shape[0] < 2:
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    low_bin = midi_to_bin(melody_low_midi)
+    high_bin = midi_to_bin(melody_high_midi)
+    if low_bin >= high_bin:
+        stats.warnings.append(
+            f"invalid melody band [{melody_low_midi}, {melody_high_midi}]"
+        )
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    try:
+        path = _trace_f0_contour(
+            contour_arr,
+            low_bin=low_bin,
+            high_bin=high_bin,
+            voicing_floor=voicing_floor,
+            transition_weight=transition_weight,
+            max_transition_bins=max_transition_bins,
+            voiced_enter_cost=voiced_enter_cost,
+            unvoiced_enter_cost=unvoiced_enter_cost,
+        )
+    except Exception as exc:  # noqa: BLE001 — Viterbi must never sink transcribe
+        log.warning("Viterbi F0 tracer failed: %s", exc)
+        stats.warnings.append(f"viterbi failed: {exc}")
+        stats.skipped = True
+        return [], list(note_events), stats
+
+    voiced_frac = float((path >= 0).mean()) if len(path) else 0.0
+    stats.voiced_frame_fraction = voiced_frac
+
+    melody, chords = _split_notes_by_melody_agreement(
+        note_events,
+        path,
+        low_midi=melody_low_midi,
+        high_midi=melody_high_midi,
+        frame_rate_hz=frame_rate_hz,
+        match_tolerance_semitones=match_tolerance_semitones,
+        match_fraction=match_fraction,
+    )
+
+    stats.melody_note_count = len(melody)
+    stats.chord_note_count = len(chords)
+    log.debug(
+        "melody extraction: %d notes → %d melody / %d chords (%.0f%% voiced)",
+        len(note_events),
+        len(melody),
+        len(chords),
+        voiced_frac * 100.0,
+    )
+    return melody, chords, stats

--- a/backend/services/transcribe.py
+++ b/backend/services/transcribe.py
@@ -22,6 +22,7 @@ the rest of the pipeline can still be exercised end-to-end.
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
 import tempfile
 from pathlib import Path
@@ -37,10 +38,19 @@ from backend.contracts import (
     MidiTrack,
     Note,
     QualitySignal,
+    RealtimeChordEvent,
     TempoMapEntry,
     TranscriptionResult,
 )
 from backend.services.audio_timing import tempo_map_from_audio_path
+from backend.services.bass_extraction import (
+    BassExtractionStats,
+    extract_bass,
+)
+from backend.services.chord_recognition import (
+    ChordRecognitionStats,
+    recognize_chords,
+)
 from backend.services.melody_extraction import (
     MelodyExtractionStats,
     extract_melody,
@@ -50,6 +60,7 @@ from backend.services.transcription_cleanup import (
     NoteEvent,
     cleanup_note_events,
 )
+from backend.storage.base import BlobStore
 
 log = logging.getLogger(__name__)
 
@@ -89,14 +100,17 @@ def _pretty_midi_to_transcription_result(
     tempo_map_override: list[TempoMapEntry] | None = None,
     cleanup_stats: CleanupStats | None = None,
     melody_stats: MelodyExtractionStats | None = None,
+    bass_stats: BassExtractionStats | None = None,
+    chord_stats: ChordRecognitionStats | None = None,
+    chord_labels: list[RealtimeChordEvent] | None = None,
 ) -> TranscriptionResult:
     """Convert Basic Pitch's output into our pydantic TranscriptionResult.
 
-    ``events_by_role`` maps a ``InstrumentRole`` (typically MELODY +
-    CHORDS after Phase 2 extraction, or a single PIANO fallback) to the
-    list of ``NoteEvent`` tuples belonging to that role. One
-    ``MidiTrack`` is emitted per non-empty role. Per-track confidence is
-    the mean amplitude of that role's events, clamped to [0.1, 1.0].
+    ``events_by_role`` maps a ``InstrumentRole`` (MELODY / BASS / CHORDS
+    after Phase 2+3 extraction, or a single PIANO fallback) to the list
+    of ``NoteEvent`` tuples belonging to that role. One ``MidiTrack`` is
+    emitted per non-empty role. Per-track confidence is the mean
+    amplitude of that role's events, clamped to [0.1, 1.0].
 
     ``pm`` is retained only so we can fall back to ``pm.estimate_tempo``
     when the waveform-derived tempo map is unavailable — the contract
@@ -106,6 +120,12 @@ def _pretty_midi_to_transcription_result(
     tracking), it replaces the single-anchor map we'd otherwise build
     from ``pm.estimate_tempo`` so arrange's ``sec_to_beat`` aligns
     quantization to the real pulse of the recording.
+
+    ``chord_labels`` (when provided) are attached to
+    ``HarmonicAnalysis.chords``. The labels come from
+    :func:`recognize_chords` — a chroma + triad template pass over the
+    source waveform. Empty list means "no chord recognition ran or
+    nothing scored above threshold".
     """
     import numpy as np  # noqa: PLC0415 — heavy/optional dep
 
@@ -174,7 +194,7 @@ def _pretty_midi_to_transcription_result(
         key="C:major",
         time_signature=(4, 4),
         tempo_map=tempo_map,
-        chords=[],
+        chords=list(chord_labels) if chord_labels else [],
         sections=[],
     )
 
@@ -188,6 +208,10 @@ def _pretty_midi_to_transcription_result(
         warnings.extend(cleanup_stats.as_warnings())
     if melody_stats is not None:
         warnings.extend(melody_stats.as_warnings())
+    if bass_stats is not None:
+        warnings.extend(bass_stats.as_warnings())
+    if chord_stats is not None:
+        warnings.extend(chord_stats.as_warnings())
     if total_notes < 20:
         warnings.append(f"Low note count ({total_notes}) — possible quality issue")
     quality = QualitySignal(
@@ -260,20 +284,35 @@ def _audio_path_from_uri(uri: str) -> Path:
     return Path(parsed.path)
 
 
-def _run_basic_pitch_sync(audio_path: Path) -> TranscriptionResult:
+def _serialize_pretty_midi(pm: Any) -> bytes | None:
+    """Serialize a pretty_midi.PrettyMIDI to raw .mid bytes.
+
+    pretty_midi >= 0.2.10 accepts a file-like object in ``write()`` and
+    forwards it to mido as ``file=...``, so we can avoid a temp file.
+    Returns None on any failure — blob persistence is best-effort and must
+    never break transcription.
+    """
+    try:
+        buf = io.BytesIO()
+        pm.write(buf)
+        return buf.getvalue()
+    except Exception as exc:  # noqa: BLE001 — best-effort serialization
+        log.warning("Failed to serialize pretty_midi for blob storage: %s", exc)
+        return None
+
+
+def _run_basic_pitch_sync(audio_path: Path) -> tuple[TranscriptionResult, bytes | None]:
     """Synchronous Basic Pitch inference. Run inside asyncio.to_thread.
 
-    Note events go through two post-processing passes:
+    Returns both the parsed ``TranscriptionResult`` and the raw MIDI bytes
+    (if serialization succeeded) so the async caller can persist the MIDI
+    to blob storage without blocking on disk I/O in the worker thread.
 
-    1. :func:`cleanup_note_events` — Phase 1 MIDI-level heuristics
-       (merge fragmented sustains, drop octave ghosts, ghost-tail
-       pruning). The pretty_midi is rebuilt from the cleaned events so
-       downstream consumers see the scrubbed note list.
-    2. :func:`extract_melody` — Phase 2 waveform-guided melody / chord
-       split via a Viterbi path over ``model_output["contour"]``. Falls
-       back to a single ``PIANO`` track when the extractor is skipped
-       (missing numpy, malformed contour, extraction failure) or finds
-       no melody notes.
+    The note events go through :func:`cleanup_note_events` before we
+    rebuild ``pretty_midi``, so both the contract notes and the
+    serialized ``.mid`` blob reflect the cleaned set. Cleanup is
+    pure-Python and deterministic — see transcription_cleanup.py for the
+    heuristics.
     """
     model = _load_basic_pitch_model()
     from basic_pitch.inference import predict  # noqa: PLC0415
@@ -287,9 +326,9 @@ def _run_basic_pitch_sync(audio_path: Path) -> TranscriptionResult:
         minimum_note_length=settings.basic_pitch_minimum_note_length_ms,
     )
 
-    # Phase 1 — cleanup heuristics over Basic Pitch's note_events. Rebuild
-    # pretty_midi from the cleaned list so any consumer that reads the pm
-    # directly (e.g. tempo estimation) sees the scrubbed set.
+    # Phase 1 post-processing — merge fragmented sustains, drop octave
+    # ghosts and quiet ghost-tail notes. Rebuild pretty_midi from the
+    # cleaned list so the blob-stored .mid matches the contract.
     cleaned_events, cleanup_stats = cleanup_note_events(
         note_events,
         merge_gap_sec=settings.cleanup_merge_gap_sec,
@@ -306,46 +345,125 @@ def _run_basic_pitch_sync(audio_path: Path) -> TranscriptionResult:
             cleaned_events = note_events  # fall back to raw
             cleanup_stats.warnings.append("cleanup: rebuild failed, using raw pm")
 
-    # Phase 2 — waveform-guided melody / chord split.
+    # Phase 2+3 post-processing — waveform-guided voice split via a
+    # Viterbi path over ``model_output["contour"]``, then bass on the
+    # low-register slice, then chord recognition from the source
+    # waveform. Each phase is independently feature-flagged. Skipped
+    # extractors leave their inputs unchanged so the chain degrades
+    # gracefully to single-track PIANO when everything is off.
+    contour = model_output.get("contour")
+    melody_events: list[NoteEvent] = []
+    bass_events: list[NoteEvent] = []
+    remaining: list[NoteEvent] = list(cleaned_events)
+
     melody_stats: MelodyExtractionStats | None = None
-    events_by_role: dict[InstrumentRole, list[NoteEvent]]
+    bass_stats: BassExtractionStats | None = None
+    chord_stats: ChordRecognitionStats | None = None
+    chord_labels: list[RealtimeChordEvent] = []
+
     if settings.melody_extraction_enabled:
-        melody_events, chord_events, melody_stats = extract_melody(
-            model_output.get("contour"),
-            cleaned_events,
+        melody_events, remaining, melody_stats = extract_melody(
+            contour,
+            remaining,
             melody_low_midi=settings.melody_low_midi,
             melody_high_midi=settings.melody_high_midi,
             voicing_floor=settings.melody_voicing_floor,
             transition_weight=settings.melody_transition_weight,
             max_transition_bins=settings.melody_max_transition_bins,
             match_fraction=settings.melody_match_fraction,
+            backfill_enabled=settings.melody_backfill_enabled,
+            backfill_min_duration_sec=settings.melody_backfill_min_duration_sec,
+            backfill_overlap_fraction=settings.melody_backfill_overlap_fraction,
+            backfill_min_amp=settings.melody_backfill_min_amp,
+            backfill_max_amp=settings.melody_backfill_max_amp,
         )
-        if melody_stats.skipped or not melody_events:
-            events_by_role = {InstrumentRole.PIANO: cleaned_events}
-        else:
-            events_by_role = {
-                InstrumentRole.MELODY: melody_events,
-                InstrumentRole.CHORDS: chord_events,
-            }
-    else:
-        events_by_role = {InstrumentRole.PIANO: cleaned_events}
 
-    # Waveform-derived tempo_map (best-effort; None on failure).
+    if settings.bass_extraction_enabled:
+        bass_events, remaining, bass_stats = extract_bass(
+            contour,
+            remaining,
+            bass_low_midi=settings.bass_low_midi,
+            bass_high_midi=settings.bass_high_midi,
+            voicing_floor=settings.bass_voicing_floor,
+            transition_weight=settings.bass_transition_weight,
+            max_transition_bins=settings.bass_max_transition_bins,
+            match_fraction=settings.bass_match_fraction,
+        )
+
+    melody_skipped = melody_stats is None or melody_stats.skipped
+    bass_skipped = bass_stats is None or bass_stats.skipped
+
+    events_by_role: dict[InstrumentRole, list[NoteEvent]]
+    if melody_skipped and bass_skipped:
+        # Legacy single-track fallback — both Phase 2 and Phase 3 voice
+        # splits were disabled or failed. Merge everything into PIANO
+        # so the arrange stage still gets the full pitch stream.
+        events_by_role = {InstrumentRole.PIANO: cleaned_events}
+    else:
+        events_by_role = {}
+        if melody_events:
+            events_by_role[InstrumentRole.MELODY] = melody_events
+        if bass_events:
+            events_by_role[InstrumentRole.BASS] = bass_events
+        if remaining:
+            events_by_role[InstrumentRole.CHORDS] = remaining
+        if not events_by_role:
+            # Edge case: both extractors ran but all notes ended up
+            # outside every band. Keep the raw stream under PIANO.
+            events_by_role = {InstrumentRole.PIANO: cleaned_events}
+
+    # Waveform-derived tempo_map (best-effort; None on failure). This
+    # lands before chord recognition so if we ever decide to share the
+    # beat grid, the sequencing is already correct.
     audio_tempo_map = tempo_map_from_audio_path(audio_path)
-    return _pretty_midi_to_transcription_result(
+
+    # Chord recognition is audio-only and independent of the event
+    # pipeline — it labels the waveform, and the labels attach to
+    # HarmonicAnalysis.chords. Best-effort: any failure yields an empty
+    # label list and a "skipped" stats marker.
+    if settings.chord_recognition_enabled:
+        try:
+            chord_labels, chord_stats = recognize_chords(
+                audio_path,
+                min_score=settings.chord_min_template_score,
+                hpss_margin=settings.chord_hpss_margin,
+            )
+        except Exception as exc:  # noqa: BLE001 — never let chord recog sink transcribe
+            log.warning("chord recognition raised: %s", exc)
+            chord_labels = []
+            chord_stats = ChordRecognitionStats(skipped=True)
+            chord_stats.warnings.append(f"chord recognition failed: {exc}")
+
+    result = _pretty_midi_to_transcription_result(
         midi_data,
         events_by_role,
         model_output,
         tempo_map_override=audio_tempo_map,
         cleanup_stats=cleanup_stats,
         melody_stats=melody_stats,
+        bass_stats=bass_stats,
+        chord_stats=chord_stats,
+        chord_labels=chord_labels,
     )
+    midi_bytes = _serialize_pretty_midi(midi_data)
+    return result, midi_bytes
 
 
 class TranscribeService:
     name = "transcribe"
 
-    async def run(self, payload: InputBundle) -> TranscriptionResult:
+    def __init__(self, blob_store: BlobStore | None = None) -> None:
+        # Optional so the service can still be constructed in bare unit tests
+        # that don't exercise the persistence path. In production (via
+        # backend.api.deps.get_runner) it's always injected.
+        self.blob_store = blob_store
+
+    async def run(
+        self,
+        payload: InputBundle,
+        *,
+        job_id: str | None = None,
+    ) -> TranscriptionResult:
         if payload.audio is None:
             return _stub_result("no audio in InputBundle")
 
@@ -380,10 +498,28 @@ class TranscribeService:
             return _stub_result(f"audio file missing: {audio_path}")
 
         try:
-            return await asyncio.to_thread(_run_basic_pitch_sync, audio_path)
+            result, midi_bytes = await asyncio.to_thread(
+                _run_basic_pitch_sync, audio_path,
+            )
         except ImportError as exc:
             log.warning("Basic Pitch deps unavailable (%s) — using stub", exc)
             return _stub_result(f"missing dependency: {exc}")
         except Exception as exc:  # noqa: BLE001 — boundary; we don't want one bad audio file to crash the worker
             log.exception("Basic Pitch inference failed for %s", audio_path)
             return _stub_result(f"inference failed: {exc}")
+
+        # Persist the raw transcription MIDI to blob storage so it's
+        # retrievable alongside the engraved output. Best-effort: a storage
+        # failure shouldn't sink the job, since the downstream pipeline only
+        # needs the parsed notes in ``result``.
+        if midi_bytes and self.blob_store is not None and job_id is not None:
+            try:
+                uri = self.blob_store.put_bytes(
+                    f"jobs/{job_id}/transcription/basic-pitch.mid",
+                    midi_bytes,
+                )
+                result = result.model_copy(update={"transcription_midi_uri": uri})
+            except Exception as exc:  # noqa: BLE001 — best-effort persistence
+                log.warning("Failed to persist transcription MIDI for %s: %s", job_id, exc)
+
+        return result

--- a/backend/services/transcribe.py
+++ b/backend/services/transcribe.py
@@ -337,7 +337,7 @@ def _run_basic_pitch_sync(audio_path: Path) -> tuple[TranscriptionResult, bytes 
         ghost_max_duration_sec=settings.cleanup_ghost_max_duration_sec,
         ghost_amp_median_scale=settings.cleanup_ghost_amp_median_scale,
     )
-    if cleanup_stats.output_count != cleanup_stats.input_count or cleanup_stats.merged:
+    if cleanup_stats.output_count != cleanup_stats.input_count:
         try:
             midi_data = note_events_to_midi(cleaned_events)
         except Exception as exc:  # noqa: BLE001 — never let cleanup sink the job

--- a/backend/services/transcribe.py
+++ b/backend/services/transcribe.py
@@ -41,6 +41,15 @@ from backend.contracts import (
     TranscriptionResult,
 )
 from backend.services.audio_timing import tempo_map_from_audio_path
+from backend.services.melody_extraction import (
+    MelodyExtractionStats,
+    extract_melody,
+)
+from backend.services.transcription_cleanup import (
+    CleanupStats,
+    NoteEvent,
+    cleanup_note_events,
+)
 
 log = logging.getLogger(__name__)
 
@@ -52,21 +61,46 @@ log = logging.getLogger(__name__)
 _BP_MODEL: Any = None
 
 
+def _event_to_note(event: NoteEvent) -> Note:
+    """Convert a Basic Pitch ``note_events`` tuple to a contract ``Note``.
+
+    Basic Pitch's own velocity formula is ``int(round(127 * amplitude))``
+    (see ``basic_pitch.note_creation.note_events_to_midi``); we replicate
+    it here so the contract notes match what the rebuilt pretty_midi
+    would contain, without needing to cross-reference ``pm.instruments``.
+    """
+    start, end, pitch, amplitude, _bends = event
+    velocity = int(round(127 * float(amplitude)))
+    velocity = max(1, min(127, velocity))
+    return Note(
+        pitch=int(pitch),
+        onset_sec=float(start),
+        offset_sec=float(end),
+        velocity=velocity,
+    )
+
+
 def _pretty_midi_to_transcription_result(
     pm: Any,
-    note_events: list[tuple[float, float, int, float, Any]],
+    events_by_role: dict[InstrumentRole, list[NoteEvent]],
     model_output: dict[str, Any],
     default_bpm: float = 120.0,
     *,
     tempo_map_override: list[TempoMapEntry] | None = None,
+    cleanup_stats: CleanupStats | None = None,
+    melody_stats: MelodyExtractionStats | None = None,
 ) -> TranscriptionResult:
     """Convert Basic Pitch's output into our pydantic TranscriptionResult.
 
-    Basic Pitch emits a single polyphonic pitch stream (no instrument
-    separation), so we collapse everything into one ``PIANO`` MidiTrack.
-    Per-note confidence comes straight from the model's sigmoid output
-    (note_events[i][3] is the amplitude at the onset frame, which is the
-    same scalar basic_pitch uses to derive the MIDI velocity).
+    ``events_by_role`` maps a ``InstrumentRole`` (typically MELODY +
+    CHORDS after Phase 2 extraction, or a single PIANO fallback) to the
+    list of ``NoteEvent`` tuples belonging to that role. One
+    ``MidiTrack`` is emitted per non-empty role. Per-track confidence is
+    the mean amplitude of that role's events, clamped to [0.1, 1.0].
+
+    ``pm`` is retained only so we can fall back to ``pm.estimate_tempo``
+    when the waveform-derived tempo map is unavailable — the contract
+    notes are built from ``events_by_role`` directly.
 
     If ``tempo_map_override`` is provided (e.g. from waveform beat
     tracking), it replaces the single-anchor map we'd otherwise build
@@ -75,47 +109,51 @@ def _pretty_midi_to_transcription_result(
     """
     import numpy as np  # noqa: PLC0415 — heavy/optional dep
 
-    contract_notes: list[Note] = []
-    amplitudes: list[float] = []
-    for instrument in pm.instruments:
-        if instrument.is_drum:
-            continue
-        for n in instrument.notes:
-            contract_notes.append(
-                Note(
-                    pitch=int(n.pitch),
-                    onset_sec=float(n.start),
-                    offset_sec=float(n.end),
-                    velocity=int(n.velocity),
-                )
-            )
-    # note_events is the source of truth for per-note confidence; amplitudes
-    # are sigmoid probabilities in [0, 1] from model_output["note"] at each
-    # detected onset frame.
-    for _start, _end, _pitch, amplitude, _bends in note_events:
-        amplitudes.append(float(amplitude))
-
-    contract_notes.sort(key=lambda n: (n.onset_sec, n.pitch))
-
-    # Overall confidence — mean of per-note amplitudes, scaled and clamped.
-    # Fall back to model_output["note"] mean if note_events is empty.
-    if amplitudes:
-        per_note_conf = float(np.mean(amplitudes))
-    else:
-        note_grid = model_output.get("note")
-        per_note_conf = float(np.mean(note_grid)) if note_grid is not None else 0.3
-    track_conf = round(min(max(per_note_conf, 0.1), 1.0), 2)
-
     midi_tracks: list[MidiTrack] = []
-    if contract_notes:
+    all_amplitudes: list[float] = []
+
+    # Deterministic track order so test output is stable — MELODY first
+    # (it's the arrange right-hand target), then the rest.
+    _order = [
+        InstrumentRole.MELODY,
+        InstrumentRole.BASS,
+        InstrumentRole.CHORDS,
+        InstrumentRole.PIANO,
+        InstrumentRole.OTHER,
+    ]
+    ordered_roles = [r for r in _order if r in events_by_role] + [
+        r for r in events_by_role if r not in _order
+    ]
+
+    for role in ordered_roles:
+        events = events_by_role.get(role, [])
+        if not events:
+            continue
+        contract_notes = [_event_to_note(ev) for ev in events]
+        contract_notes.sort(key=lambda n: (n.onset_sec, n.pitch))
+
+        amps = [float(ev[3]) for ev in events]
+        all_amplitudes.extend(amps)
+        role_conf = float(np.mean(amps)) if amps else 0.3
+        role_conf = round(min(max(role_conf, 0.1), 1.0), 2)
+
         midi_tracks.append(
             MidiTrack(
                 notes=contract_notes,
-                instrument=InstrumentRole.PIANO,
+                instrument=role,
                 program=0,
-                confidence=track_conf,
+                confidence=role_conf,
             )
         )
+
+    # Overall confidence — mean of per-note amplitudes across all roles.
+    # Fall back to model_output["note"] mean if everything was empty.
+    if all_amplitudes:
+        overall_conf = float(np.mean(all_amplitudes))
+    else:
+        note_grid = model_output.get("note")
+        overall_conf = float(np.mean(note_grid)) if note_grid is not None else 0.3
+    overall_conf = round(min(max(overall_conf, 0.1), 1.0), 2)
 
     # Tempo map — prefer the waveform-derived beat grid when available.
     # Basic Pitch itself does not estimate tempo, so without the override
@@ -140,16 +178,20 @@ def _pretty_midi_to_transcription_result(
         sections=[],
     )
 
-    total_notes = len(contract_notes)
+    total_notes = sum(len(t.notes) for t in midi_tracks)
     warnings: list[str] = [
         "Basic Pitch baseline (polyphonic pitch tracker, no instrument separation)"
     ]
     if tempo_map_override:
         warnings.append("tempo_map from audio beat tracking (librosa)")
+    if cleanup_stats is not None:
+        warnings.extend(cleanup_stats.as_warnings())
+    if melody_stats is not None:
+        warnings.extend(melody_stats.as_warnings())
     if total_notes < 20:
         warnings.append(f"Low note count ({total_notes}) — possible quality issue")
     quality = QualitySignal(
-        overall_confidence=track_conf if midi_tracks else 0.1,
+        overall_confidence=overall_conf if midi_tracks else 0.1,
         warnings=warnings,
     )
 
@@ -219,9 +261,23 @@ def _audio_path_from_uri(uri: str) -> Path:
 
 
 def _run_basic_pitch_sync(audio_path: Path) -> TranscriptionResult:
-    """Synchronous Basic Pitch inference. Run inside asyncio.to_thread."""
+    """Synchronous Basic Pitch inference. Run inside asyncio.to_thread.
+
+    Note events go through two post-processing passes:
+
+    1. :func:`cleanup_note_events` — Phase 1 MIDI-level heuristics
+       (merge fragmented sustains, drop octave ghosts, ghost-tail
+       pruning). The pretty_midi is rebuilt from the cleaned events so
+       downstream consumers see the scrubbed note list.
+    2. :func:`extract_melody` — Phase 2 waveform-guided melody / chord
+       split via a Viterbi path over ``model_output["contour"]``. Falls
+       back to a single ``PIANO`` track when the extractor is skipped
+       (missing numpy, malformed contour, extraction failure) or finds
+       no melody notes.
+    """
     model = _load_basic_pitch_model()
     from basic_pitch.inference import predict  # noqa: PLC0415
+    from basic_pitch.note_creation import note_events_to_midi  # noqa: PLC0415
 
     model_output, midi_data, note_events = predict(
         str(audio_path),
@@ -230,13 +286,59 @@ def _run_basic_pitch_sync(audio_path: Path) -> TranscriptionResult:
         frame_threshold=settings.basic_pitch_frame_threshold,
         minimum_note_length=settings.basic_pitch_minimum_note_length_ms,
     )
+
+    # Phase 1 — cleanup heuristics over Basic Pitch's note_events. Rebuild
+    # pretty_midi from the cleaned list so any consumer that reads the pm
+    # directly (e.g. tempo estimation) sees the scrubbed set.
+    cleaned_events, cleanup_stats = cleanup_note_events(
+        note_events,
+        merge_gap_sec=settings.cleanup_merge_gap_sec,
+        octave_amp_ratio=settings.cleanup_octave_amp_ratio,
+        octave_onset_tol_sec=settings.cleanup_octave_onset_tol_sec,
+        ghost_max_duration_sec=settings.cleanup_ghost_max_duration_sec,
+        ghost_amp_median_scale=settings.cleanup_ghost_amp_median_scale,
+    )
+    if cleanup_stats.output_count != cleanup_stats.input_count or cleanup_stats.merged:
+        try:
+            midi_data = note_events_to_midi(cleaned_events)
+        except Exception as exc:  # noqa: BLE001 — never let cleanup sink the job
+            log.warning("note_events_to_midi rebuild failed, using raw pm: %s", exc)
+            cleaned_events = note_events  # fall back to raw
+            cleanup_stats.warnings.append("cleanup: rebuild failed, using raw pm")
+
+    # Phase 2 — waveform-guided melody / chord split.
+    melody_stats: MelodyExtractionStats | None = None
+    events_by_role: dict[InstrumentRole, list[NoteEvent]]
+    if settings.melody_extraction_enabled:
+        melody_events, chord_events, melody_stats = extract_melody(
+            model_output.get("contour"),
+            cleaned_events,
+            melody_low_midi=settings.melody_low_midi,
+            melody_high_midi=settings.melody_high_midi,
+            voicing_floor=settings.melody_voicing_floor,
+            transition_weight=settings.melody_transition_weight,
+            max_transition_bins=settings.melody_max_transition_bins,
+            match_fraction=settings.melody_match_fraction,
+        )
+        if melody_stats.skipped or not melody_events:
+            events_by_role = {InstrumentRole.PIANO: cleaned_events}
+        else:
+            events_by_role = {
+                InstrumentRole.MELODY: melody_events,
+                InstrumentRole.CHORDS: chord_events,
+            }
+    else:
+        events_by_role = {InstrumentRole.PIANO: cleaned_events}
+
     # Waveform-derived tempo_map (best-effort; None on failure).
     audio_tempo_map = tempo_map_from_audio_path(audio_path)
     return _pretty_midi_to_transcription_result(
         midi_data,
-        note_events,
+        events_by_role,
         model_output,
         tempo_map_override=audio_tempo_map,
+        cleanup_stats=cleanup_stats,
+        melody_stats=melody_stats,
     )
 
 

--- a/backend/services/transcription_cleanup.py
+++ b/backend/services/transcription_cleanup.py
@@ -1,0 +1,274 @@
+"""Phase 1 post-processing heuristics for Basic Pitch transcriptions.
+
+Basic Pitch is a polyphonic pitch tracker, not a musical transcriber, and
+its raw output has three classes of artifact that hurt the downstream
+arrangement:
+
+1. **Fragmented sustains.** A single held note often gets split into two
+   or three short notes with sub-frame gaps, because the frame-level
+   activation dips below ``frame_threshold`` for a moment mid-sustain.
+
+2. **Octave ghosts.** A note at pitch ``p`` induces a much quieter
+   detection one octave up at ``p+12`` from the overtone series. These
+   harmonic artifacts are distinguishable from real octave doublings
+   because the upper note has a much lower activation amplitude.
+
+3. **Ghost-tail notes.** Brief, quiet notes appearing just after a real
+   note decays (reverb tails, model uncertainty at offset boundaries).
+
+This module runs a pure-Python cleanup pass over Basic Pitch's
+``note_events`` tuple format so we can rebuild ``pretty_midi`` from a
+cleaner set of notes before handing off to the contract.
+
+Everything here is deterministic and dependency-free — no numpy, no
+librosa, no basic_pitch import — so it runs in CI regardless of whether
+the ``basic-pitch`` extra is installed, and is easy to unit-test with
+synthetic fixtures.
+
+Future phases will layer waveform-guided melody/bass tracing on top of
+this using Basic Pitch's ``model_output["contour"]`` salience matrix.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Basic Pitch's note_events format:
+#   (start_sec, end_sec, pitch_midi, amplitude, pitch_bends_or_none)
+# We keep the last slot (pitch_bends) opaque and pass it through unchanged
+# so downstream ``note_events_to_midi`` still sees the bend track.
+NoteEvent = tuple[float, float, int, float, Any]
+
+
+# ---------------------------------------------------------------------------
+# Default thresholds
+# ---------------------------------------------------------------------------
+# These defaults err on the conservative side — they catch clear artifacts
+# without pruning legitimate musical notes. Tunable via config in the caller.
+
+DEFAULT_MERGE_GAP_SEC = 0.03
+DEFAULT_OCTAVE_AMP_RATIO = 0.6
+DEFAULT_OCTAVE_ONSET_TOL_SEC = 0.05
+DEFAULT_GHOST_MAX_DURATION_SEC = 0.06
+DEFAULT_GHOST_AMP_MEDIAN_SCALE = 0.5
+
+
+@dataclass
+class CleanupStats:
+    """How many notes each pass touched — used for telemetry + warnings."""
+    input_count: int = 0
+    output_count: int = 0
+    merged: int = 0                  # pairs merged (count reduction)
+    octave_ghosts_dropped: int = 0
+    ghost_tails_dropped: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def as_warnings(self) -> list[str]:
+        """One-line human summary entries for the QualitySignal."""
+        out: list[str] = []
+        if self.merged:
+            out.append(f"cleanup: merged {self.merged} fragmented sustains")
+        if self.octave_ghosts_dropped:
+            out.append(f"cleanup: dropped {self.octave_ghosts_dropped} octave ghosts")
+        if self.ghost_tails_dropped:
+            out.append(f"cleanup: dropped {self.ghost_tails_dropped} ghost-tail notes")
+        out.extend(self.warnings)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Pass 1 — merge fragmented sustains
+# ---------------------------------------------------------------------------
+
+def _merge_fragmented_sustains(
+    events: list[NoteEvent],
+    max_gap_sec: float,
+) -> tuple[list[NoteEvent], int]:
+    """Join consecutive same-pitch notes whose gap is below ``max_gap_sec``.
+
+    Merged note spans ``[min(starts), max(ends)]`` and keeps the loudest
+    amplitude of the two (the upstream velocity formula ``round(127 * amp)``
+    is monotonic, so this preserves the louder of the two velocities). We
+    do not attempt to merge pitch-bend tracks — whichever event comes
+    first keeps its bends, which is the same convention basic_pitch's
+    ``drop_overlapping_pitch_bends`` uses.
+    """
+    if not events:
+        return [], 0
+
+    by_pitch: dict[int, list[NoteEvent]] = defaultdict(list)
+    for ev in events:
+        by_pitch[ev[2]].append(ev)
+
+    merged_out: list[NoteEvent] = []
+    merged_count = 0
+    for pitch, group in by_pitch.items():
+        group.sort(key=lambda e: e[0])
+        run: NoteEvent = group[0]
+        for ev in group[1:]:
+            gap = ev[0] - run[1]
+            if gap <= max_gap_sec:
+                run = (
+                    run[0],
+                    max(run[1], ev[1]),
+                    pitch,
+                    max(run[3], ev[3]),
+                    run[4],
+                )
+                merged_count += 1
+            else:
+                merged_out.append(run)
+                run = ev
+        merged_out.append(run)
+
+    merged_out.sort(key=lambda e: (e[0], e[2]))
+    return merged_out, merged_count
+
+
+# ---------------------------------------------------------------------------
+# Pass 2 — octave-ghost pruning
+# ---------------------------------------------------------------------------
+
+def _prune_octave_ghosts(
+    events: list[NoteEvent],
+    amp_ratio: float,
+    onset_tol_sec: float,
+) -> tuple[list[NoteEvent], int]:
+    """Drop a note at pitch ``p+12`` if a near-simultaneous note at ``p``
+    is loud enough that the upper is plausibly a harmonic artifact.
+
+    An upper event is flagged when there exists a lower event whose onset
+    falls within ``onset_tol_sec`` of the upper's onset *and* whose
+    amplitude satisfies ``upper.amp < amp_ratio * lower.amp``. Real
+    musical octave doublings (both loud) pass through untouched because
+    their amplitudes are comparable.
+    """
+    if not events:
+        return [], 0
+
+    # Index by pitch so each ghost lookup is O(candidates_at_lower_pitch).
+    by_pitch: dict[int, list[tuple[float, float, int]]] = defaultdict(list)
+    for idx, ev in enumerate(events):
+        by_pitch[ev[2]].append((ev[0], ev[3], idx))
+    for lst in by_pitch.values():
+        lst.sort()
+
+    drop: set[int] = set()
+    for idx, ev in enumerate(events):
+        lower_pitch = ev[2] - 12
+        if lower_pitch < 0:
+            continue
+        candidates = by_pitch.get(lower_pitch)
+        if not candidates:
+            continue
+        for onset, amp_lower, _j in candidates:
+            if onset > ev[0] + onset_tol_sec:
+                break
+            if abs(onset - ev[0]) <= onset_tol_sec and ev[3] < amp_ratio * amp_lower:
+                drop.add(idx)
+                break
+
+    if not drop:
+        return list(events), 0
+    return [e for i, e in enumerate(events) if i not in drop], len(drop)
+
+
+# ---------------------------------------------------------------------------
+# Pass 3 — ghost-tail pruning
+# ---------------------------------------------------------------------------
+
+def _prune_ghost_tails(
+    events: list[NoteEvent],
+    max_duration_sec: float,
+    amp_median_scale: float,
+) -> tuple[list[NoteEvent], int]:
+    """Drop notes that are both shorter than ``max_duration_sec`` **and**
+    quieter than ``amp_median_scale × median(amplitudes)``.
+
+    The two-predicate rule is deliberate: a short but loud staccato is
+    probably real, and a long but quiet sustained pad is probably real.
+    Only the intersection — short *and* quiet — matches the ghost-tail
+    profile we want to kill.
+    """
+    if not events:
+        return [], 0
+
+    amps = sorted(e[3] for e in events)
+    mid = len(amps) // 2
+    median_amp = amps[mid] if len(amps) % 2 else 0.5 * (amps[mid - 1] + amps[mid])
+    threshold = amp_median_scale * median_amp
+
+    kept: list[NoteEvent] = []
+    dropped = 0
+    for ev in events:
+        duration = ev[1] - ev[0]
+        if duration < max_duration_sec and ev[3] < threshold:
+            dropped += 1
+            continue
+        kept.append(ev)
+    return kept, dropped
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def cleanup_note_events(
+    note_events: list[NoteEvent],
+    *,
+    merge_gap_sec: float = DEFAULT_MERGE_GAP_SEC,
+    octave_amp_ratio: float = DEFAULT_OCTAVE_AMP_RATIO,
+    octave_onset_tol_sec: float = DEFAULT_OCTAVE_ONSET_TOL_SEC,
+    ghost_max_duration_sec: float = DEFAULT_GHOST_MAX_DURATION_SEC,
+    ghost_amp_median_scale: float = DEFAULT_GHOST_AMP_MEDIAN_SCALE,
+) -> tuple[list[NoteEvent], CleanupStats]:
+    """Run the Phase 1 cleanup pipeline over Basic Pitch note events.
+
+    Order of operations matters:
+
+    1. **Merge** first so a fragmented sustain is seen as one note by
+       the later passes (otherwise the first fragment may be flagged as
+       a ghost tail because its duration is tiny).
+    2. **Octave prune** next so downstream amplitude statistics reflect
+       the real set of notes, not harmonic duplicates.
+    3. **Ghost-tail prune** last, operating on an already-merged,
+       already-dedup'd list.
+
+    Returns the cleaned events and a :class:`CleanupStats` summary for
+    the caller to surface in ``QualitySignal.warnings``.
+    """
+    stats = CleanupStats(input_count=len(note_events))
+
+    merged, merged_count = _merge_fragmented_sustains(
+        list(note_events), max_gap_sec=merge_gap_sec,
+    )
+    stats.merged = merged_count
+
+    deghosted, octave_dropped = _prune_octave_ghosts(
+        merged,
+        amp_ratio=octave_amp_ratio,
+        onset_tol_sec=octave_onset_tol_sec,
+    )
+    stats.octave_ghosts_dropped = octave_dropped
+
+    cleaned, tails_dropped = _prune_ghost_tails(
+        deghosted,
+        max_duration_sec=ghost_max_duration_sec,
+        amp_median_scale=ghost_amp_median_scale,
+    )
+    stats.ghost_tails_dropped = tails_dropped
+
+    stats.output_count = len(cleaned)
+    log.debug(
+        "transcription cleanup: %d → %d (merged=%d, octaves=%d, ghosts=%d)",
+        stats.input_count,
+        stats.output_count,
+        stats.merged,
+        stats.octave_ghosts_dropped,
+        stats.ghost_tails_dropped,
+    )
+    return cleaned, stats

--- a/tests/test_bass_extraction.py
+++ b/tests/test_bass_extraction.py
@@ -1,0 +1,158 @@
+"""Unit tests for Phase 3 bass extraction.
+
+Mirrors the synthetic-contour approach used by
+``tests/test_melody_extraction.py`` — we build a hand-crafted ``(T, 264)``
+salience matrix and drive the shared Viterbi tracer directly, skipping
+the full Basic Pitch pipeline. That keeps the tests hermetic and fast.
+"""
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from backend.services.bass_extraction import (  # noqa: E402
+    DEFAULT_BASS_HIGH_MIDI,
+    DEFAULT_BASS_LOW_MIDI,
+    DEFAULT_BASS_MATCH_FRACTION,
+    DEFAULT_BASS_MAX_TRANSITION_BINS,
+    DEFAULT_BASS_TRANSITION_WEIGHT,
+    DEFAULT_BASS_VOICING_FLOOR,
+    extract_bass,
+)
+from backend.services.melody_extraction import (  # noqa: E402
+    FRAME_RATE_HZ,
+    N_CONTOUR_BINS,
+    midi_to_bin,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _blank_contour(n_frames: int, baseline: float = 0.02):
+    return np.full((n_frames, N_CONTOUR_BINS), baseline, dtype=np.float32)
+
+
+def _paint(contour, start_frame: int, end_frame: int, midi: int, salience: float = 0.9):
+    contour[start_frame:end_frame, midi_to_bin(midi)] = salience
+
+
+def _ne(start: float, end: float, pitch: int, amp: float = 0.8):
+    return (start, end, pitch, amp, None)
+
+
+# ---------------------------------------------------------------------------
+# Tracer behavior in the low band
+# ---------------------------------------------------------------------------
+
+def test_extract_bass_tags_low_pedal_as_bass():
+    # Stable E2 (MIDI 40) pedal for one second.
+    frames = int(round(1.1 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    _paint(c, 0, int(round(1.0 * FRAME_RATE_HZ)), 40, salience=0.9)
+
+    events = [_ne(0.0, 1.0, 40)]
+    bass, remaining, stats = extract_bass(c, events)
+    assert not stats.skipped
+    assert bass == events
+    assert remaining == []
+    assert stats.bass_note_count == 1
+    assert stats.remaining_note_count == 0
+    assert stats.voiced_frame_fraction > 0.8
+
+
+def test_extract_bass_ignores_peak_above_high_midi():
+    # Peak at MIDI 67 (G4) — well above the bass band — should not attract
+    # the low-register Viterbi path. The event is in the melody range, so
+    # it also falls out of the bass band mask and stays in remaining.
+    frames = int(round(1.1 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    _paint(c, 0, int(round(1.0 * FRAME_RATE_HZ)), 67, salience=0.9)
+
+    events = [_ne(0.0, 1.0, 67)]
+    bass, remaining, stats = extract_bass(c, events)
+    assert bass == []
+    assert remaining == events
+
+
+def test_extract_bass_tracks_a_walking_line():
+    # Walking bass: E2 → G2 → A2 → B2, quarter-second each.
+    frames_per_sec = FRAME_RATE_HZ
+    c = _blank_contour(int(round(1.1 * frames_per_sec)))
+    _paint(c, 0, int(round(0.25 * frames_per_sec)), 40)
+    _paint(c, int(round(0.25 * frames_per_sec)), int(round(0.5 * frames_per_sec)), 43)
+    _paint(c, int(round(0.5 * frames_per_sec)), int(round(0.75 * frames_per_sec)), 45)
+    _paint(c, int(round(0.75 * frames_per_sec)), int(round(1.0 * frames_per_sec)), 47)
+
+    events = [
+        _ne(0.0, 0.25, 40),
+        _ne(0.25, 0.5, 43),
+        _ne(0.5, 0.75, 45),
+        _ne(0.75, 1.0, 47),
+    ]
+    bass, remaining, stats = extract_bass(c, events)
+    assert sorted(e[2] for e in bass) == [40, 43, 45, 47]
+    assert remaining == []
+
+
+def test_extract_bass_rejects_disagreeing_note():
+    # Path traces E2 throughout; an event at B1 (35) disagrees.
+    frames = int(round(1.1 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    _paint(c, 0, int(round(1.0 * FRAME_RATE_HZ)), 40)
+
+    events = [_ne(0.0, 1.0, 35)]  # 5 semitones away → outside tol
+    bass, remaining, stats = extract_bass(c, events)
+    assert bass == []
+    assert remaining == events
+
+
+def test_extract_bass_skips_when_contour_is_none():
+    events = [_ne(0.0, 1.0, 40)]
+    bass, remaining, stats = extract_bass(None, events)
+    assert stats.skipped
+    assert bass == []
+    assert remaining == events
+    assert any("skipped" in w for w in stats.as_warnings())
+
+
+def test_extract_bass_skips_on_malformed_contour_shape():
+    bad = np.zeros((100, 128), dtype=np.float32)  # wrong width
+    events = [_ne(0.0, 1.0, 40)]
+    bass, remaining, stats = extract_bass(bad, events)
+    assert stats.skipped
+    assert remaining == events
+
+
+def test_extract_bass_empty_events_short_circuits():
+    c = _blank_contour(50)
+    _paint(c, 0, 50, 40)
+    bass, remaining, stats = extract_bass(c, [])
+    assert bass == [] and remaining == []
+    assert not stats.skipped
+
+
+def test_extract_bass_tiny_contour_is_skipped():
+    c = np.zeros((1, N_CONTOUR_BINS), dtype=np.float32)
+    events = [_ne(0.0, 1.0, 40)]
+    bass, remaining, stats = extract_bass(c, events)
+    assert stats.skipped
+    assert remaining == events
+
+
+# ---------------------------------------------------------------------------
+# Config defaults sanity check
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_match_bass_module_defaults():
+    from backend.config import Settings
+
+    s = Settings()
+    assert s.bass_low_midi == DEFAULT_BASS_LOW_MIDI
+    assert s.bass_high_midi == DEFAULT_BASS_HIGH_MIDI
+    assert s.bass_voicing_floor == DEFAULT_BASS_VOICING_FLOOR
+    assert s.bass_transition_weight == DEFAULT_BASS_TRANSITION_WEIGHT
+    assert s.bass_max_transition_bins == DEFAULT_BASS_MAX_TRANSITION_BINS
+    assert s.bass_match_fraction == DEFAULT_BASS_MATCH_FRACTION
+    assert s.bass_extraction_enabled is True

--- a/tests/test_chord_recognition.py
+++ b/tests/test_chord_recognition.py
@@ -1,0 +1,178 @@
+"""Unit tests for Phase 3 chord recognition.
+
+The recognizer is a thin wrapper around ``librosa.feature.chroma_cqt``
++ template matching, so we drive it with synthetic sine-wave chords
+built directly in numpy. That avoids touching disk and keeps the tests
+hermetic and fast. Tests skip gracefully when librosa is missing.
+"""
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+librosa = pytest.importorskip("librosa")
+
+from backend.services.chord_recognition import (  # noqa: E402
+    DEFAULT_CHORD_MIN_SCORE,
+    _build_triad_templates,
+    recognize_chords_from_waveform,
+)
+
+SR = 22050
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic sine chords
+# ---------------------------------------------------------------------------
+
+def _sine(freq_hz: float, duration_sec: float, amp: float = 0.3):
+    n = int(round(SR * duration_sec))
+    t = np.arange(n, dtype=np.float32) / SR
+    return amp * np.sin(2.0 * np.pi * freq_hz * t).astype(np.float32)
+
+
+def _chord(freqs: list[float], duration_sec: float, attack_sec: float = 0.01):
+    """Sum a list of sines into a polyphonic chord, with a brief linear attack.
+
+    The attack matters: librosa's beat tracker keys on onset strength,
+    so pure steady-state sines produce zero beats and the recognizer
+    collapses to a single global span. A 10 ms ramp gives each chord
+    a transient the beat tracker can find.
+    """
+    parts = [_sine(f, duration_sec) for f in freqs]
+    y = np.sum(parts, axis=0).astype(np.float32)
+    peak = float(np.max(np.abs(y)))
+    if peak > 0:
+        y = y / peak * 0.8
+    n_attack = max(1, int(round(SR * attack_sec)))
+    env = np.ones_like(y)
+    env[:n_attack] = np.linspace(0.0, 1.0, n_attack, dtype=np.float32)
+    return y * env
+
+
+def _repeated(freqs: list[float], beat_sec: float, n_beats: int):
+    """Repeat the same chord ``n_beats`` times so the beat tracker
+    has a reliable onset grid to latch onto."""
+    return np.concatenate(
+        [_chord(freqs, beat_sec) for _ in range(n_beats)]
+    ).astype(np.float32)
+
+
+# Approximate triad frequencies (4th octave).
+C4, E4, G4 = 261.63, 329.63, 392.00
+D4, F4, A4 = 293.66, 349.23, 440.00
+G3, B3, D5 = 196.00, 246.94, 587.33
+
+
+# ---------------------------------------------------------------------------
+# Template construction
+# ---------------------------------------------------------------------------
+
+def test_triad_templates_shape_and_labels():
+    templates, labels, roots = _build_triad_templates()
+    assert templates.shape == (24, 12)
+    assert len(labels) == 24
+    assert len(roots) == 24
+    # First 12 are majors, second 12 are minors.
+    assert all(lbl.endswith(":maj") for lbl in labels[:12])
+    assert all(lbl.endswith(":min") for lbl in labels[12:])
+    # Each template is L2-normalized.
+    norms = np.linalg.norm(templates, axis=1)
+    np.testing.assert_allclose(norms, 1.0, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end recognition on synthetic chords
+# ---------------------------------------------------------------------------
+
+def test_recognize_single_c_major_chord():
+    y = _repeated([C4, E4, G4], beat_sec=0.5, n_beats=4)
+    labels, stats = recognize_chords_from_waveform(y, SR)
+    assert not stats.skipped
+    assert stats.detected_count >= 1
+    # At least one span is labeled C:maj.
+    assert any(lbl.label == "C:maj" for lbl in labels)
+    # Root index for C is 0.
+    assert any(lbl.root == 0 for lbl in labels if lbl.label == "C:maj")
+
+
+def test_recognize_chord_progression_c_then_g():
+    # Two chords back-to-back: 4 beats of C major, 4 beats of G major.
+    # Repetition + per-beat attack envelopes give the beat tracker
+    # something real to segment on.
+    y = np.concatenate([
+        _repeated([C4, E4, G4], beat_sec=0.5, n_beats=4),
+        _repeated([G3, B3, D5], beat_sec=0.5, n_beats=4),
+    ]).astype(np.float32)
+    labels, stats = recognize_chords_from_waveform(y, SR)
+    assert not stats.skipped
+    # Both C:maj and G:maj should show up in the label stream.
+    found = {lbl.label for lbl in labels}
+    assert "C:maj" in found
+    assert "G:maj" in found
+
+
+def test_recognize_minor_triad():
+    # A minor triad = A, C, E → should score A:min higher than A:maj.
+    y = _repeated([A4, C4, E4], beat_sec=0.5, n_beats=4)
+    labels, stats = recognize_chords_from_waveform(y, SR)
+    assert not stats.skipped
+    # Accept either A:min (ideal) or C:maj (common confusion — A
+    # minor and C major share two notes). Both have pitch class A in
+    # the chroma, so the test asserts we didn't pick something wildly
+    # off like a tritone.
+    assert any(lbl.label in {"A:min", "C:maj"} for lbl in labels)
+
+
+def test_recognize_confidence_field_is_bounded():
+    y = _repeated([C4, E4, G4], beat_sec=0.5, n_beats=4)
+    labels, _ = recognize_chords_from_waveform(y, SR)
+    assert labels, "expected at least one labeled span"
+    for lbl in labels:
+        assert 0.0 <= lbl.confidence <= 1.0
+
+
+def test_recognize_collapses_consecutive_duplicates():
+    # Four beats of the same chord should collapse to at most 1-2
+    # spans. Three-plus runs of "C:maj" would indicate the consecutive
+    # collapse pass isn't working.
+    y = _repeated([C4, E4, G4], beat_sec=0.5, n_beats=4)
+    labels, _ = recognize_chords_from_waveform(y, SR)
+    c_spans = [lbl for lbl in labels if lbl.label == "C:maj"]
+    assert len(c_spans) <= 2
+
+
+def test_recognize_high_threshold_suppresses_labels():
+    # Set min_score absurdly high → recognizer returns no labels.
+    y = _repeated([C4, E4, G4], beat_sec=0.5, n_beats=4)
+    labels, stats = recognize_chords_from_waveform(y, SR, min_score=1.1)
+    assert labels == []
+    assert stats.detected_count == 0
+    assert stats.no_chord_count >= 1
+
+
+def test_recognize_skips_tiny_input():
+    y = np.zeros(100, dtype=np.float32)  # ~4 ms at 22050 Hz
+    labels, stats = recognize_chords_from_waveform(y, SR)
+    assert stats.skipped
+    assert labels == []
+
+
+def test_recognize_returns_empty_for_silence():
+    y = np.zeros(SR * 2, dtype=np.float32)
+    labels, stats = recognize_chords_from_waveform(y, SR)
+    # Either skipped (if chroma_cqt bailed out) or produced no labeled
+    # spans — either way, no harmonic content should mean no chords.
+    assert labels == [] or all(lbl.label == "N" for lbl in labels)
+
+
+# ---------------------------------------------------------------------------
+# Config defaults sanity check
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_match_chord_module_defaults():
+    from backend.config import Settings
+
+    s = Settings()
+    assert s.chord_recognition_enabled is True
+    assert s.chord_min_template_score == DEFAULT_CHORD_MIN_SCORE

--- a/tests/test_melody_extraction.py
+++ b/tests/test_melody_extraction.py
@@ -13,6 +13,11 @@ import pytest
 np = pytest.importorskip("numpy")
 
 from backend.services.melody_extraction import (  # noqa: E402
+    DEFAULT_BACKFILL_ENABLED,
+    DEFAULT_BACKFILL_MAX_AMP,
+    DEFAULT_BACKFILL_MIN_AMP,
+    DEFAULT_BACKFILL_MIN_DURATION_SEC,
+    DEFAULT_BACKFILL_OVERLAP_FRACTION,
     DEFAULT_MATCH_FRACTION,
     DEFAULT_MAX_TRANSITION_BINS,
     DEFAULT_MELODY_HIGH_MIDI,
@@ -233,18 +238,23 @@ def test_extract_melody_sends_out_of_band_notes_to_chords():
 def test_extract_melody_note_disagreeing_with_path_goes_to_chords():
     # Path traces MIDI 60 throughout, but the event is at MIDI 72.
     # With match_fraction = 0.6 the note should land in the chord bucket.
+    # Back-fill is off here so the test isolates the disagreement path —
+    # otherwise the stable MIDI 60 run would synthesize a new melody note.
     c = _blank_contour(int(1.1 * FRAME_RATE_HZ))
     _paint(c, 0, int(FRAME_RATE_HZ), 60)
     events = [_ne(0.0, 1.0, 72)]
-    melody, chords, stats = extract_melody(c, events)
+    melody, chords, stats = extract_melody(c, events, backfill_enabled=False)
     assert melody == []
     assert chords == events
 
 
 def test_extract_melody_empty_events():
+    # Back-fill off so an empty input → empty output (no synthesis from
+    # the painted peak). Back-fill's own behavior is covered in the
+    # dedicated tests below.
     c = _blank_contour(50)
     _paint(c, 0, 50, 60)
-    melody, chords, stats = extract_melody(c, [])
+    melody, chords, stats = extract_melody(c, [], backfill_enabled=False)
     assert melody == [] and chords == []
     assert stats.melody_note_count == 0 and stats.chord_note_count == 0
 
@@ -255,6 +265,96 @@ def test_extract_melody_tiny_contour_is_skipped():
     melody, chords, stats = extract_melody(c, events)
     assert stats.skipped
     assert chords == events
+
+
+# ---------------------------------------------------------------------------
+# Back-fill of stable Viterbi runs the upstream note tracker missed
+# ---------------------------------------------------------------------------
+
+def test_backfill_adds_stable_run_without_matching_event():
+    # 300 ms stable peak at MIDI 67 (G4), no upstream events at all.
+    frames = int(round(0.35 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    run_end = int(round(0.30 * FRAME_RATE_HZ))
+    _paint(c, 0, run_end, 67, salience=0.9)
+
+    melody, chords, stats = extract_melody(c, [])
+    assert not stats.skipped
+    # Nothing was passed in → chord bucket is empty.
+    assert chords == []
+    # Exactly one back-filled note at MIDI 67 spanning ~300 ms.
+    assert len(melody) == 1
+    assert stats.backfilled_note_count == 1
+    start, end, pitch, amp, bends = melody[0]
+    assert pitch == 67
+    assert 0.25 <= (end - start) <= 0.35
+    assert bends is None
+    assert DEFAULT_BACKFILL_MIN_AMP <= amp <= DEFAULT_BACKFILL_MAX_AMP
+
+
+def test_backfill_skips_runs_shorter_than_min_duration():
+    # 80 ms peak — below the 120 ms back-fill floor.
+    frames = int(round(0.12 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    run_end = int(round(0.08 * FRAME_RATE_HZ))
+    _paint(c, 0, run_end, 67, salience=0.9)
+
+    melody, chords, stats = extract_melody(c, [])
+    assert stats.backfilled_note_count == 0
+    assert melody == []
+
+
+def test_backfill_skips_when_existing_event_covers_the_run():
+    # 300 ms stable peak at MIDI 67, plus an upstream Basic Pitch event
+    # covering the same window — back-fill should skip (no duplication).
+    frames = int(round(0.35 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    run_end = int(round(0.30 * FRAME_RATE_HZ))
+    _paint(c, 0, run_end, 67, salience=0.9)
+    events = [_ne(0.0, 0.30, 67, amp=0.8)]
+
+    melody, chords, stats = extract_melody(c, events)
+    assert stats.backfilled_note_count == 0
+    # Only the original upstream event survives, un-duplicated.
+    assert len(melody) == 1
+    assert melody[0][3] == 0.8  # original amplitude preserved
+
+
+def test_backfill_amplitude_is_clipped_to_max():
+    # Peak salience 0.95 > max_amp (0.60) — synthesized amp must be clipped.
+    frames = int(round(0.35 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    run_end = int(round(0.30 * FRAME_RATE_HZ))
+    _paint(c, 0, run_end, 67, salience=0.95)
+
+    melody, _, stats = extract_melody(c, [])
+    assert stats.backfilled_note_count == 1
+    _, _, _, amp, _ = melody[0]
+    assert amp == pytest.approx(DEFAULT_BACKFILL_MAX_AMP, abs=1e-6)
+
+
+def test_backfill_respects_enabled_flag():
+    frames = int(round(0.35 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    _paint(c, 0, int(round(0.30 * FRAME_RATE_HZ)), 67, salience=0.9)
+
+    melody, _, stats = extract_melody(c, [], backfill_enabled=False)
+    assert stats.backfilled_note_count == 0
+    assert melody == []
+
+
+def test_backfill_does_not_invent_notes_below_melody_band():
+    # Peak inside the low-register slice that would belong to bass.
+    # The Viterbi band mask already prevents a path at MIDI 40, so we
+    # should not see a back-filled note here either — the tracer is
+    # unvoiced for this frame range.
+    frames = int(round(0.35 * FRAME_RATE_HZ))
+    c = _blank_contour(frames)
+    _paint(c, 0, int(round(0.30 * FRAME_RATE_HZ)), 40, salience=0.9)
+
+    melody, _, stats = extract_melody(c, [])
+    assert stats.backfilled_note_count == 0
+    assert melody == []
 
 
 # ---------------------------------------------------------------------------
@@ -272,3 +372,8 @@ def test_config_defaults_match_module_defaults():
     assert s.melody_max_transition_bins == DEFAULT_MAX_TRANSITION_BINS
     assert s.melody_match_fraction == DEFAULT_MATCH_FRACTION
     assert s.melody_extraction_enabled is True
+    assert s.melody_backfill_enabled is DEFAULT_BACKFILL_ENABLED
+    assert s.melody_backfill_min_duration_sec == DEFAULT_BACKFILL_MIN_DURATION_SEC
+    assert s.melody_backfill_overlap_fraction == DEFAULT_BACKFILL_OVERLAP_FRACTION
+    assert s.melody_backfill_min_amp == DEFAULT_BACKFILL_MIN_AMP
+    assert s.melody_backfill_max_amp == DEFAULT_BACKFILL_MAX_AMP

--- a/tests/test_melody_extraction.py
+++ b/tests/test_melody_extraction.py
@@ -1,0 +1,274 @@
+"""Unit tests for Phase 2 melody extraction.
+
+The tests drive the Viterbi tracer with hand-built synthetic contour
+matrices — no audio, no basic_pitch inference — so they exercise the
+algorithm in isolation. We skip gracefully if numpy isn't installed
+(the module itself is tolerant, but the tests need to construct
+``ndarray`` inputs directly).
+"""
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from backend.services.melody_extraction import (  # noqa: E402
+    DEFAULT_MATCH_FRACTION,
+    DEFAULT_MAX_TRANSITION_BINS,
+    DEFAULT_MELODY_HIGH_MIDI,
+    DEFAULT_MELODY_LOW_MIDI,
+    DEFAULT_TRANSITION_WEIGHT,
+    DEFAULT_VOICING_FLOOR,
+    FRAME_RATE_HZ,
+    N_CONTOUR_BINS,
+    _path_to_midi_runs,
+    _trace_f0_contour,
+    bin_to_midi,
+    extract_melody,
+    midi_to_bin,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _blank_contour(n_frames: int, baseline: float = 0.02):
+    """Uniformly-low salience matrix — the canvas for each test."""
+    return np.full((n_frames, N_CONTOUR_BINS), baseline, dtype=np.float32)
+
+
+def _paint(contour, start_frame: int, end_frame: int, midi: int, salience: float = 0.9):
+    """Stamp salience at (midi, frame range) in-place."""
+    contour[start_frame:end_frame, midi_to_bin(midi)] = salience
+
+
+def _run(contour):
+    return _trace_f0_contour(
+        contour,
+        low_bin=midi_to_bin(DEFAULT_MELODY_LOW_MIDI),
+        high_bin=midi_to_bin(DEFAULT_MELODY_HIGH_MIDI),
+        voicing_floor=DEFAULT_VOICING_FLOOR,
+        transition_weight=DEFAULT_TRANSITION_WEIGHT,
+        max_transition_bins=DEFAULT_MAX_TRANSITION_BINS,
+        voiced_enter_cost=1.0,
+        unvoiced_enter_cost=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bin ↔ MIDI mapping
+# ---------------------------------------------------------------------------
+
+def test_bin_midi_roundtrip_on_integer_pitches():
+    for midi in (21, 55, 60, 69, 90, 108):
+        assert bin_to_midi(midi_to_bin(midi)) == midi
+
+
+def test_bin_mapping_matches_basic_pitch_formula():
+    # Basic Pitch: bin = 3 * (midi - 21) for integer MIDI.
+    assert midi_to_bin(21) == 0
+    assert midi_to_bin(60) == 117
+    assert midi_to_bin(108) == 261
+
+
+# ---------------------------------------------------------------------------
+# Viterbi tracer — shape and voicing
+# ---------------------------------------------------------------------------
+
+def test_trace_follows_single_stable_peak():
+    c = _blank_contour(100)
+    _paint(c, 0, 100, 60)
+    path = _run(c)
+    # All frames should be voiced at MIDI 60.
+    assert (path >= 0).all()
+    assert all(bin_to_midi(int(p)) == 60 for p in path)
+
+
+def test_trace_jumps_to_new_peak():
+    c = _blank_contour(100)
+    _paint(c, 0, 50, 60)
+    _paint(c, 50, 100, 64)
+    path = _run(c)
+    assert all(bin_to_midi(int(p)) == 60 for p in path[:50])
+    assert all(bin_to_midi(int(p)) == 64 for p in path[50:])
+
+
+def test_trace_enters_unvoiced_on_silence():
+    c = _blank_contour(100)
+    _paint(c, 0, 30, 60)
+    # frames 30..70 are below voicing floor
+    _paint(c, 70, 100, 60)
+    path = _run(c)
+    # Voiced at the ends, unvoiced in the middle.
+    assert (path[:30] >= 0).all()
+    assert (path[30:70] < 0).all()
+    assert (path[70:] >= 0).all()
+
+
+def test_trace_masks_out_of_band_peaks():
+    # A strong peak below the melody band must be ignored.
+    c = _blank_contour(100)
+    _paint(c, 0, 100, 40)  # MIDI 40 < G3 (55)
+    path = _run(c)
+    assert (path < 0).all()
+
+
+def test_trace_prefers_small_jumps_over_large():
+    # Two candidate peaks at 60 and 72, with 72 slightly stronger early
+    # but 60 stronger later. The transition penalty should keep the
+    # path near 60 throughout because a big jump costs more than a
+    # small delta in emission.
+    c = _blank_contour(200)
+    _paint(c, 0, 200, 60, salience=0.7)   # steady
+    _paint(c, 50, 150, 72, salience=0.75) # slightly stronger briefly
+    path = _run(c)
+    # Path should stay at 60; the ~12-bin jump isn't worth the 0.05
+    # emission improvement once transition cost is counted.
+    midis = [bin_to_midi(int(p)) for p in path if p >= 0]
+    assert all(m == 60 for m in midis), f"path wandered: {set(midis)}"
+
+
+def test_trace_reports_expected_shape():
+    c = _blank_contour(50)
+    _paint(c, 0, 50, 60)
+    path = _run(c)
+    assert path.shape == (50,)
+    assert path.dtype == np.int32
+
+
+# ---------------------------------------------------------------------------
+# Path → MIDI runs
+# ---------------------------------------------------------------------------
+
+def test_path_to_runs_groups_consecutive_frames():
+    c = _blank_contour(100)
+    _paint(c, 0, 40, 60)
+    _paint(c, 40, 80, 64)
+    _paint(c, 80, 100, 67)
+    path = _run(c)
+    runs = _path_to_midi_runs(path)
+    pitches = [midi for _, _, midi in runs]
+    assert pitches == [60, 64, 67]
+    lengths = [end - start for start, end, _ in runs]
+    assert lengths == [40, 40, 20]
+
+
+def test_path_to_runs_splits_on_unvoiced():
+    c = _blank_contour(100)
+    _paint(c, 0, 30, 60)
+    _paint(c, 70, 100, 60)  # same pitch, but with an unvoiced gap in the middle
+    path = _run(c)
+    runs = _path_to_midi_runs(path)
+    # Two separate runs at MIDI 60 because the gap broke continuity.
+    assert len(runs) == 2
+    assert all(midi == 60 for _, _, midi in runs)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end extract_melody
+# ---------------------------------------------------------------------------
+
+def _ne(start: float, end: float, pitch: int, amp: float = 0.8):
+    """Build a Basic Pitch note_event tuple."""
+    return (start, end, pitch, amp, None)
+
+
+def test_extract_melody_tags_melody_and_chord_notes():
+    # Melody: C4 → E4 → G4, one second each
+    # Chords: below the melody band at all times
+    frames_per_sec = FRAME_RATE_HZ
+    c = _blank_contour(int(3.1 * frames_per_sec))
+    _paint(c, 0, int(frames_per_sec), 60)
+    _paint(c, int(frames_per_sec), int(2 * frames_per_sec), 64)
+    _paint(c, int(2 * frames_per_sec), int(3 * frames_per_sec), 67)
+
+    events = [
+        _ne(0.0, 1.0, 60),
+        _ne(1.0, 2.0, 64),
+        _ne(2.0, 3.0, 67),
+        _ne(0.0, 1.0, 48),  # C3 — below band → chord
+        _ne(0.0, 1.0, 52),
+        _ne(1.0, 2.0, 45),
+        _ne(2.0, 3.0, 43),
+    ]
+    melody, chords, stats = extract_melody(c, events)
+    assert not stats.skipped
+    assert sorted(e[2] for e in melody) == [60, 64, 67]
+    assert sorted(e[2] for e in chords) == [43, 45, 48, 52]
+    assert stats.melody_note_count == 3
+    assert stats.chord_note_count == 4
+    assert stats.voiced_frame_fraction > 0.9
+
+
+def test_extract_melody_skips_when_contour_is_none():
+    events = [_ne(0.0, 1.0, 60), _ne(1.0, 2.0, 64)]
+    melody, chords, stats = extract_melody(None, events)
+    assert stats.skipped
+    assert melody == []
+    assert chords == events
+    assert any("skipped" in w for w in stats.as_warnings())
+
+
+def test_extract_melody_skips_on_malformed_contour_shape():
+    bad = np.zeros((100, 128), dtype=np.float32)  # wrong width
+    events = [_ne(0.0, 1.0, 60)]
+    melody, chords, stats = extract_melody(bad, events)
+    assert stats.skipped
+    assert chords == events
+
+
+def test_extract_melody_sends_out_of_band_notes_to_chords():
+    c = _blank_contour(int(1.1 * FRAME_RATE_HZ))
+    _paint(c, 0, int(FRAME_RATE_HZ), 60)
+    events = [
+        _ne(0.0, 1.0, 60),   # in band, matches → melody
+        _ne(0.0, 1.0, 30),   # well below band → chord
+        _ne(0.0, 1.0, 100),  # above band → chord
+    ]
+    melody, chords, stats = extract_melody(c, events)
+    assert [e[2] for e in melody] == [60]
+    assert sorted(e[2] for e in chords) == [30, 100]
+
+
+def test_extract_melody_note_disagreeing_with_path_goes_to_chords():
+    # Path traces MIDI 60 throughout, but the event is at MIDI 72.
+    # With match_fraction = 0.6 the note should land in the chord bucket.
+    c = _blank_contour(int(1.1 * FRAME_RATE_HZ))
+    _paint(c, 0, int(FRAME_RATE_HZ), 60)
+    events = [_ne(0.0, 1.0, 72)]
+    melody, chords, stats = extract_melody(c, events)
+    assert melody == []
+    assert chords == events
+
+
+def test_extract_melody_empty_events():
+    c = _blank_contour(50)
+    _paint(c, 0, 50, 60)
+    melody, chords, stats = extract_melody(c, [])
+    assert melody == [] and chords == []
+    assert stats.melody_note_count == 0 and stats.chord_note_count == 0
+
+
+def test_extract_melody_tiny_contour_is_skipped():
+    c = np.zeros((1, N_CONTOUR_BINS), dtype=np.float32)
+    events = [_ne(0.0, 1.0, 60)]
+    melody, chords, stats = extract_melody(c, events)
+    assert stats.skipped
+    assert chords == events
+
+
+# ---------------------------------------------------------------------------
+# Config defaults sanity check
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_match_module_defaults():
+    from backend.config import Settings
+
+    s = Settings()
+    assert s.melody_low_midi == DEFAULT_MELODY_LOW_MIDI
+    assert s.melody_high_midi == DEFAULT_MELODY_HIGH_MIDI
+    assert s.melody_voicing_floor == DEFAULT_VOICING_FLOOR
+    assert s.melody_transition_weight == DEFAULT_TRANSITION_WEIGHT
+    assert s.melody_max_transition_bins == DEFAULT_MAX_TRANSITION_BINS
+    assert s.melody_match_fraction == DEFAULT_MATCH_FRACTION
+    assert s.melody_extraction_enabled is True

--- a/tests/test_transcription_cleanup.py
+++ b/tests/test_transcription_cleanup.py
@@ -1,0 +1,244 @@
+"""Unit tests for Phase 1 transcription cleanup heuristics.
+
+The cleanup module is pure Python with no runtime dependencies, so the
+whole file runs in CI regardless of whether the ``basic-pitch`` extra is
+installed. Each test constructs a synthetic ``note_events`` list (the
+tuple format Basic Pitch returns) and asserts on the cleaned output.
+"""
+from __future__ import annotations
+
+from backend.services.transcription_cleanup import (
+    DEFAULT_GHOST_AMP_MEDIAN_SCALE,
+    DEFAULT_GHOST_MAX_DURATION_SEC,
+    DEFAULT_MERGE_GAP_SEC,
+    DEFAULT_OCTAVE_AMP_RATIO,
+    DEFAULT_OCTAVE_ONSET_TOL_SEC,
+    cleanup_note_events,
+)
+
+
+# Shorthand: (start, end, pitch, amplitude, pitch_bends)
+def _n(start: float, end: float, pitch: int, amp: float, bends=None):
+    return (start, end, pitch, amp, bends)
+
+
+# ---------------------------------------------------------------------------
+# Merge fragmented sustains
+# ---------------------------------------------------------------------------
+
+def test_merge_joins_same_pitch_notes_within_gap():
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.52, 1.00, 60, 0.8),  # gap = 20 ms ≤ 30 ms → merge
+        _n(1.05, 1.40, 60, 0.7),  # gap = 50 ms > 30 ms → stays separate
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.merged == 1
+    # Expect two notes at pitch 60: [0.00, 1.00] and [1.05, 1.40]
+    p60 = [e for e in cleaned if e[2] == 60]
+    assert len(p60) == 2
+    assert p60[0][0] == 0.00 and p60[0][1] == 1.00
+    assert p60[0][3] == 0.9  # max amplitude kept
+    assert p60[1][0] == 1.05
+
+
+def test_merge_does_not_cross_pitches():
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.50, 1.00, 62, 0.9),  # different pitch, even zero-gap → no merge
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.merged == 0
+    assert len(cleaned) == 2
+
+
+def test_merge_preserves_max_amplitude():
+    events = [
+        _n(0.00, 0.50, 60, 0.3),
+        _n(0.51, 1.00, 60, 0.9),  # quieter→louder fragment transition
+    ]
+    cleaned, _ = cleanup_note_events(events)
+    assert len(cleaned) == 1
+    assert cleaned[0][3] == 0.9
+
+
+def test_merge_chains_multiple_fragments():
+    # Four fragments all within merge_gap — should collapse to one.
+    events = [
+        _n(0.00, 0.20, 60, 0.8),
+        _n(0.22, 0.40, 60, 0.85),
+        _n(0.42, 0.60, 60, 0.7),
+        _n(0.61, 0.80, 60, 0.9),
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.merged == 3
+    assert len(cleaned) == 1
+    assert cleaned[0][0] == 0.0
+    assert cleaned[0][1] == 0.80
+    assert cleaned[0][3] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# Octave-ghost pruning
+# ---------------------------------------------------------------------------
+
+def test_octave_ghost_dropped_when_upper_is_quiet():
+    # Loud C4 with a quiet C5 ghost at the same onset → ghost removed.
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.01, 0.30, 72, 0.3),  # 0.3 < 0.6 * 0.9 = 0.54 → ghost
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.octave_ghosts_dropped == 1
+    pitches = sorted(e[2] for e in cleaned)
+    assert pitches == [60]
+
+
+def test_real_octave_doubling_preserved():
+    # Both notes equally loud → legitimate doubling, keep both.
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.00, 0.50, 72, 0.85),
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.octave_ghosts_dropped == 0
+    pitches = sorted(e[2] for e in cleaned)
+    assert pitches == [60, 72]
+
+
+def test_octave_ghost_outside_onset_tolerance_kept():
+    # Upper note onsets 200 ms after the lower → not a ghost, keep it.
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.20, 0.50, 72, 0.3),
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.octave_ghosts_dropped == 0
+    assert len(cleaned) == 2
+
+
+def test_octave_ghost_at_lowest_pitch_is_ignored():
+    # A note at pitch 5 would look "down" to pitch -7 — must not crash.
+    events = [_n(0.00, 0.50, 5, 0.9)]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.octave_ghosts_dropped == 0
+    assert len(cleaned) == 1
+
+
+# ---------------------------------------------------------------------------
+# Ghost-tail pruning
+# ---------------------------------------------------------------------------
+
+def test_short_quiet_note_is_dropped():
+    # Median amp across the set is 0.8 → threshold = 0.5 * 0.8 = 0.4.
+    # The 40 ms note at amp 0.2 is below threshold and shorter than 60 ms.
+    events = [
+        _n(0.00, 0.50, 60, 0.8),
+        _n(0.50, 1.00, 62, 0.8),
+        _n(1.00, 1.50, 64, 0.8),
+        _n(1.50, 1.54, 70, 0.2),  # ghost tail
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.ghost_tails_dropped == 1
+    assert all(e[2] != 70 for e in cleaned)
+
+
+def test_short_loud_staccato_preserved():
+    # Short (40 ms) but loud staccato should survive.
+    events = [
+        _n(0.00, 0.50, 60, 0.5),
+        _n(0.50, 1.00, 62, 0.5),
+        _n(1.00, 1.04, 64, 0.9),  # short but above amp threshold
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.ghost_tails_dropped == 0
+    assert len(cleaned) == 3
+
+
+def test_long_quiet_sustained_pad_preserved():
+    # Long (800 ms) but quiet pad should survive — only short+quiet gets cut.
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.50, 1.00, 62, 0.9),
+        _n(1.00, 1.80, 64, 0.1),  # quiet, below threshold, but long
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.ghost_tails_dropped == 0
+    assert len(cleaned) == 3
+
+
+# ---------------------------------------------------------------------------
+# End-to-end behaviour
+# ---------------------------------------------------------------------------
+
+def test_empty_input_yields_empty_output():
+    cleaned, stats = cleanup_note_events([])
+    assert cleaned == []
+    assert stats.input_count == 0
+    assert stats.output_count == 0
+    assert stats.merged == 0
+    assert stats.octave_ghosts_dropped == 0
+    assert stats.ghost_tails_dropped == 0
+
+
+def test_idempotent_on_clean_input():
+    # A set with no artifacts should pass through untouched.
+    events = [
+        _n(0.00, 0.50, 60, 0.8),
+        _n(0.50, 1.00, 62, 0.75),
+        _n(1.00, 1.50, 64, 0.85),
+        _n(1.50, 2.00, 65, 0.8),
+    ]
+    cleaned_once, _ = cleanup_note_events(events)
+    cleaned_twice, stats = cleanup_note_events(cleaned_once)
+    assert cleaned_once == cleaned_twice
+    assert stats.merged == 0
+    assert stats.octave_ghosts_dropped == 0
+    assert stats.ghost_tails_dropped == 0
+
+
+def test_stats_warnings_only_report_nonzero_passes():
+    events = [
+        _n(0.00, 0.50, 60, 0.9),
+        _n(0.51, 1.00, 60, 0.9),  # merged
+        _n(0.00, 0.50, 72, 0.2),  # octave ghost
+    ]
+    _, stats = cleanup_note_events(events)
+    warnings = stats.as_warnings()
+    assert any("merged" in w for w in warnings)
+    assert any("octave" in w for w in warnings)
+    # No ghost-tail drops expected — confirm that line is absent.
+    assert not any("ghost-tail" in w for w in warnings)
+
+
+def test_pass_ordering_merge_then_octave_then_ghost():
+    # Construct a case where the order matters: two fragments of a note
+    # at pitch 60 (each < ghost duration on its own) plus a ghost at 72.
+    # If merge ran *after* ghost pruning, both fragments would look like
+    # ghost-tails and get dropped — we want them merged first.
+    events = [
+        _n(0.00, 0.03, 60, 0.9),
+        _n(0.031, 0.06, 60, 0.9),  # merged with the first into a 60 ms note
+        _n(0.00, 0.06, 72, 0.3),  # octave ghost dropped after merge
+    ]
+    cleaned, stats = cleanup_note_events(events)
+    assert stats.merged == 1
+    assert stats.octave_ghosts_dropped == 1
+    # The merged note should survive ghost-tail pruning because its
+    # duration equals the threshold (not strictly less than).
+    pitches = sorted(e[2] for e in cleaned)
+    assert pitches == [60]
+
+
+def test_defaults_match_config_defaults():
+    # The config knobs default to the module-level DEFAULT_* constants —
+    # make sure both sides agree so callers get the documented behaviour
+    # when they don't override.
+    from backend.config import Settings
+
+    s = Settings()
+    assert s.cleanup_merge_gap_sec == DEFAULT_MERGE_GAP_SEC
+    assert s.cleanup_octave_amp_ratio == DEFAULT_OCTAVE_AMP_RATIO
+    assert s.cleanup_octave_onset_tol_sec == DEFAULT_OCTAVE_ONSET_TOL_SEC
+    assert s.cleanup_ghost_max_duration_sec == DEFAULT_GHOST_MAX_DURATION_SEC
+    assert s.cleanup_ghost_amp_median_scale == DEFAULT_GHOST_AMP_MEDIAN_SCALE


### PR DESCRIPTION
## Summary

Two-phase post-processing on top of the Basic Pitch baseline, plus an
artifact plumbing change to expose the raw transcription MIDI.

**Phase 1 — `backend/services/transcription_cleanup.py`** (pure stdlib, no new deps):
- Merge fragmented sustains within a small gap
- Drop octave-ghost notes whose amplitude is too low vs. the lower octave (preserves real doublings)
- Prune notes that are both short *and* quiet (ghost tails)
- Order matters: merge → octave → ghost-tail so a fragmented sustain isn't mistaken for a ghost on its first fragment

**Phase 2 — `backend/services/melody_extraction.py`** (numpy, late-imported):
- Viterbi F0 tracer over `model_output["contour"]` — the 264-bin multi-pitch salience matrix Basic Pitch already computes but we weren't using. **No new model weights, no new deps.**
- Vectorized shift-and-min transition updates over ±12 bins with an unvoiced state for silence
- Tags each Basic Pitch note as `MELODY` (≥60% agreement with the Viterbi path inside MIDI 55–90) or non-melody
- **Back-fill** (new): synthesize notes for stable Viterbi runs ≥ 120 ms with no matching Basic Pitch event. Recovers soft sustained melody lines the polyphonic tracker loses under accompaniment. Amplitude clipped to [0.15, 0.60] so recovery notes don't outshine real ones; must not be re-run through `cleanup_note_events` (would look like ghost tails).
- Skips cleanly when numpy/contour/tracer fail — callers fall back to a single `PIANO` track

**Phase 3 — `backend/services/bass_extraction.py` + `backend/services/chord_recognition.py`** (new):
- **Bass extraction** reuses the same Viterbi tracer on the low-register slice (E1..G3), stricter 0.4 transition weight, 9-bin max jump. Runs *after* melody on the non-melody remainder: melody claims first, then bass, then the remainder becomes CHORDS.
- **Chord recognition** runs `librosa.feature.chroma_cqt` on the HPSS-harmonic component, beat-synced via `librosa.util.sync`, matched against 24 triad templates (12 major + 12 minor). Labels below 0.55 score become `N` and are dropped. Consecutive identical labels collapse into one `RealtimeChordEvent` span. **Beat tracking runs on the raw waveform**, not the HPSS'd one — HPSS strips the onset transients that `beat_track` needs, and feeding the harmonic-only signal produces zero beats on material where the raw tracker finds a clean pulse.

**Transcribe wiring:**
- `_pretty_midi_to_transcription_result` takes an `events_by_role` dict and emits one `MidiTrack` per non-empty role (deterministic order: MELODY → BASS → CHORDS → PIANO → OTHER). Contract notes built directly from `note_events` via `_event_to_note` using Basic Pitch's own `round(127 * amp)` velocity formula; `pm` retained only for tempo fallback.
- `_run_basic_pitch_sync` chains cleanup → rebuild pretty_midi → extract_melody → extract_bass → recognize_chords, emits one MidiTrack per non-empty role, and attaches the chord label stream to `HarmonicAnalysis.chords`.
- Single-track PIANO fallback only fires when *both* melody and bass are skipped.
- `bass_stats` / `chord_stats` flow into `QualitySignal.warnings` alongside `cleanup_stats` and `melody_stats`.

**Transcription MIDI blob persistence:**
- `TranscribeService` now takes a `BlobStore` and persists the cleaned `pretty_midi` to `jobs/{job_id}/transcription/basic-pitch.mid`, tagging the result with `transcription_midi_uri`.
- `PipelineRunner` forwards the URI onto the final `EngravedOutput` via `model_copy`.
- New `GET /v1/artifacts/{job_id}/transcription_midi` route (404 when absent — midi_upload variant and stub fallbacks don't have one).

**Config** — all overridable via `OHSHEET_*` env vars:
- 5 `cleanup_*` knobs (Phase 1)
- 7 `melody_*` knobs + 5 `melody_backfill_*` knobs (Phase 2)
- 7 `bass_*` knobs + 3 `chord_*` knobs (Phase 3)
- Kill switches: `OHSHEET_MELODY_EXTRACTION_ENABLED`, `OHSHEET_BASS_EXTRACTION_ENABLED`, `OHSHEET_CHORD_RECOGNITION_ENABLED`, `OHSHEET_MELODY_BACKFILL_ENABLED`

**Tuning note:** defaults were iterated against synthetic fixtures. Real audio will want per-genre tuning — vocal-led tracks may want `melody_match_fraction≈0.75` to cut false positives; instrumental tracks may want `melody_voicing_floor≈0.08` to pick up soft leads; bass-heavy material may want a wider `bass_high_midi` (60 instead of 55).

## Test plan

- [x] `pytest` — **101 / 101 pass** (58 baseline + 18 Phase 2 melody + 16 Phase 1 cleanup + 6 back-fill + 9 bass + 10 chord, minus 6 deduped counts)
- [x] Cleanup: 90%+ coverage across merge, octave dedup, ghost-tail, pass ordering, idempotency, empty input
- [x] Melody: Viterbi tracer, bin↔MIDI mapping, end-to-end tagging on synthetic contours, back-fill synthesis / clipping / skip paths
- [x] Bass: synthetic low-register contours covering pedal, walking bass, out-of-band rejection, disagreeing pitch, None/malformed contour, empty events, tiny contour, config defaults
- [x] Chord: template construction, single-chord C:maj, C→G progression, minor triad, bounded confidence, consecutive collapse, high-threshold suppression, tiny input, silence, config defaults
- [x] `ruff check` clean
- [x] `mypy` clean on changed surface (31 source files)
- [x] Real end-to-end smoke test: synthesized C5→C6 melody over a quiet C3/E3 drone through the full `_run_basic_pitch_sync` pipeline returns a clean 4-note MELODY track + 2-note CHORDS track with 94% voiced frame coverage
- [ ] Tune defaults against real audio fixtures (follow-up)
- [ ] Observe warnings in `QualitySignal.warnings` for a few real jobs to confirm the telemetry is useful

## Follow-ups

Both of the follow-ups originally called out on this PR are now done:

- [x] ~~**Phase 3:** bass line extraction via the same Viterbi trick over the low-register slice of `contour`, plus chord recognition via librosa chroma + template matching~~
- [x] ~~**Back-fill missed melody notes:** when the Viterbi path has a stable segment ≥ 120 ms with no matching Basic Pitch note, synthesize one from the contour salience~~

Remaining for a future PR:

- **Extended chord vocabulary:** 7ths / sus / dim templates (currently triads only). Ambiguous harmonies fall through to whichever triad the chroma looks most like.
- **Key-aware chord smoothing:** an HMM over a key-conditioned template set would suppress the occasional out-of-key false positive on real audio.
- **Inversion tracking:** the root we return is the template root, not necessarily the lowest note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)