### PR TITLE
feat(transcribe): Demucs stem separation + audio preprocessing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PORT         ?= 8000
 
 DART_DEFINE := $(if $(API_BASE_URL),--dart-define=API_BASE_URL=$(API_BASE_URL),)
 
-.PHONY: help install install-backend install-basic-pitch install-frontend backend frontend test test-backend lint typecheck clean
+.PHONY: help install install-backend install-basic-pitch install-demucs install-frontend backend frontend test test-backend lint typecheck clean
 
 help:
 	@echo "Oh Sheet — make targets"
@@ -23,6 +23,7 @@ help:
 	@echo "  make install-backend      pip install -e .[dev]  (API only — TranscribeService"
 	@echo "                            will fall back to a 4-note stub without Basic Pitch)"
 	@echo "  make install-basic-pitch  pip install -e .[basic-pitch]  (basic-pitch[onnx] + pretty_midi)"
+	@echo "  make install-demucs       pip install -e .[demucs]  (demucs + torch; opt-in stem split)"
 	@echo "  make install-frontend     flutter pub get inside frontend/"
 	@echo ""
 	@echo "  make backend            run uvicorn dev server on $(HOST):$(PORT)"
@@ -47,6 +48,13 @@ install-basic-pitch:
 	# --no-deps and rely on [basic-pitch] above for the actual runtime
 	# deps. See pyproject.toml comment for details.
 	pip install --no-deps "basic-pitch>=0.4"
+
+install-demucs:
+	# Optional stem-separation stack (demucs + torch). Off by default;
+	# flip on via OHSHEET_DEMUCS_ENABLED=1. The htdemucs pretrained
+	# weights are CC BY-NC 4.0 — see pyproject.toml for the commercial
+	# caveat before enabling in production.
+	pip install -e ".[demucs]"
 
 install-frontend:
 	cd $(FRONTEND) && flutter pub get

--- a/backend/config.py
+++ b/backend/config.py
@@ -137,14 +137,31 @@ class Settings(BaseSettings):
     # leaving this on is safe even on boxes where demucs/torch
     # aren't installed.
     #
-    # Caveats operators should know about:
-    #   * Demucs is heavy: ~80 MB weights, 0.2–0.5x real-time on CPU,
-    #     2–3x real-time on Apple MPS, 5–10x on CUDA. Jobs get
-    #     noticeably slower when this is on.
-    #   * The default htdemucs pretrained weights are CC BY-NC 4.0.
-    #     Commercial deployments must either swap in a commercially
-    #     licensed model, train their own, or set
-    #     ``OHSHEET_DEMUCS_ENABLED=0`` to force the single-mix path.
+    # Latency budget operators should know about:
+    #   * Demucs separation itself is heavy: ~80 MB weights,
+    #     0.2–0.5x real-time on CPU, 2–3x real-time on Apple MPS,
+    #     5–10x on CUDA. Pay this once per job.
+    #   * After separation the stems path runs Basic Pitch three
+    #     times — once per stem (vocals/bass/other). The three
+    #     passes run **in parallel** by default (see
+    #     ``demucs_parallel_stems`` below), and since the bulk of
+    #     Basic Pitch's wall time happens in GIL-releasing C
+    #     extensions (ONNX Runtime, librosa, numpy) on a multi-core
+    #     host the three passes overlap down to roughly one Basic
+    #     Pitch pass of wall time. On a single-core host or with
+    #     parallelism disabled, expect ~3x Basic Pitch cost instead.
+    #
+    # Rough wall-clock with the defaults (multi-core + parallel):
+    #     stems path ≈ 1x Demucs + 1x Basic Pitch
+    #     single-mix path ≈ 1x Basic Pitch
+    # So flipping Demucs on costs you approximately one full Demucs
+    # pass in additional wall time — roughly 2–10x the Basic Pitch
+    # cost depending on CPU/GPU.
+    #
+    # The default htdemucs pretrained weights are CC BY-NC 4.0.
+    # Commercial deployments must either swap in a commercially
+    # licensed model, train their own, or set
+    # ``OHSHEET_DEMUCS_ENABLED=0`` to force the single-mix path.
     demucs_enabled: bool = True
     demucs_model: str = "htdemucs"
     demucs_device: str | None = None             # None → auto: cuda → mps → cpu
@@ -152,6 +169,22 @@ class Settings(BaseSettings):
     demucs_shifts: int = 1                       # upstream default; >1 improves SDR
     demucs_overlap: float = 0.25
     demucs_split: bool = True
+
+    # Parallel Basic Pitch inference across stems. When enabled, the
+    # three per-stem passes run concurrently in a ThreadPoolExecutor
+    # sharing the cached ``basic_pitch.inference.Model`` — safe because
+    # the underlying ONNX / CoreML sessions are documented thread-safe
+    # and ``basic_pitch.inference`` has no module-level mutable state.
+    # Disable to reproduce the old serial behavior (useful for
+    # debugging single-thread traces or for hosts where the process
+    # is already CPU-saturated and parallelism would just thrash).
+    demucs_parallel_stems: bool = True
+    # Upper bound on concurrent stem workers. The effective worker
+    # count is ``min(this, active_stem_count)`` — usually 3
+    # (vocals/bass/other). Raising this above 3 has no effect today
+    # but leaves room for future per-stem fan-out (e.g. a secondary
+    # accompaniment pass on the ``other`` stem).
+    demucs_parallel_max_workers: int = 3
 
     # Per-consumer routing. Each flag gates whether the corresponding
     # stem is used; flipping individual switches off is the escape

--- a/backend/config.py
+++ b/backend/config.py
@@ -34,6 +34,36 @@ class Settings(BaseSettings):
     basic_pitch_frame_threshold: float = 0.3
     basic_pitch_minimum_note_length_ms: float = 127.7
 
+    # ---- Audio pre-processing (runs before Basic Pitch) --------------------
+    # HPSS + RMS normalization applied to the waveform before inference.
+    # See backend/services/audio_preprocess.py for semantics; the defaults
+    # here mirror the DEFAULT_* constants in that module.
+    #
+    # Enabled=False by default. The measurement run against
+    # assets/rising-sun-{1,2,3}.mp3 (scripts/bench_preprocess.py) showed:
+    #   * Note counts shift by at most ±10% with preprocessing on — the
+    #     cleanup_* and basic_pitch_*_threshold defaults above are robust
+    #     to preprocessing and do NOT need a preprocessing-aware profile.
+    #   * Cleanup's merge-fragmented-sustains pass drops ~25% of its
+    #     workload because HPSS heals most frame-level activation dips
+    #     at the source. A welcome side-effect, not a retune driver.
+    #   * Octave-ghost counts stay flat (2→1, 3→3, 1→0) — the
+    #     octave_amp_ratio threshold is ratio-based and self-corrects.
+    #   * Overall confidence improves by +0.00 to +0.04 on the three
+    #     fixtures. Real but marginal.
+    #   * Cost: ~1.3–1.5s of extra wall time per inference for HPSS +
+    #     normalize + tempfile write.
+    # The three fixtures are correlated (same piece, three takes) so the
+    # evidence is not strong enough to flip the default globally. Users
+    # with drum-heavy or dynamic-range-varied material can opt in via
+    # OHSHEET_AUDIO_PREPROCESS_ENABLED=1 without touching any other knob.
+    audio_preprocess_enabled: bool = False
+    audio_preprocess_hpss_enabled: bool = True
+    audio_preprocess_hpss_margin: float = 1.0        # librosa default — gentle
+    audio_preprocess_normalize_enabled: bool = True
+    audio_preprocess_target_rms_dbfs: float = -20.0
+    audio_preprocess_peak_ceiling_dbfs: float = -1.0
+
     # ---- Transcription cleanup (Phase 1 post-processing) -------------------
     # Heuristic thresholds applied to Basic Pitch's note_events before we
     # rebuild pretty_midi. See backend/services/transcription_cleanup.py for
@@ -88,6 +118,50 @@ class Settings(BaseSettings):
     chord_recognition_enabled: bool = True
     chord_min_template_score: float = 0.55
     chord_hpss_margin: float = 3.0               # librosa.effects.harmonic margin
+
+    # ---- Demucs source separation (pre-Basic Pitch) -----------------------
+    # When enabled, the transcribe stage runs Demucs over the source
+    # waveform to split it into {drums, bass, other, vocals} and routes
+    # each stem to a dedicated downstream consumer:
+    #   * vocals  → Basic Pitch → MELODY events
+    #   * bass    → Basic Pitch → BASS events
+    #   * other   → Basic Pitch → CHORDS events (+ chord recognition)
+    #   * drums   → tempo_map beat tracking
+    # See backend/services/stem_separation.py for the semantics; the
+    # defaults here mirror the DEFAULT_* constants in that module.
+    #
+    # Enabled by default — the stems path is the preferred pipeline
+    # whenever the demucs extra is installed. Any failure (missing
+    # dep, load crash, apply OOM, all-stems-empty, ...) falls back
+    # transparently to the original single-mix Basic Pitch path, so
+    # leaving this on is safe even on boxes where demucs/torch
+    # aren't installed.
+    #
+    # Caveats operators should know about:
+    #   * Demucs is heavy: ~80 MB weights, 0.2–0.5x real-time on CPU,
+    #     2–3x real-time on Apple MPS, 5–10x on CUDA. Jobs get
+    #     noticeably slower when this is on.
+    #   * The default htdemucs pretrained weights are CC BY-NC 4.0.
+    #     Commercial deployments must either swap in a commercially
+    #     licensed model, train their own, or set
+    #     ``OHSHEET_DEMUCS_ENABLED=0`` to force the single-mix path.
+    demucs_enabled: bool = True
+    demucs_model: str = "htdemucs"
+    demucs_device: str | None = None             # None → auto: cuda → mps → cpu
+    demucs_segment_sec: float | None = None      # None → model's own default
+    demucs_shifts: int = 1                       # upstream default; >1 improves SDR
+    demucs_overlap: float = 0.25
+    demucs_split: bool = True
+
+    # Per-consumer routing. Each flag gates whether the corresponding
+    # stem is used; flipping individual switches off is the escape
+    # hatch when one stem turns out to be unreliable on a given corpus
+    # (e.g. Demucs drums on a cappella material is noisy — disable
+    # beats-from-drums and let audio_timing fall back to the mix).
+    demucs_use_vocals_for_melody: bool = True
+    demucs_use_bass_stem: bool = True
+    demucs_use_other_for_chords: bool = True     # both notes + chord labels
+    demucs_use_drums_for_beats: bool = True
 
 
 settings = Settings()

--- a/backend/services/audio_preprocess.py
+++ b/backend/services/audio_preprocess.py
@@ -1,0 +1,337 @@
+"""Audio pre-processing stage — HPSS + loudness normalization.
+
+Runs before Basic Pitch inference to hand the pitch tracker a cleaner,
+more consistent waveform:
+
+1. **HPSS harmonic extraction.** ``librosa.effects.harmonic`` strips
+   percussive transients (drums, cymbal hiss, plosive consonants) that
+   the tracker otherwise emits as ghost onsets. This is the same trick
+   :mod:`backend.services.chord_recognition` uses on the waveform
+   before chroma, but with a gentler margin — we still want piano
+   attacks to survive.
+
+2. **RMS loudness normalization with peak ceiling.** Scales the
+   waveform to a target RMS level, clamped so the peak never exceeds
+   ``peak_ceiling_dbfs``. Basic Pitch's ``onset_threshold`` and
+   ``frame_threshold`` are amplitude-sensitive, so un-normalized input
+   makes the thresholds effectively level-dependent: a quiet YouTube
+   rip and a mastered WAV hit them very differently. After
+   normalization the thresholds become properties of the *signal*, not
+   the *gain stage*.
+
+Both passes are independently feature-flagged via :mod:`backend.config`
+and degrade gracefully — any failure (missing librosa, unreadable
+audio, HPSS crash, ...) returns the original ``audio_path`` with
+``stats.skipped = True`` and a descriptive warning, so the caller
+carries on with un-preprocessed audio.
+
+The output is a WAV (32-bit float) written to a tempfile at the
+original sample rate. Basic Pitch will do its own internal resampling
+to 22050 Hz; preserving the native SR here avoids a double-resample.
+The caller owns the returned path and must unlink it when done (only
+when it differs from the input — see ``_run_basic_pitch_sync``).
+
+Note that downstream consumers that need *percussive* information —
+the librosa beat tracker in :mod:`backend.services.audio_timing` and
+:mod:`backend.services.chord_recognition` — must continue reading the
+*original* audio path, not the preprocessed one. HPSS strips the
+transients they lock onto.
+"""
+from __future__ import annotations
+
+import logging
+import math
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults — mirrored in backend/config.py so config and tests agree.
+# ---------------------------------------------------------------------------
+
+# librosa.effects.harmonic default is 1.0 (soft-mask, no bias). We keep
+# the default gentle so piano attacks survive; users with drum-heavy
+# material can crank up via OHSHEET_AUDIO_PREPROCESS_HPSS_MARGIN.
+DEFAULT_HPSS_MARGIN = 1.0
+
+# -20 dBFS RMS ≈ typical broadcast/speech normalization target.
+# Combined with a -1 dBFS peak ceiling this leaves ~19 dB of crest
+# factor headroom, which is enough for piano/rock/pop program material.
+DEFAULT_TARGET_RMS_DBFS = -20.0
+DEFAULT_PEAK_CEILING_DBFS = -1.0
+
+# Below this duration we bail out — HPSS STFT windows and meaningful
+# RMS both need a few hundred ms of audio to be stable.
+DEFAULT_MIN_DURATION_SEC = 0.25
+
+
+@dataclass
+class PreprocessStats:
+    """Per-run summary of what the preprocessor did.
+
+    Structured like the other service stats objects (``CleanupStats``,
+    ``ChordRecognitionStats``) so the transcribe wiring can thread it
+    through to :class:`~backend.contracts.QualitySignal.warnings` the
+    same way.
+    """
+    skipped: bool = False
+    hpss_applied: bool = False
+    normalize_applied: bool = False
+    input_rms_dbfs: float | None = None
+    output_rms_dbfs: float | None = None
+    input_peak_dbfs: float | None = None
+    output_peak_dbfs: float | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def as_warnings(self) -> list[str]:
+        """One-line human summary entries for the QualitySignal."""
+        if self.skipped:
+            if self.warnings:
+                return [f"audio preprocess skipped: {w}" for w in self.warnings]
+            return ["audio preprocess skipped"]
+        out: list[str] = []
+        applied: list[str] = []
+        if self.hpss_applied:
+            applied.append("hpss")
+        if (
+            self.normalize_applied
+            and self.input_rms_dbfs is not None
+            and self.output_rms_dbfs is not None
+            and math.isfinite(self.input_rms_dbfs)
+            and math.isfinite(self.output_rms_dbfs)
+        ):
+            applied.append(
+                f"rms {self.input_rms_dbfs:.1f}→{self.output_rms_dbfs:.1f} dBFS"
+            )
+        elif self.normalize_applied:
+            applied.append("rms normalize")
+        if applied:
+            out.append("audio preprocess: " + ", ".join(applied))
+        out.extend(self.warnings)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Math helpers — numpy-only, late import.
+# ---------------------------------------------------------------------------
+
+def _rms_dbfs(y: Any) -> float:
+    """Compute RMS of a waveform in dBFS. Silent input → ``-inf``."""
+    import numpy as np  # noqa: PLC0415
+
+    rms = float(np.sqrt(np.mean(np.square(y, dtype=np.float64))))
+    if rms <= 0.0:
+        return float("-inf")
+    return 20.0 * math.log10(rms)
+
+
+def _peak_dbfs(y: Any) -> float:
+    """Compute peak level of a waveform in dBFS. Silent input → ``-inf``."""
+    import numpy as np  # noqa: PLC0415
+
+    peak = float(np.max(np.abs(y)))
+    if peak <= 0.0:
+        return float("-inf")
+    return 20.0 * math.log10(peak)
+
+
+# ---------------------------------------------------------------------------
+# In-memory waveform entry point — unit-testable core
+# ---------------------------------------------------------------------------
+
+def preprocess_waveform(
+    y: Any,
+    sr: int,
+    *,
+    hpss_enabled: bool = True,
+    hpss_margin: float = DEFAULT_HPSS_MARGIN,
+    normalize_enabled: bool = True,
+    target_rms_dbfs: float = DEFAULT_TARGET_RMS_DBFS,
+    peak_ceiling_dbfs: float = DEFAULT_PEAK_CEILING_DBFS,
+    min_duration_sec: float = DEFAULT_MIN_DURATION_SEC,
+) -> tuple[Any, PreprocessStats]:
+    """Run the preprocessing pipeline on a loaded waveform.
+
+    Factored out from :func:`preprocess_audio_file` so unit tests can
+    drive it with synthetic numpy signals without touching disk. Returns
+    ``(processed_y, stats)``. On any failure the original waveform is
+    returned with ``stats.skipped = True``.
+    """
+    stats = PreprocessStats()
+
+    if not hpss_enabled and not normalize_enabled:
+        stats.skipped = True
+        return y, stats
+
+    try:
+        import numpy as np  # noqa: PLC0415
+    except ImportError as exc:
+        log.debug("numpy unavailable for preprocess: %s", exc)
+        stats.skipped = True
+        stats.warnings.append("numpy unavailable")
+        return y, stats
+
+    if y is None:
+        stats.skipped = True
+        stats.warnings.append("empty audio")
+        return y, stats
+
+    y = np.asarray(y, dtype=np.float32)
+    if y.size == 0 or sr <= 0:
+        stats.skipped = True
+        stats.warnings.append("empty audio")
+        return y, stats
+
+    duration = float(y.size / sr)
+    if duration < min_duration_sec:
+        stats.skipped = True
+        stats.warnings.append(f"audio too short ({duration:.2f}s)")
+        return y, stats
+
+    stats.input_rms_dbfs = _rms_dbfs(y)
+    stats.input_peak_dbfs = _peak_dbfs(y)
+
+    # HPSS — keep only the harmonic component. Any failure falls
+    # through and we continue with the un-HPSS'd signal.
+    if hpss_enabled:
+        try:
+            import librosa  # noqa: PLC0415
+
+            y_h = librosa.effects.harmonic(y, margin=hpss_margin)
+            y = np.asarray(y_h, dtype=np.float32)
+            stats.hpss_applied = True
+        except ImportError:
+            stats.warnings.append("hpss skipped: librosa unavailable")
+        except Exception as exc:  # noqa: BLE001 — never let preprocess sink the job
+            log.warning("HPSS failed: %s", exc)
+            stats.warnings.append(f"hpss failed: {exc}")
+
+    # RMS normalization with a peak ceiling. The peak-ceiling check
+    # runs *after* the RMS gain is applied, so we can reduce the final
+    # gain to honor the ceiling without ever having to clip. Silent
+    # input (RMS ≈ 0) skips this pass — there's nothing to scale.
+    if normalize_enabled:
+        try:
+            rms = float(np.sqrt(np.mean(np.square(y, dtype=np.float64))))
+            if rms > 1e-6:
+                target_rms = 10.0 ** (target_rms_dbfs / 20.0)
+                gain = target_rms / rms
+                projected_peak = float(np.max(np.abs(y))) * gain
+                ceiling = 10.0 ** (peak_ceiling_dbfs / 20.0)
+                if projected_peak > ceiling:
+                    gain *= ceiling / projected_peak
+                y = (y * gain).astype(np.float32)
+                stats.normalize_applied = True
+            else:
+                stats.warnings.append("normalize skipped: silent input")
+        except Exception as exc:  # noqa: BLE001
+            log.warning("normalize failed: %s", exc)
+            stats.warnings.append(f"normalize failed: {exc}")
+
+    stats.output_rms_dbfs = _rms_dbfs(y)
+    stats.output_peak_dbfs = _peak_dbfs(y)
+
+    # If neither pass actually ran, flag skipped so the file-path
+    # wrapper doesn't bother writing a redundant temp file.
+    if not stats.hpss_applied and not stats.normalize_applied:
+        stats.skipped = True
+
+    return y, stats
+
+
+# ---------------------------------------------------------------------------
+# File-path entry point — what transcribe.py calls
+# ---------------------------------------------------------------------------
+
+def preprocess_audio_file(
+    audio_path: Path,
+    *,
+    hpss_enabled: bool = True,
+    hpss_margin: float = DEFAULT_HPSS_MARGIN,
+    normalize_enabled: bool = True,
+    target_rms_dbfs: float = DEFAULT_TARGET_RMS_DBFS,
+    peak_ceiling_dbfs: float = DEFAULT_PEAK_CEILING_DBFS,
+    min_duration_sec: float = DEFAULT_MIN_DURATION_SEC,
+) -> tuple[Path, PreprocessStats]:
+    """Pre-process an audio file for Basic Pitch inference.
+
+    Returns ``(processed_path, stats)``. When preprocessing ran,
+    ``processed_path`` points at a newly-written tempfile (32-bit float
+    WAV at the native sample rate) and the caller is responsible for
+    unlinking it. When preprocessing was skipped or failed,
+    ``processed_path == audio_path`` and ``stats.skipped`` is True —
+    the caller must **not** unlink in that case.
+
+    Compare the returned path against the input to decide whether a
+    cleanup is needed::
+
+        processed, stats = preprocess_audio_file(audio_path)
+        try:
+            run_inference(processed)
+        finally:
+            if processed != audio_path:
+                processed.unlink(missing_ok=True)
+    """
+    stats = PreprocessStats()
+
+    if not hpss_enabled and not normalize_enabled:
+        stats.skipped = True
+        return audio_path, stats
+
+    try:
+        import librosa  # noqa: PLC0415
+        import numpy as np  # noqa: PLC0415
+        import soundfile  # noqa: PLC0415
+    except ImportError as exc:
+        log.debug("audio preprocess deps unavailable: %s", exc)
+        stats.skipped = True
+        stats.warnings.append(f"missing dep: {exc.name}")
+        return audio_path, stats
+
+    # Load at native SR, force mono — Basic Pitch will resample to
+    # 22050 Hz internally regardless, so we skip an extra resample here.
+    try:
+        y, sr = librosa.load(str(audio_path), sr=None, mono=True)
+    except Exception as exc:  # noqa: BLE001 — bad audio shouldn't crash the worker
+        log.warning("preprocess load failed for %s: %s", audio_path, exc)
+        stats.skipped = True
+        stats.warnings.append(f"load failed: {exc}")
+        return audio_path, stats
+
+    y_proc, stats = preprocess_waveform(
+        y, int(sr),
+        hpss_enabled=hpss_enabled,
+        hpss_margin=hpss_margin,
+        normalize_enabled=normalize_enabled,
+        target_rms_dbfs=target_rms_dbfs,
+        peak_ceiling_dbfs=peak_ceiling_dbfs,
+        min_duration_sec=min_duration_sec,
+    )
+
+    if stats.skipped:
+        return audio_path, stats
+
+    # Write to a tempfile. 32-bit float WAV is lossless and reads fast.
+    tmp_path: Path | None = None
+    try:
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=".wav", prefix="ohsheet-preprocess-", delete=False,
+        )
+        tmp.close()
+        tmp_path = Path(tmp.name)
+        soundfile.write(str(tmp_path), np.asarray(y_proc), int(sr), subtype="FLOAT")
+        return tmp_path, stats
+    except Exception as exc:  # noqa: BLE001
+        log.warning("preprocess write failed for %s: %s", audio_path, exc)
+        stats.skipped = True
+        stats.warnings.append(f"write failed: {exc}")
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:  # noqa: BLE001
+                pass
+        return audio_path, stats

--- a/backend/services/stem_separation.py
+++ b/backend/services/stem_separation.py
@@ -18,12 +18,16 @@ a *mixed* waveform, and a proper source-separation front-end renders
 them redundant.
 
 Everything here is feature-flagged via
-:attr:`backend.config.Settings.demucs_enabled` (off by default) and
-degrades gracefully. Any failure — missing ``demucs`` / ``torch``,
+:attr:`backend.config.Settings.demucs_enabled` — **on by default**,
+because the stems path produces cleaner role splits than the
+single-mix Viterbi heuristics whenever ``demucs`` is installed.
+Every failure mode degrades gracefully: missing ``demucs`` / ``torch``,
 unreadable audio, model load crash, apply_model OOM, tempfile write
-failure — returns ``(None, stats)`` with ``stats.skipped = True`` and
+failure all return ``(None, stats)`` with ``stats.skipped = True`` and
 a descriptive warning, so the caller falls back to the original
-single-mix Basic Pitch path without losing notes.
+single-mix Basic Pitch path without losing notes. Commercial
+deployments that can't accept the CC BY-NC ``htdemucs`` weights
+should set ``OHSHEET_DEMUCS_ENABLED=0`` to force the fallback.
 
 Cost
 ----

--- a/backend/services/stem_separation.py
+++ b/backend/services/stem_separation.py
@@ -1,0 +1,386 @@
+"""Source-separation stage — Demucs stem split.
+
+Runs `demucs.apply.apply_model`_ on the source waveform to split it
+into the four ``htdemucs`` sources — ``{drums, bass, other, vocals}``
+— each written to its own WAV tempfile. The transcribe wiring then
+feeds each stem to a dedicated downstream stage:
+
+  * ``vocals.wav`` → Basic Pitch → ``MELODY`` note events
+  * ``bass.wav``   → Basic Pitch → ``BASS`` note events
+  * ``other.wav``  → Basic Pitch → ``CHORDS`` note events
+  * ``other.wav``  → ``chord_recognition`` (chroma + triad templates)
+  * ``drums.wav``  → ``tempo_map_from_audio_path`` (beat tracking)
+
+With Demucs enabled the transcribe stage skips the Viterbi melody /
+bass split entirely: those heuristics exist to compensate for the
+fact that Basic Pitch is a single-stream polyphonic tracker run over
+a *mixed* waveform, and a proper source-separation front-end renders
+them redundant.
+
+Everything here is feature-flagged via
+:attr:`backend.config.Settings.demucs_enabled` (off by default) and
+degrades gracefully. Any failure — missing ``demucs`` / ``torch``,
+unreadable audio, model load crash, apply_model OOM, tempfile write
+failure — returns ``(None, stats)`` with ``stats.skipped = True`` and
+a descriptive warning, so the caller falls back to the original
+single-mix Basic Pitch path without losing notes.
+
+Cost
+----
+Demucs is a heavy model. ``htdemucs`` runs at roughly 0.2–0.5x
+real-time on CPU, 2–3x real-time on Apple MPS, and 5–10x real-time on
+CUDA. The pretrained weights are ~80 MB and are fetched on first use
+via ``demucs.pretrained.get_model``; once loaded, the model is cached
+at module scope (``_MODEL_CACHE``) so subsequent jobs pay only the
+inference cost.
+
+License
+-------
+Demucs itself is MIT, but the pretrained ``htdemucs`` weights are
+distributed under CC BY-NC 4.0 (non-commercial). Commercial
+deployments must either train their own weights, pick a different
+pretrained bag with a commercial license, or swap in another
+separator — the rest of the transcribe wiring only cares about the
+``SeparatedStems`` paths, not which model produced them.
+
+.. _demucs.apply.apply_model: https://github.com/facebookresearch/demucs
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults — mirrored in backend/config.py so config and tests agree.
+# ---------------------------------------------------------------------------
+
+# Default 4-stem pretrained bag. htdemucs is the latest Hybrid
+# Transformer Demucs model and is what ``demucs.separate`` itself
+# picks when ``--name`` is omitted.
+DEFAULT_MODEL_NAME = "htdemucs"
+
+# None → use the model's own segment default. Lower values trade
+# accuracy for memory; the htdemucs default (~7.8s) is a good balance.
+DEFAULT_SEGMENT_SEC: float | None = None
+
+# ``shifts=1`` matches ``demucs.separate`` defaults. Increasing to 5-10
+# improves SDR by ~0.2 points but multiplies inference time by ``shifts``.
+DEFAULT_SHIFTS = 1
+
+# Overlap between split chunks when ``split=True``. 0.25 is the
+# upstream default and gives a good accuracy / speed trade-off.
+DEFAULT_OVERLAP = 0.25
+
+# Splitting breaks the input into ~8s chunks so large audio files
+# don't OOM. Disable only for very short clips where the extra
+# overlap cost dominates.
+DEFAULT_SPLIT = True
+
+# Below this duration we bail — Demucs segment inference needs at
+# least a few hundred ms of audio to do anything meaningful.
+DEFAULT_MIN_DURATION_SEC = 0.5
+
+# Stem names used by the 4-source htdemucs family. Order matches
+# ``model.sources`` exactly — these are the names we route on in
+# ``_tensor_to_stems``. Custom-trained bags may ship with different
+# source lists; we detect missing names via the per-stem ``is None``
+# fallback in the consumers rather than failing here.
+STEM_VOCALS = "vocals"
+STEM_BASS = "bass"
+STEM_DRUMS = "drums"
+STEM_OTHER = "other"
+
+# Process-scoped cache for loaded models. Keyed on model name so a
+# test that swaps in a different pretrained bag gets its own slot.
+_MODEL_CACHE: dict[str, Any] = {}
+
+
+# ---------------------------------------------------------------------------
+# Data carriers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SeparatedStems:
+    """Paths to the four stem tempfiles written by :func:`separate_stems`.
+
+    Any subset of these may be ``None`` if the selected Demucs bag
+    doesn't emit that source (e.g. a 2-stem vocal/accompaniment model).
+    Callers should treat ``None`` as "stem unavailable, fall back to
+    the original audio" — that's why each slot is independently
+    optional rather than baked into a tuple.
+
+    The stems share a parent ``_tempdir`` so :meth:`cleanup` can
+    ``rmtree`` them in one call; the transcribe wiring should always
+    invoke ``cleanup()`` in a ``finally`` around the downstream
+    inference passes so large WAV blobs don't pile up on disk.
+    """
+    vocals: Path | None = None
+    bass: Path | None = None
+    drums: Path | None = None
+    other: Path | None = None
+    _tempdir: Path | None = None
+
+    def cleanup(self) -> None:
+        """Remove the tempdir that holds the stem WAVs. Idempotent."""
+        if self._tempdir is not None:
+            try:
+                shutil.rmtree(self._tempdir, ignore_errors=True)
+            except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+                log.warning(
+                    "failed to clean up demucs tempdir %s: %s",
+                    self._tempdir, exc,
+                )
+            self._tempdir = None
+            self.vocals = None
+            self.bass = None
+            self.drums = None
+            self.other = None
+
+
+@dataclass
+class StemSeparationStats:
+    """Per-run summary of what the separator did.
+
+    Structured like the other service stats objects (``PreprocessStats``,
+    ``ChordRecognitionStats``) so the transcribe wiring can thread it
+    through :class:`~backend.contracts.QualitySignal.warnings` the
+    same way.
+    """
+    skipped: bool = False
+    model_name: str = ""
+    device: str = ""
+    wall_time_sec: float = 0.0
+    stems_written: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def as_warnings(self) -> list[str]:
+        """One-line human summary entries for the QualitySignal."""
+        if self.skipped:
+            if self.warnings:
+                return [f"stem separation skipped: {w}" for w in self.warnings]
+            return ["stem separation skipped"]
+        out: list[str] = []
+        if self.stems_written:
+            stems = ", ".join(self.stems_written)
+            out.append(
+                f"stem separation: {self.model_name} on {self.device} "
+                f"({stems}) in {self.wall_time_sec:.1f}s"
+            )
+        out.extend(self.warnings)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Model + device helpers
+# ---------------------------------------------------------------------------
+
+def _load_model(name: str) -> Any:
+    """Lazy-load and cache a pretrained Demucs model. Process-scoped."""
+    cached = _MODEL_CACHE.get(name)
+    if cached is not None:
+        return cached
+
+    from demucs.pretrained import get_model  # noqa: PLC0415
+
+    log.info("Loading Demucs model %r", name)
+    model = get_model(name)
+    model.eval()
+    _MODEL_CACHE[name] = model
+    return model
+
+
+def _pick_device(preferred: str | None = None) -> str:
+    """Pick a torch device string. Auto-selects cuda → mps → cpu.
+
+    An explicit ``preferred`` value is trusted verbatim — no
+    availability check — so tests can force ``"cpu"`` even on a CUDA
+    box without paying the probe cost.
+    """
+    if preferred:
+        return preferred
+
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        return "cpu"
+
+    if torch.cuda.is_available():
+        return "cuda"
+    mps = getattr(torch.backends, "mps", None)
+    if mps is not None and mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def separate_stems(
+    audio_path: Path,
+    *,
+    model_name: str = DEFAULT_MODEL_NAME,
+    device: str | None = None,
+    segment_sec: float | None = DEFAULT_SEGMENT_SEC,
+    shifts: int = DEFAULT_SHIFTS,
+    overlap: float = DEFAULT_OVERLAP,
+    split: bool = DEFAULT_SPLIT,
+    min_duration_sec: float = DEFAULT_MIN_DURATION_SEC,
+) -> tuple[SeparatedStems | None, StemSeparationStats]:
+    """Run Demucs on ``audio_path`` and write each stem to a tempfile.
+
+    Returns ``(stems, stats)``. On any failure returns ``(None, stats)``
+    with ``stats.skipped = True`` and a reason in ``stats.warnings``, so
+    the caller can fall back cleanly to the original (stemless)
+    pipeline.
+
+    The caller owns the returned :class:`SeparatedStems` object and
+    **must** call :meth:`SeparatedStems.cleanup` when done — typically
+    in a ``try``/``finally`` around the downstream inference passes.
+    Large Demucs outputs (multi-minute audio × 4 stems) can pile up
+    fast if cleanup is skipped.
+    """
+    stats = StemSeparationStats(model_name=model_name)
+
+    # Deps — late-imported so the module is importable (and
+    # unit-testable with ``pytest.importorskip``) on machines without
+    # demucs / torch.
+    try:
+        import torch  # noqa: PLC0415
+        from demucs.apply import apply_model  # noqa: PLC0415
+        from demucs.audio import AudioFile, save_audio  # noqa: PLC0415
+    except ImportError as exc:
+        log.debug("demucs deps unavailable: %s", exc)
+        stats.skipped = True
+        stats.warnings.append(f"missing dep: {exc.name}")
+        return None, stats
+
+    if not audio_path.is_file():
+        stats.skipped = True
+        stats.warnings.append(f"audio file missing: {audio_path}")
+        return None, stats
+
+    try:
+        model = _load_model(model_name)
+    except Exception as exc:  # noqa: BLE001 — network/disk/import at load
+        log.warning("Failed to load Demucs model %r: %s", model_name, exc)
+        stats.skipped = True
+        stats.warnings.append(f"model load failed: {exc}")
+        return None, stats
+
+    device_str = _pick_device(device)
+    stats.device = device_str
+
+    # Load at the model's native samplerate / channel count so apply
+    # sees exactly what the weights were trained on. AudioFile shells
+    # out to ffmpeg — we already require ffmpeg for audio ingest
+    # upstream, so there's no torchaudio fallback dance here.
+    try:
+        wav = AudioFile(audio_path).read(
+            streams=0,
+            samplerate=model.samplerate,
+            channels=model.audio_channels,
+        )
+    except Exception as exc:  # noqa: BLE001 — bad bytes / ffmpeg missing
+        log.warning("Demucs load failed for %s: %s", audio_path, exc)
+        stats.skipped = True
+        stats.warnings.append(f"load failed: {exc}")
+        return None, stats
+
+    if wav is None or wav.numel() == 0:
+        stats.skipped = True
+        stats.warnings.append("empty audio")
+        return None, stats
+
+    duration = float(wav.shape[-1] / model.samplerate) if model.samplerate else 0.0
+    if duration < min_duration_sec:
+        stats.skipped = True
+        stats.warnings.append(f"audio too short ({duration:.2f}s)")
+        return None, stats
+
+    # Zero-mean, unit-variance inference, undone after apply. This is
+    # what ``demucs.separate`` does — the model was trained on
+    # normalized inputs and we don't want to drift from that.
+    ref = wav.mean(0)
+    ref_mean = ref.mean()
+    ref_std = ref.std()
+    if float(ref_std) < 1e-8:
+        stats.skipped = True
+        stats.warnings.append("silent input")
+        return None, stats
+    wav_norm = (wav - ref_mean) / ref_std
+
+    t0 = time.perf_counter()
+    try:
+        with torch.no_grad():
+            sources = apply_model(
+                model,
+                wav_norm[None],  # add batch dim → (1, C, T)
+                device=device_str,
+                shifts=shifts,
+                split=split,
+                overlap=overlap,
+                progress=False,
+                num_workers=0,
+                segment=segment_sec,
+            )
+        sources = sources[0]  # drop batch dim → (S, C, T)
+        sources = sources * ref_std + ref_mean
+    except Exception as exc:  # noqa: BLE001 — inference boundary
+        log.warning("Demucs apply_model failed for %s: %s", audio_path, exc)
+        stats.skipped = True
+        stats.warnings.append(f"apply failed: {exc}")
+        return None, stats
+    stats.wall_time_sec = time.perf_counter() - t0
+
+    # Write each stem to its own WAV inside a dedicated tempdir so
+    # SeparatedStems.cleanup can rmtree the whole thing in one call.
+    tempdir = Path(tempfile.mkdtemp(prefix="ohsheet-demucs-"))
+    stems = SeparatedStems(_tempdir=tempdir)
+
+    try:
+        for source, name in zip(sources, model.sources):
+            out_path = tempdir / f"{name}.wav"
+            save_audio(
+                source,
+                str(out_path),
+                samplerate=model.samplerate,
+                clip="rescale",
+                bits_per_sample=16,
+                as_float=False,
+            )
+            if name == STEM_VOCALS:
+                stems.vocals = out_path
+            elif name == STEM_BASS:
+                stems.bass = out_path
+            elif name == STEM_DRUMS:
+                stems.drums = out_path
+            elif name == STEM_OTHER:
+                stems.other = out_path
+            else:
+                # Unknown stem from a custom bag — still write it so
+                # the tempdir cleanup removes it, but don't attach it
+                # to a SeparatedStems slot. The consumer routing is
+                # name-based and will just treat that stem as absent.
+                log.debug("ignoring unknown demucs stem %r", name)
+            stats.stems_written.append(name)
+    except Exception as exc:  # noqa: BLE001 — write boundary
+        log.warning("Demucs stem write failed: %s", exc)
+        stems.cleanup()
+        stats.skipped = True
+        stats.warnings.append(f"write failed: {exc}")
+        return None, stats
+
+    log.debug(
+        "demucs separated %s into %d stems on %s in %.2fs",
+        audio_path, len(stats.stems_written), device_str, stats.wall_time_sec,
+    )
+    return stems, stats

--- a/backend/services/transcribe.py
+++ b/backend/services/transcribe.py
@@ -25,6 +25,7 @@ import asyncio
 import io
 import logging
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -358,7 +359,11 @@ class _BasicPitchPass:
     cleanup_stats: CleanupStats
 
 
-def _basic_pitch_single_pass(audio_path: Path) -> _BasicPitchPass:
+def _basic_pitch_single_pass(
+    audio_path: Path,
+    *,
+    keep_model_output: bool = True,
+) -> _BasicPitchPass:
     """Run preprocess → Basic Pitch → cleanup for one audio file.
 
     Factored out of :func:`_run_basic_pitch_sync` so the Demucs path
@@ -374,6 +379,17 @@ def _basic_pitch_single_pass(audio_path: Path) -> _BasicPitchPass:
     old inline code did — the preprocessed tempfile (if any) is
     unlinked in a ``finally`` regardless of whether ``predict``
     succeeded, so we never leak temp WAVs on the inference path.
+
+    ``keep_model_output`` defaults to True for the single-mix path,
+    where the downstream Viterbi melody/bass extractors read
+    ``model_output["contour"]``. The stems path passes False so the
+    contour tensor (tens of MB per stem — three copies in the
+    parallel path) can be garbage-collected as soon as Basic Pitch's
+    note events are extracted. On the stems path that matrix is
+    dead data: the ``if not events_by_role`` guard in
+    :func:`_run_with_stems` makes the ``model_output.get("note")``
+    confidence fallback in :func:`_pretty_midi_to_transcription_result`
+    unreachable.
     """
     model = _load_basic_pitch_model()
     from basic_pitch.inference import predict  # noqa: PLC0415
@@ -435,6 +451,15 @@ def _basic_pitch_single_pass(audio_path: Path) -> _BasicPitchPass:
             cleaned_events = note_events  # fall back to raw
             cleanup_stats.warnings.append("cleanup: rebuild failed, using raw pm")
 
+    # Drop the shared reference to ``model_output`` before the
+    # function returns when the caller doesn't need it. The local
+    # binding above goes out of scope regardless, but keeping this
+    # explicit means the stems path never hands a live reference
+    # to the contour tensor back to the orchestrator — the C-backed
+    # numpy arrays can be reclaimed before the next stem's
+    # ``predict()`` allocates its own.
+    if not keep_model_output:
+        model_output.clear()
     return _BasicPitchPass(
         cleaned_events=cleaned_events,
         model_output=model_output,
@@ -627,41 +652,86 @@ def _run_with_stems(
     stay off in this code path regardless, because their purpose is
     to compensate for the single-mix Basic Pitch limitation the
     stems already fix.
+
+    Parallelism
+    -----------
+    The three Basic Pitch passes (vocals / bass / other) are
+    independent, so by default they run concurrently in a
+    :class:`~concurrent.futures.ThreadPoolExecutor` gated by
+    :attr:`Settings.demucs_parallel_stems`. The shared cached
+    ``basic_pitch.inference.Model`` is safe to call from multiple
+    threads because its backing session — ONNX Runtime on Linux/CI,
+    CoreML on Darwin — is documented thread-safe for concurrent
+    ``.run()`` / ``.predict()`` calls, and ``basic_pitch.inference``
+    itself has no module-level mutable state to race on. Most of the
+    wall time (session inference, numpy window packing, ``librosa``
+    resampling) happens in C extensions that release the GIL, so on
+    a multi-core host the three passes overlap to ~1x Basic Pitch
+    cost instead of ~3x.
+
+    Set ``OHSHEET_DEMUCS_PARALLEL_STEMS=0`` to force serial
+    execution (useful for debugging single-thread traces or
+    reproducing sequential memory behavior).
     """
     events_by_role: dict[InstrumentRole, list[NoteEvent]] = {}
     per_stem_preprocess_stats: dict[str, PreprocessStats] = {}
     per_stem_cleanup_stats: dict[str, CleanupStats] = {}
     per_stem_passes: dict[str, _BasicPitchPass] = {}
 
-    def _run_stem(label: str, stem_path: Path | None) -> _BasicPitchPass | None:
-        if stem_path is None:
-            return None
+    # Build the list of stems we actually need to run Basic Pitch on,
+    # honoring the per-consumer escape hatches. An absent stem (e.g.
+    # a 2-source bag that didn't emit vocals) naturally drops out
+    # here too.
+    stem_jobs: list[tuple[str, Path]] = []
+    if settings.demucs_use_vocals_for_melody and stems.vocals is not None:
+        stem_jobs.append(("vocals", stems.vocals))
+    if settings.demucs_use_bass_stem and stems.bass is not None:
+        stem_jobs.append(("bass", stems.bass))
+    if settings.demucs_use_other_for_chords and stems.other is not None:
+        stem_jobs.append(("other", stems.other))
+
+    def _run_stem(job: tuple[str, Path]) -> tuple[str, _BasicPitchPass | None]:
+        label, stem_path = job
         try:
-            bp = _basic_pitch_single_pass(stem_path)
+            # ``keep_model_output=False`` lets each pass drop its
+            # ``contour`` tensor as soon as note extraction finishes.
+            # On the parallel path this matters twice: the three
+            # passes overlap in time (peak memory would otherwise
+            # carry three live contour matrices), and the stems path
+            # never consults ``model_output`` downstream because the
+            # Viterbi fallbacks are disabled here.
+            bp = _basic_pitch_single_pass(stem_path, keep_model_output=False)
         except Exception as exc:  # noqa: BLE001 — one bad stem must not sink the job
             log.warning("Basic Pitch failed on %s stem (%s): %s", label, stem_path, exc)
-            return None
+            return label, None
+        return label, bp
+
+    if stem_jobs and settings.demucs_parallel_stems and len(stem_jobs) > 1:
+        # The cached Basic Pitch model is thread-safe to call
+        # concurrently (see docstring) and most of the work happens
+        # in GIL-releasing C extensions, so a ThreadPoolExecutor is
+        # the right tool here — no pickling, no process spawn cost,
+        # no duplicated model weights.
+        max_workers = min(settings.demucs_parallel_max_workers, len(stem_jobs))
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="bp-stem",
+        ) as ex:
+            results = list(ex.map(_run_stem, stem_jobs))
+    else:
+        results = [_run_stem(job) for job in stem_jobs]
+
+    for label, bp in results:
+        if bp is None:
+            continue
         per_stem_passes[label] = bp
         if bp.preprocess_stats is not None:
             per_stem_preprocess_stats[label] = bp.preprocess_stats
         per_stem_cleanup_stats[label] = bp.cleanup_stats
-        return bp
 
-    vocals_bp = (
-        _run_stem("vocals", stems.vocals)
-        if settings.demucs_use_vocals_for_melody
-        else None
-    )
-    bass_bp = (
-        _run_stem("bass", stems.bass)
-        if settings.demucs_use_bass_stem
-        else None
-    )
-    other_bp = (
-        _run_stem("other", stems.other)
-        if settings.demucs_use_other_for_chords
-        else None
-    )
+    vocals_bp = per_stem_passes.get("vocals")
+    bass_bp = per_stem_passes.get("bass")
+    other_bp = per_stem_passes.get("other")
 
     if vocals_bp is not None and vocals_bp.cleaned_events:
         events_by_role[InstrumentRole.MELODY] = vocals_bp.cleaned_events
@@ -742,20 +812,20 @@ def _run_with_stems(
     fallback_midi = representative_pass.midi_data if representative_pass else None
     combined_midi = _combined_midi_from_events(events_by_role, fallback_midi)
 
-    # Representative model_output for the existing note_grid confidence
-    # fallback in _pretty_midi_to_transcription_result. We pass the
-    # "other" stem's model_output when available because it mirrors
-    # the mix-wide harmonic density best; otherwise any available
-    # pass works — the fallback is only exercised when events_by_role
-    # is empty, which we already guarded against above.
-    representative_model_output: dict[str, Any] = (
-        representative_pass.model_output if representative_pass else {}
-    )
+    # ``model_output`` is intentionally empty on the stems path. The
+    # ``_pretty_midi_to_transcription_result`` consumer only reads it
+    # as a ``note_grid`` confidence fallback when ``all_amplitudes``
+    # is empty, and the ``if not events_by_role`` guard above
+    # guarantees at least one non-empty per-stem event list, so that
+    # branch is unreachable here. Carrying a live reference would
+    # just pin the (unused) contour tensors until the function
+    # returns, defeating the ``keep_model_output=False`` memory win.
+    stems_model_output: dict[str, Any] = {}
 
     result = _pretty_midi_to_transcription_result(
         combined_midi,
         events_by_role,
-        representative_model_output,
+        stems_model_output,
         tempo_map_override=audio_tempo_map,
         preprocess_stats=None,  # surfaced per-stem below
         cleanup_stats=None,     # surfaced per-stem below

--- a/backend/services/transcribe.py
+++ b/backend/services/transcribe.py
@@ -25,6 +25,7 @@ import asyncio
 import io
 import logging
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -42,6 +43,10 @@ from backend.contracts import (
     TempoMapEntry,
     TranscriptionResult,
 )
+from backend.services.audio_preprocess import (
+    PreprocessStats,
+    preprocess_audio_file,
+)
 from backend.services.audio_timing import tempo_map_from_audio_path
 from backend.services.bass_extraction import (
     BassExtractionStats,
@@ -54,6 +59,11 @@ from backend.services.chord_recognition import (
 from backend.services.melody_extraction import (
     MelodyExtractionStats,
     extract_melody,
+)
+from backend.services.stem_separation import (
+    SeparatedStems,
+    StemSeparationStats,
+    separate_stems,
 )
 from backend.services.transcription_cleanup import (
     CleanupStats,
@@ -91,6 +101,20 @@ def _event_to_note(event: NoteEvent) -> Note:
     )
 
 
+def _prefixed_warnings(label: str, warnings: list[str]) -> list[str]:
+    """Tag each warning line with a ``[label]`` prefix.
+
+    Used when a stage runs once per Demucs stem — the base warning
+    string comes from ``Stats.as_warnings()`` and doesn't know which
+    stem produced it, so we decorate at the assembly site instead of
+    mutating the stats objects themselves (which would make them
+    harder to diff across re-runs).
+    """
+    if not label:
+        return list(warnings)
+    return [f"[{label}] {w}" for w in warnings]
+
+
 def _pretty_midi_to_transcription_result(
     pm: Any,
     events_by_role: dict[InstrumentRole, list[NoteEvent]],
@@ -98,11 +122,15 @@ def _pretty_midi_to_transcription_result(
     default_bpm: float = 120.0,
     *,
     tempo_map_override: list[TempoMapEntry] | None = None,
+    preprocess_stats: PreprocessStats | None = None,
     cleanup_stats: CleanupStats | None = None,
     melody_stats: MelodyExtractionStats | None = None,
     bass_stats: BassExtractionStats | None = None,
     chord_stats: ChordRecognitionStats | None = None,
     chord_labels: list[RealtimeChordEvent] | None = None,
+    stem_stats: StemSeparationStats | None = None,
+    per_stem_preprocess_stats: dict[str, PreprocessStats] | None = None,
+    per_stem_cleanup_stats: dict[str, CleanupStats] | None = None,
 ) -> TranscriptionResult:
     """Convert Basic Pitch's output into our pydantic TranscriptionResult.
 
@@ -204,8 +232,22 @@ def _pretty_midi_to_transcription_result(
     ]
     if tempo_map_override:
         warnings.append("tempo_map from audio beat tracking (librosa)")
+    if stem_stats is not None:
+        warnings.extend(stem_stats.as_warnings())
+    # Single-pass stats (no Demucs). When the Demucs path is active
+    # these stay None and the per_stem_* dicts carry the equivalents.
+    if preprocess_stats is not None:
+        warnings.extend(preprocess_stats.as_warnings())
     if cleanup_stats is not None:
         warnings.extend(cleanup_stats.as_warnings())
+    # Per-stem stats — one entry per active stem, prefixed so the
+    # reader can tell them apart (e.g. ``[vocals] cleanup: 12 merged``).
+    if per_stem_preprocess_stats:
+        for label, pps in per_stem_preprocess_stats.items():
+            warnings.extend(_prefixed_warnings(label, pps.as_warnings()))
+    if per_stem_cleanup_stats:
+        for label, cps in per_stem_cleanup_stats.items():
+            warnings.extend(_prefixed_warnings(label, cps.as_warnings()))
     if melody_stats is not None:
         warnings.extend(melody_stats.as_warnings())
     if bass_stats is not None:
@@ -301,30 +343,78 @@ def _serialize_pretty_midi(pm: Any) -> bytes | None:
         return None
 
 
-def _run_basic_pitch_sync(audio_path: Path) -> tuple[TranscriptionResult, bytes | None]:
-    """Synchronous Basic Pitch inference. Run inside asyncio.to_thread.
+@dataclass
+class _BasicPitchPass:
+    """Captured outputs of one Basic Pitch inference run on a single audio file.
 
-    Returns both the parsed ``TranscriptionResult`` and the raw MIDI bytes
-    (if serialization succeeded) so the async caller can persist the MIDI
-    to blob storage without blocking on disk I/O in the worker thread.
+    Returned by :func:`_basic_pitch_single_pass` so the orchestrator in
+    :func:`_run_basic_pitch_sync` can either use one pass directly
+    (no-Demucs path) or stitch several passes together (one per stem).
+    """
+    cleaned_events: list[NoteEvent]
+    model_output: dict[str, Any]
+    midi_data: Any  # pretty_midi.PrettyMIDI rebuilt from cleaned_events
+    preprocess_stats: PreprocessStats | None
+    cleanup_stats: CleanupStats
 
-    The note events go through :func:`cleanup_note_events` before we
-    rebuild ``pretty_midi``, so both the contract notes and the
-    serialized ``.mid`` blob reflect the cleaned set. Cleanup is
-    pure-Python and deterministic — see transcription_cleanup.py for the
-    heuristics.
+
+def _basic_pitch_single_pass(audio_path: Path) -> _BasicPitchPass:
+    """Run preprocess → Basic Pitch → cleanup for one audio file.
+
+    Factored out of :func:`_run_basic_pitch_sync` so the Demucs path
+    can call it once per stem (vocals / bass / other) without
+    duplicating the preprocess + predict + cleanup boilerplate. The
+    returned :class:`_BasicPitchPass` carries everything downstream
+    consumers might want: the cleaned note events, Basic Pitch's
+    ``model_output`` (for contour access in Viterbi fallbacks),
+    the rebuilt pretty_midi for blob serialization, and the
+    per-pass stats objects.
+
+    Honors ``settings.audio_preprocess_enabled`` exactly like the
+    old inline code did — the preprocessed tempfile (if any) is
+    unlinked in a ``finally`` regardless of whether ``predict``
+    succeeded, so we never leak temp WAVs on the inference path.
     """
     model = _load_basic_pitch_model()
     from basic_pitch.inference import predict  # noqa: PLC0415
     from basic_pitch.note_creation import note_events_to_midi  # noqa: PLC0415
 
-    model_output, midi_data, note_events = predict(
-        str(audio_path),
-        model_or_model_path=model,
-        onset_threshold=settings.basic_pitch_onset_threshold,
-        frame_threshold=settings.basic_pitch_frame_threshold,
-        minimum_note_length=settings.basic_pitch_minimum_note_length_ms,
-    )
+    # Audio pre-processing (feature-flagged). Any failure falls back
+    # to the original path with stats.skipped=True, so the rest of the
+    # pipeline runs unchanged. The preprocessed temp file is cleaned up
+    # after predict() regardless of success.
+    preprocess_stats: PreprocessStats | None = None
+    inference_path = audio_path
+    preprocessed_tempfile: Path | None = None
+    if settings.audio_preprocess_enabled:
+        inference_path, preprocess_stats = preprocess_audio_file(
+            audio_path,
+            hpss_enabled=settings.audio_preprocess_hpss_enabled,
+            hpss_margin=settings.audio_preprocess_hpss_margin,
+            normalize_enabled=settings.audio_preprocess_normalize_enabled,
+            target_rms_dbfs=settings.audio_preprocess_target_rms_dbfs,
+            peak_ceiling_dbfs=settings.audio_preprocess_peak_ceiling_dbfs,
+        )
+        if inference_path != audio_path:
+            preprocessed_tempfile = inference_path
+
+    try:
+        model_output, midi_data, note_events = predict(
+            str(inference_path),
+            model_or_model_path=model,
+            onset_threshold=settings.basic_pitch_onset_threshold,
+            frame_threshold=settings.basic_pitch_frame_threshold,
+            minimum_note_length=settings.basic_pitch_minimum_note_length_ms,
+        )
+    finally:
+        if preprocessed_tempfile is not None:
+            try:
+                preprocessed_tempfile.unlink(missing_ok=True)
+            except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+                log.warning(
+                    "Failed to unlink preprocessed temp file %s: %s",
+                    preprocessed_tempfile, exc,
+                )
 
     # Phase 1 post-processing — merge fragmented sustains, drop octave
     # ghosts and quiet ghost-tail notes. Rebuild pretty_midi from the
@@ -344,6 +434,68 @@ def _run_basic_pitch_sync(audio_path: Path) -> tuple[TranscriptionResult, bytes 
             log.warning("note_events_to_midi rebuild failed, using raw pm: %s", exc)
             cleaned_events = note_events  # fall back to raw
             cleanup_stats.warnings.append("cleanup: rebuild failed, using raw pm")
+
+    return _BasicPitchPass(
+        cleaned_events=cleaned_events,
+        model_output=model_output,
+        midi_data=midi_data,
+        preprocess_stats=preprocess_stats,
+        cleanup_stats=cleanup_stats,
+    )
+
+
+def _combined_midi_from_events(
+    events_by_role: dict[InstrumentRole, list[NoteEvent]],
+    fallback: Any,
+) -> Any:
+    """Build a single pretty_midi from the concatenated per-role events.
+
+    Used on the Demucs path where we have three independent Basic
+    Pitch passes (vocals / bass / other) and need *one* ``.mid``
+    artifact for blob storage. We flatten the per-role note lists and
+    run them through ``note_events_to_midi`` — the blob MIDI is a
+    debugging artifact, not authoritative, so collapsing the role
+    split there is fine (the contract ``TranscriptionResult`` keeps
+    the split intact).
+
+    On any failure we fall back to ``fallback`` (typically the last
+    pretty_midi we produced in the loop) so blob persistence stays
+    best-effort.
+    """
+    try:
+        from basic_pitch.note_creation import note_events_to_midi  # noqa: PLC0415
+    except ImportError:
+        return fallback
+
+    combined: list[NoteEvent] = []
+    for events in events_by_role.values():
+        combined.extend(events)
+    if not combined:
+        return fallback
+    combined.sort(key=lambda e: (e[0], e[2]))
+    try:
+        return note_events_to_midi(combined)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("combined note_events_to_midi failed: %s", exc)
+        return fallback
+
+
+def _run_without_stems(
+    audio_path: Path,
+    stem_stats: StemSeparationStats | None,
+) -> tuple[TranscriptionResult, bytes | None]:
+    """Legacy single-mix pipeline — one Basic Pitch pass + Viterbi splits.
+
+    This is what ``_run_basic_pitch_sync`` falls back to when Demucs
+    is disabled *or* stem separation failed. ``stem_stats`` may
+    carry a "skipped: ..." message from a failed Demucs attempt;
+    threading it through lets the QualitySignal explain why the
+    per-stem code path didn't run.
+    """
+    pass_result = _basic_pitch_single_pass(audio_path)
+    cleaned_events = pass_result.cleaned_events
+    model_output = pass_result.model_output
+    midi_data = pass_result.midi_data
 
     # Phase 2+3 post-processing — waveform-guided voice split via a
     # Viterbi path over ``model_output["contour"]``, then bass on the
@@ -439,14 +591,229 @@ def _run_basic_pitch_sync(audio_path: Path) -> tuple[TranscriptionResult, bytes 
         events_by_role,
         model_output,
         tempo_map_override=audio_tempo_map,
-        cleanup_stats=cleanup_stats,
+        preprocess_stats=pass_result.preprocess_stats,
+        cleanup_stats=pass_result.cleanup_stats,
         melody_stats=melody_stats,
         bass_stats=bass_stats,
         chord_stats=chord_stats,
         chord_labels=chord_labels,
+        stem_stats=stem_stats,
     )
     midi_bytes = _serialize_pretty_midi(midi_data)
     return result, midi_bytes
+
+
+def _run_with_stems(
+    audio_path: Path,
+    stems: SeparatedStems,
+    stem_stats: StemSeparationStats,
+) -> tuple[TranscriptionResult, bytes | None]:
+    """Demucs-driven pipeline — one Basic Pitch pass per stem.
+
+    Routing:
+
+      * ``vocals.wav`` → Basic Pitch → MELODY events
+      * ``bass.wav``   → Basic Pitch → BASS events
+      * ``other.wav``  → Basic Pitch → CHORDS events
+      * ``drums.wav``  → ``tempo_map_from_audio_path`` (beat tracking)
+      * ``other.wav``  → ``recognize_chords`` (chroma + triad templates)
+
+    Each routing is gated by a ``demucs_use_*`` flag so an operator
+    can disable a single stem without touching the others (e.g. turn
+    off drums-for-beats on material where Demucs drums is noisy, and
+    let beat tracking fall back to the mix). When a stem is missing
+    or its consumer returns empty, we fall back to the *original*
+    mixed audio for that stage — the Viterbi melody/bass extractors
+    stay off in this code path regardless, because their purpose is
+    to compensate for the single-mix Basic Pitch limitation the
+    stems already fix.
+    """
+    events_by_role: dict[InstrumentRole, list[NoteEvent]] = {}
+    per_stem_preprocess_stats: dict[str, PreprocessStats] = {}
+    per_stem_cleanup_stats: dict[str, CleanupStats] = {}
+    per_stem_passes: dict[str, _BasicPitchPass] = {}
+
+    def _run_stem(label: str, stem_path: Path | None) -> _BasicPitchPass | None:
+        if stem_path is None:
+            return None
+        try:
+            bp = _basic_pitch_single_pass(stem_path)
+        except Exception as exc:  # noqa: BLE001 — one bad stem must not sink the job
+            log.warning("Basic Pitch failed on %s stem (%s): %s", label, stem_path, exc)
+            return None
+        per_stem_passes[label] = bp
+        if bp.preprocess_stats is not None:
+            per_stem_preprocess_stats[label] = bp.preprocess_stats
+        per_stem_cleanup_stats[label] = bp.cleanup_stats
+        return bp
+
+    vocals_bp = (
+        _run_stem("vocals", stems.vocals)
+        if settings.demucs_use_vocals_for_melody
+        else None
+    )
+    bass_bp = (
+        _run_stem("bass", stems.bass)
+        if settings.demucs_use_bass_stem
+        else None
+    )
+    other_bp = (
+        _run_stem("other", stems.other)
+        if settings.demucs_use_other_for_chords
+        else None
+    )
+
+    if vocals_bp is not None and vocals_bp.cleaned_events:
+        events_by_role[InstrumentRole.MELODY] = vocals_bp.cleaned_events
+    if bass_bp is not None and bass_bp.cleaned_events:
+        events_by_role[InstrumentRole.BASS] = bass_bp.cleaned_events
+    if other_bp is not None and other_bp.cleaned_events:
+        events_by_role[InstrumentRole.CHORDS] = other_bp.cleaned_events
+
+    # If every per-stem pass came back empty we can't ship a useful
+    # stem-driven result. Fall back to the single-mix pipeline so the
+    # caller still gets notes, and tag stem_stats so the QualitySignal
+    # explains why we bailed.
+    if not events_by_role:
+        log.warning(
+            "all Demucs stems produced empty Basic Pitch output for %s; "
+            "falling back to single-mix path",
+            audio_path,
+        )
+        stem_stats.warnings.append("all stems empty; fell back to single-mix")
+        return _run_without_stems(audio_path, stem_stats)
+
+    # Tempo map — prefer the drums stem when enabled and available.
+    # A drums-stem beat track that returns no beats (possible on
+    # cappella / ambient material) falls back to the mix so the
+    # downstream tempo_map is still waveform-derived.
+    tempo_src: Path = audio_path
+    if settings.demucs_use_drums_for_beats and stems.drums is not None:
+        tempo_src = stems.drums
+    audio_tempo_map = tempo_map_from_audio_path(tempo_src)
+    if audio_tempo_map is None and tempo_src != audio_path:
+        log.debug("drums-stem beat tracking returned None, retrying with mix")
+        audio_tempo_map = tempo_map_from_audio_path(audio_path)
+
+    # Chord recognition — prefer the "other" stem when enabled and
+    # available. Chord labeling on the other stem is cleaner because
+    # vocal sibilance and drum spectral leakage don't pollute the
+    # chroma vectors. Same mix-fallback pattern as beat tracking.
+    chord_labels: list[RealtimeChordEvent] = []
+    chord_stats: ChordRecognitionStats | None = None
+    if settings.chord_recognition_enabled:
+        chord_src: Path = audio_path
+        if settings.demucs_use_other_for_chords and stems.other is not None:
+            chord_src = stems.other
+        try:
+            chord_labels, chord_stats = recognize_chords(
+                chord_src,
+                min_score=settings.chord_min_template_score,
+                hpss_margin=settings.chord_hpss_margin,
+            )
+            if chord_stats.skipped and chord_src != audio_path:
+                log.debug(
+                    "chord recognition on other-stem skipped, retrying with mix"
+                )
+                chord_labels, chord_stats = recognize_chords(
+                    audio_path,
+                    min_score=settings.chord_min_template_score,
+                    hpss_margin=settings.chord_hpss_margin,
+                )
+        except Exception as exc:  # noqa: BLE001 — chord recog must not sink transcribe
+            log.warning("chord recognition raised: %s", exc)
+            chord_labels = []
+            chord_stats = ChordRecognitionStats(skipped=True)
+            chord_stats.warnings.append(f"chord recognition failed: {exc}")
+
+    # Pick a representative pretty_midi for the blob artifact — we
+    # prefer the "other" pass because it carries the largest note
+    # count on most material, and fall back to whichever stem did
+    # return something. The combined builder flattens every stem's
+    # notes into one list for serialization so the blob is still a
+    # complete debugging artifact (just without role tags, which
+    # pretty_midi can't represent losslessly anyway).
+    #
+    # This is reached only after the ``not events_by_role`` guard
+    # above, so at least one of the three passes is non-None — the
+    # ``or``-chain always returns a real _BasicPitchPass here. The
+    # explicit binding is for type narrowing.
+    representative_pass: _BasicPitchPass | None = other_bp or bass_bp or vocals_bp
+    fallback_midi = representative_pass.midi_data if representative_pass else None
+    combined_midi = _combined_midi_from_events(events_by_role, fallback_midi)
+
+    # Representative model_output for the existing note_grid confidence
+    # fallback in _pretty_midi_to_transcription_result. We pass the
+    # "other" stem's model_output when available because it mirrors
+    # the mix-wide harmonic density best; otherwise any available
+    # pass works — the fallback is only exercised when events_by_role
+    # is empty, which we already guarded against above.
+    representative_model_output: dict[str, Any] = (
+        representative_pass.model_output if representative_pass else {}
+    )
+
+    result = _pretty_midi_to_transcription_result(
+        combined_midi,
+        events_by_role,
+        representative_model_output,
+        tempo_map_override=audio_tempo_map,
+        preprocess_stats=None,  # surfaced per-stem below
+        cleanup_stats=None,     # surfaced per-stem below
+        melody_stats=None,      # Viterbi split is skipped on the stems path
+        bass_stats=None,
+        chord_stats=chord_stats,
+        chord_labels=chord_labels,
+        stem_stats=stem_stats,
+        per_stem_preprocess_stats=per_stem_preprocess_stats,
+        per_stem_cleanup_stats=per_stem_cleanup_stats,
+    )
+    midi_bytes = _serialize_pretty_midi(combined_midi) if combined_midi else None
+    return result, midi_bytes
+
+
+def _run_basic_pitch_sync(audio_path: Path) -> tuple[TranscriptionResult, bytes | None]:
+    """Synchronous Basic Pitch inference. Run inside asyncio.to_thread.
+
+    Returns both the parsed ``TranscriptionResult`` and the raw MIDI bytes
+    (if serialization succeeded) so the async caller can persist the MIDI
+    to blob storage without blocking on disk I/O in the worker thread.
+
+    Dispatches between two pipelines:
+
+      * **Demucs path** (``settings.demucs_enabled``): split the source
+        into 4 stems, run Basic Pitch once per stem (vocals / bass /
+        other), and route drums + other to the beat-track and chord
+        recognizers. See :func:`_run_with_stems`.
+      * **Single-mix path** (default): one Basic Pitch pass on the
+        whole mix + Viterbi melody/bass split + chord recognition on
+        the original waveform. See :func:`_run_without_stems`.
+
+    Any failure in the Demucs path (separation crash, all-stems-empty,
+    missing torch) transparently falls back to the single-mix path so
+    flipping ``demucs_enabled`` is always safe — the worst case is that
+    the user pays the Demucs load cost for nothing.
+    """
+    stems: SeparatedStems | None = None
+    stem_stats: StemSeparationStats | None = None
+
+    if settings.demucs_enabled:
+        stems, stem_stats = separate_stems(
+            audio_path,
+            model_name=settings.demucs_model,
+            device=settings.demucs_device,
+            segment_sec=settings.demucs_segment_sec,
+            shifts=settings.demucs_shifts,
+            overlap=settings.demucs_overlap,
+            split=settings.demucs_split,
+        )
+
+    try:
+        if stems is not None and stem_stats is not None:
+            return _run_with_stems(audio_path, stems, stem_stats)
+        return _run_without_stems(audio_path, stem_stats)
+    finally:
+        if stems is not None:
+            stems.cleanup()
 
 
 class TranscribeService:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,26 @@ basic-pitch = [
     "scipy>=1.4.1",
     "typing_extensions",
 ]
+# Demucs source separation, used by TranscribeService when
+# OHSHEET_DEMUCS_ENABLED=1. Splits the input mix into
+# {drums, bass, other, vocals} stems and routes each stem to its
+# own Basic Pitch pass / chord-recognition / beat-tracking stage.
+#
+# License note: the ``demucs`` package itself is MIT, but the
+# default ``htdemucs`` pretrained weights (fetched on first use
+# from dl.fbaipublicfiles.com) are distributed under CC BY-NC 4.0
+# — non-commercial only. Commercial deployments must either train
+# their own weights, pick a commercially-licensed pretrained bag,
+# or swap in another separator. Stem separation is disabled by
+# default so the commercial risk is opt-in.
+#
+# Without this extra the TranscribeService falls back to the
+# single-mix Basic Pitch path regardless of ``demucs_enabled``.
+demucs = [
+    "demucs>=4.0",
+    "torch>=2.0",
+    "torchaudio>=2.0",
+]
 
 [project.scripts]
 ohsheet = "backend.main:run"

--- a/scripts/bench_preprocess.py
+++ b/scripts/bench_preprocess.py
@@ -1,0 +1,238 @@
+"""A/B benchmark: preprocessing off vs preprocessing on.
+
+Runs :func:`backend.services.transcribe._run_basic_pitch_sync` twice on
+the same audio file — once with ``audio_preprocess_enabled=False``, once
+with it True — and prints a side-by-side diagnostic so we can see how
+HPSS + RMS normalization shift the distribution of Basic Pitch's output,
+how cleanup reacts, and how the role-split counts land.
+
+There's no ground truth here; the goal is to *measure the shift*, not to
+score accuracy. Specifically we want to know:
+
+  * Does HPSS pull Basic Pitch's per-note amplitudes down as a block?
+    (If so, ``basic_pitch_onset_threshold`` / ``frame_threshold`` may
+    need to come down in the preprocess-on profile.)
+
+  * Does the merge / octave-prune / ghost-tail cleanup drop more or
+    fewer notes after preprocessing? (Tells us whether cleanup is
+    still doing useful work or has been rendered redundant.)
+
+  * Do the per-role counts (melody / bass / chords) land in roughly
+    the same proportions? (If the distribution flips wildly, the
+    Viterbi extractors may need their voicing floors re-evaluated.)
+
+Usage::
+
+    python scripts/bench_preprocess.py assets/rising-sun-1.mp3
+    python scripts/bench_preprocess.py assets/rising-sun-{1,2,3}.mp3
+
+Any failure in a single file is logged and the script continues —
+benchmarking is best-effort, and we'd rather see partial results than
+abort on the first unreadable fixture.
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Nearest-rank percentile — no numpy dep needed at the top level."""
+    if not values:
+        return float("nan")
+    sorted_vals = sorted(values)
+    k = max(0, min(len(sorted_vals) - 1, int(round(pct / 100.0 * (len(sorted_vals) - 1)))))
+    return sorted_vals[k]
+
+
+def _summarize_amps(amps: list[float]) -> dict[str, float]:
+    if not amps:
+        return {"n": 0, "mean": float("nan"), "median": float("nan"),
+                "p10": float("nan"), "p90": float("nan"),
+                "min": float("nan"), "max": float("nan")}
+    return {
+        "n": len(amps),
+        "mean": statistics.fmean(amps),
+        "median": statistics.median(amps),
+        "p10": _percentile(amps, 10),
+        "p90": _percentile(amps, 90),
+        "min": min(amps),
+        "max": max(amps),
+    }
+
+
+def _amps_from_result(result: Any) -> list[float]:
+    """Pull per-note 'amplitude' proxies from a TranscriptionResult.
+
+    Contract ``Note`` stores ``velocity`` (int 1–127) not the raw Basic
+    Pitch amplitude, but the two are monotonic (``velocity = round(127 *
+    amp)``) so the shape of the distribution is preserved. We return
+    amplitudes in the 0–1 range for comparability with Basic Pitch's
+    raw output.
+    """
+    out: list[float] = []
+    for track in result.midi_tracks:
+        for note in track.notes:
+            out.append(note.velocity / 127.0)
+    return out
+
+
+def _print_row(label: str, a: Any, b: Any, fmt: str = "{:>10}") -> None:
+    print(f"  {label:<28} " + fmt.format(str(a)) + "   " + fmt.format(str(b)))
+
+
+def _print_header() -> None:
+    print(f"  {'metric':<28} {'preprocess OFF':>10}   {'preprocess ON':>10}")
+    print(f"  {'-'*28} {'-'*10}   {'-'*10}")
+
+
+def _extract_warning_summary(result: Any) -> dict[str, str]:
+    """Pick out the interesting per-stage summary lines from warnings."""
+    out: dict[str, str] = {}
+    for w in result.quality.warnings:
+        if w.startswith("cleanup:"):
+            out.setdefault("cleanup", []).append(w[len("cleanup:"):].strip())  # type: ignore[attr-defined]
+        elif w.startswith("melody"):
+            out["melody"] = w
+        elif w.startswith("bass"):
+            out["bass"] = w
+        elif w.startswith("chords:"):
+            out["chords"] = w
+        elif w.startswith("audio preprocess"):
+            out["preprocess"] = w
+    # Collapse cleanup list back to a string.
+    if "cleanup" in out and isinstance(out["cleanup"], list):
+        out["cleanup"] = "; ".join(out["cleanup"])  # type: ignore[index]
+    return out  # type: ignore[return-value]
+
+
+def _run_once(audio_path: Path, preprocess_enabled: bool) -> tuple[Any, float]:
+    """Run _run_basic_pitch_sync once with preprocess flag flipped."""
+    import backend.config as cfg
+    import backend.services.transcribe as T
+    from backend.config import Settings
+
+    # Build a fresh Settings instance with the flag overridden so env
+    # vars don't leak between runs.
+    old_settings = cfg.settings
+    override = Settings(audio_preprocess_enabled=preprocess_enabled)
+    cfg.settings = override
+    T.settings = override
+
+    try:
+        t0 = time.perf_counter()
+        result, _midi_bytes = T._run_basic_pitch_sync(audio_path)
+        elapsed = time.perf_counter() - t0
+        return result, elapsed
+    finally:
+        cfg.settings = old_settings
+        T.settings = old_settings
+
+
+def _role_counts(result: Any) -> dict[str, int]:
+    """Return {role_name: note_count} for each non-empty midi track."""
+    out: dict[str, int] = {}
+    for track in result.midi_tracks:
+        out[track.instrument.value] = len(track.notes)
+    return out
+
+
+def _bench_file(audio_path: Path) -> None:
+    print(f"\n=== {audio_path.name} ===")
+    if not audio_path.is_file():
+        print("  ! not a file, skipping")
+        return
+
+    try:
+        off_result, off_wall = _run_once(audio_path, preprocess_enabled=False)
+    except Exception as exc:
+        print(f"  ! preprocess OFF run failed: {exc}")
+        return
+
+    try:
+        on_result, on_wall = _run_once(audio_path, preprocess_enabled=True)
+    except Exception as exc:
+        print(f"  ! preprocess ON run failed: {exc}")
+        return
+
+    off_amps = _amps_from_result(off_result)
+    on_amps = _amps_from_result(on_result)
+    off_stats = _summarize_amps(off_amps)
+    on_stats = _summarize_amps(on_amps)
+
+    _print_header()
+    _print_row("wall time (s)", f"{off_wall:.2f}", f"{on_wall:.2f}")
+    _print_row("overall confidence",
+               f"{off_result.quality.overall_confidence:.2f}",
+               f"{on_result.quality.overall_confidence:.2f}")
+    _print_row("total notes", off_stats["n"], on_stats["n"])
+    _print_row("amp mean",
+               f"{off_stats['mean']:.3f}" if off_stats["n"] else "-",
+               f"{on_stats['mean']:.3f}" if on_stats["n"] else "-")
+    _print_row("amp median",
+               f"{off_stats['median']:.3f}" if off_stats["n"] else "-",
+               f"{on_stats['median']:.3f}" if on_stats["n"] else "-")
+    _print_row("amp p10",
+               f"{off_stats['p10']:.3f}" if off_stats["n"] else "-",
+               f"{on_stats['p10']:.3f}" if on_stats["n"] else "-")
+    _print_row("amp p90",
+               f"{off_stats['p90']:.3f}" if off_stats["n"] else "-",
+               f"{on_stats['p90']:.3f}" if on_stats["n"] else "-")
+
+    # Per-role counts.
+    off_roles = _role_counts(off_result)
+    on_roles = _role_counts(on_result)
+    all_roles = sorted(set(off_roles) | set(on_roles))
+    for role in all_roles:
+        _print_row(f"role: {role}",
+                   off_roles.get(role, 0),
+                   on_roles.get(role, 0))
+
+    # Stage-summary warnings (cleanup / melody / bass / chords / preprocess).
+    off_w = _extract_warning_summary(off_result)
+    on_w = _extract_warning_summary(on_result)
+    print()
+    for key in ("cleanup", "melody", "bass", "chords", "preprocess"):
+        if key in off_w or key in on_w:
+            print(f"  {key:<12}")
+            print(f"    OFF: {off_w.get(key, '-')}")
+            print(f"    ON:  {on_w.get(key, '-')}")
+
+    # Derived deltas for the three thresholds that matter.
+    print()
+    if off_stats["n"] and on_stats["n"]:
+        amp_shift = on_stats["mean"] - off_stats["mean"]
+        med_shift = on_stats["median"] - off_stats["median"]
+        count_shift = on_stats["n"] - off_stats["n"]
+        count_pct = 100.0 * count_shift / off_stats["n"]
+        print(f"  Δ amp mean:    {amp_shift:+.3f}")
+        print(f"  Δ amp median:  {med_shift:+.3f}")
+        print(f"  Δ note count:  {count_shift:+d} ({count_pct:+.1f}%)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "audio_paths",
+        nargs="+",
+        type=Path,
+        help="Audio file(s) to benchmark (WAV/MP3/M4A/etc.).",
+    )
+    args = parser.parse_args()
+
+    print("Benchmarking preprocess OFF vs ON")
+    print("Note: same model, same thresholds; only audio_preprocess_enabled differs.")
+
+    for path in args.audio_paths:
+        _bench_file(path)
+
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audio_preprocess.py
+++ b/tests/test_audio_preprocess.py
@@ -1,0 +1,306 @@
+"""Unit tests for the audio pre-processing stage.
+
+Drives :mod:`backend.services.audio_preprocess` with synthetic
+sine + percussive impulse waveforms so we can verify HPSS actually
+strips transients and RMS normalization hits its target. Tests skip
+gracefully when librosa is missing — mirroring the chord / melody /
+bass test modules.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+librosa = pytest.importorskip("librosa")
+soundfile = pytest.importorskip("soundfile")
+
+from backend.services.audio_preprocess import (  # noqa: E402
+    DEFAULT_PEAK_CEILING_DBFS,
+    DEFAULT_TARGET_RMS_DBFS,
+    PreprocessStats,
+    _peak_dbfs,
+    _rms_dbfs,
+    preprocess_audio_file,
+    preprocess_waveform,
+)
+
+SR = 22050
+
+
+# ---------------------------------------------------------------------------
+# Synthetic waveform helpers
+# ---------------------------------------------------------------------------
+
+def _sine(freq_hz: float, duration_sec: float, amp: float = 0.3) -> np.ndarray:
+    n = int(round(SR * duration_sec))
+    t = np.arange(n, dtype=np.float32) / SR
+    return (amp * np.sin(2.0 * np.pi * freq_hz * t)).astype(np.float32)
+
+
+def _impulse_train(duration_sec: float, period_sec: float, amp: float = 0.8) -> np.ndarray:
+    """A sparse impulse train — pure percussive content for HPSS to strip."""
+    n = int(round(SR * duration_sec))
+    y = np.zeros(n, dtype=np.float32)
+    step = max(1, int(round(SR * period_sec)))
+    y[::step] = amp
+    return y
+
+
+def _mixed_signal(duration_sec: float = 2.0) -> np.ndarray:
+    """Sine (harmonic) + impulse train (percussive) — the canonical HPSS fixture."""
+    harmonic = _sine(440.0, duration_sec, amp=0.2)
+    percussive = _impulse_train(duration_sec, period_sec=0.25, amp=0.6)
+    return (harmonic + percussive).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Math helpers
+# ---------------------------------------------------------------------------
+
+def test_rms_dbfs_silence_is_negative_infinity():
+    y = np.zeros(SR, dtype=np.float32)
+    assert _rms_dbfs(y) == float("-inf")
+
+
+def test_rms_dbfs_full_scale_is_zero():
+    y = np.ones(SR, dtype=np.float32)  # all-ones → RMS = 1.0 = 0 dBFS
+    assert _rms_dbfs(y) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_peak_dbfs_matches_max_abs():
+    y = np.array([0.0, 0.5, -0.25, 0.1], dtype=np.float32)
+    assert _peak_dbfs(y) == pytest.approx(20.0 * math.log10(0.5), abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# preprocess_waveform — core logic on in-memory arrays
+# ---------------------------------------------------------------------------
+
+def test_preprocess_waveform_skipped_when_both_passes_disabled():
+    y = _mixed_signal()
+    out, stats = preprocess_waveform(
+        y, SR, hpss_enabled=False, normalize_enabled=False,
+    )
+    assert stats.skipped
+    assert not stats.hpss_applied
+    assert not stats.normalize_applied
+    # Signal passes through unchanged.
+    np.testing.assert_array_equal(out, y)
+
+
+def test_preprocess_waveform_skips_tiny_input():
+    y = np.zeros(100, dtype=np.float32)  # ~4.5 ms at 22050 Hz
+    _, stats = preprocess_waveform(y, SR)
+    assert stats.skipped
+    assert any("too short" in w for w in stats.warnings)
+
+
+def test_preprocess_waveform_empty_input():
+    y = np.array([], dtype=np.float32)
+    _, stats = preprocess_waveform(y, SR)
+    assert stats.skipped
+
+
+def test_preprocess_waveform_hpss_reduces_percussive_energy():
+    """HPSS should drop the impulse-train component by a large margin.
+
+    We sum sine + impulse-train and verify the peak of the processed
+    signal is dramatically lower than the peak of the raw signal. A
+    sine-only waveform has peak ≈ amplitude (0.2); the raw mixed signal
+    has peak ≈ 0.6 (the impulse). After HPSS the impulses should be
+    gone and the peak should be back in sine-only territory.
+    """
+    y = _mixed_signal(duration_sec=2.0)
+    raw_peak = float(np.max(np.abs(y)))
+    assert raw_peak > 0.5, "fixture should have clear percussive spikes"
+
+    # Run HPSS only (no normalize) so we can compare absolute peaks.
+    out, stats = preprocess_waveform(
+        y, SR,
+        hpss_enabled=True,
+        normalize_enabled=False,
+        hpss_margin=3.0,  # aggressive enough to matter on a synthetic fixture
+    )
+    assert stats.hpss_applied
+    out_peak = float(np.max(np.abs(out)))
+    # Expect a meaningful reduction — impulses should be largely gone.
+    assert out_peak < raw_peak * 0.7, (
+        f"HPSS did not strip transients: raw peak {raw_peak:.3f}, out peak {out_peak:.3f}"
+    )
+
+
+def test_preprocess_waveform_normalize_hits_target_rms():
+    # Quiet sine → normalize should amplify to ~target RMS.
+    y = _sine(440.0, 2.0, amp=0.01)  # ~-43 dBFS RMS
+    _, stats = preprocess_waveform(
+        y, SR,
+        hpss_enabled=False,
+        normalize_enabled=True,
+        target_rms_dbfs=-20.0,
+        peak_ceiling_dbfs=-1.0,
+    )
+    assert stats.normalize_applied
+    assert stats.output_rms_dbfs is not None
+    # Target is -20 dBFS; allow a small margin for float precision.
+    assert stats.output_rms_dbfs == pytest.approx(-20.0, abs=0.5)
+    # Input was quieter than output — gain was positive.
+    assert stats.input_rms_dbfs is not None
+    assert stats.output_rms_dbfs > stats.input_rms_dbfs
+
+
+def test_preprocess_waveform_normalize_honors_peak_ceiling():
+    """A loud sine should be capped by the peak ceiling, not lifted to target RMS."""
+    # Already-hot input: peak at 0.95 (~ -0.45 dBFS), RMS ~ -3 dBFS.
+    # Asking for -3 dBFS RMS but with a -6 dBFS peak ceiling should
+    # *reduce* the signal — the ceiling wins.
+    y = _sine(440.0, 2.0, amp=0.95)
+    _, stats = preprocess_waveform(
+        y, SR,
+        hpss_enabled=False,
+        normalize_enabled=True,
+        target_rms_dbfs=-3.0,
+        peak_ceiling_dbfs=-6.0,
+    )
+    assert stats.normalize_applied
+    assert stats.output_peak_dbfs is not None
+    # Peak is at or below the ceiling (with a small tolerance).
+    assert stats.output_peak_dbfs <= -6.0 + 0.5
+
+
+def test_preprocess_waveform_normalize_skips_silence():
+    y = np.zeros(int(SR * 1.0), dtype=np.float32)
+    _, stats = preprocess_waveform(
+        y, SR,
+        hpss_enabled=False,
+        normalize_enabled=True,
+    )
+    assert not stats.normalize_applied
+    assert any("silent" in w for w in stats.warnings)
+
+
+def test_preprocess_waveform_records_input_output_levels():
+    y = _sine(440.0, 1.5, amp=0.1)
+    _, stats = preprocess_waveform(y, SR)
+    assert stats.input_rms_dbfs is not None
+    assert stats.output_rms_dbfs is not None
+    assert stats.input_peak_dbfs is not None
+    assert stats.output_peak_dbfs is not None
+    assert math.isfinite(stats.input_rms_dbfs)
+    assert math.isfinite(stats.output_rms_dbfs)
+
+
+# ---------------------------------------------------------------------------
+# PreprocessStats.as_warnings formatting
+# ---------------------------------------------------------------------------
+
+def test_as_warnings_skipped_includes_reason():
+    stats = PreprocessStats(skipped=True, warnings=["load failed: bad bytes"])
+    msgs = stats.as_warnings()
+    assert any("audio preprocess skipped" in m for m in msgs)
+    assert any("bad bytes" in m for m in msgs)
+
+
+def test_as_warnings_skipped_no_reason():
+    stats = PreprocessStats(skipped=True)
+    msgs = stats.as_warnings()
+    assert msgs == ["audio preprocess skipped"]
+
+
+def test_as_warnings_active_includes_rms_delta():
+    stats = PreprocessStats(
+        hpss_applied=True,
+        normalize_applied=True,
+        input_rms_dbfs=-35.0,
+        output_rms_dbfs=-20.0,
+        input_peak_dbfs=-20.0,
+        output_peak_dbfs=-5.0,
+    )
+    msgs = stats.as_warnings()
+    joined = " ".join(msgs)
+    assert "hpss" in joined
+    assert "rms" in joined
+    assert "-35.0" in joined
+    assert "-20.0" in joined
+
+
+# ---------------------------------------------------------------------------
+# preprocess_audio_file — file-path entry point
+# ---------------------------------------------------------------------------
+
+def test_preprocess_audio_file_roundtrips_through_disk(tmp_path: Path):
+    # Write a fixture WAV to disk, run the file-path entry point, then
+    # load the output and check RMS.
+    y = _sine(440.0, 1.5, amp=0.02)
+    src = tmp_path / "quiet.wav"
+    soundfile.write(str(src), y, SR, subtype="FLOAT")
+
+    out_path, stats = preprocess_audio_file(
+        src,
+        hpss_enabled=False,   # isolate the normalization path for this test
+        normalize_enabled=True,
+        target_rms_dbfs=-20.0,
+    )
+    assert not stats.skipped
+    assert stats.normalize_applied
+    # A new file was written (not the original path).
+    assert out_path != src
+    assert out_path.exists()
+
+    # Load back and verify the output hit target RMS within tolerance.
+    out_y, out_sr = soundfile.read(str(out_path), dtype="float32")
+    assert out_sr == SR
+    rms = float(np.sqrt(np.mean(np.square(out_y, dtype=np.float64))))
+    measured_dbfs = 20.0 * math.log10(rms)
+    assert measured_dbfs == pytest.approx(-20.0, abs=0.5)
+
+    # Caller owns cleanup.
+    out_path.unlink()
+
+
+def test_preprocess_audio_file_returns_original_on_skipped(tmp_path: Path):
+    y = _sine(440.0, 1.5, amp=0.1)
+    src = tmp_path / "in.wav"
+    soundfile.write(str(src), y, SR, subtype="FLOAT")
+
+    out_path, stats = preprocess_audio_file(
+        src, hpss_enabled=False, normalize_enabled=False,
+    )
+    assert stats.skipped
+    # No temp file written — returns the input path unchanged so the
+    # caller's "unlink if different" check is correct.
+    assert out_path == src
+
+
+def test_preprocess_audio_file_skips_unreadable_file(tmp_path: Path):
+    bogus = tmp_path / "not-audio.wav"
+    bogus.write_bytes(b"\x00\x01\x02not a wav file at all")
+
+    out_path, stats = preprocess_audio_file(bogus)
+    assert stats.skipped
+    assert out_path == bogus
+    assert any("load failed" in w for w in stats.warnings)
+
+
+def test_preprocess_audio_file_missing_file(tmp_path: Path):
+    ghost = tmp_path / "does-not-exist.wav"
+    out_path, stats = preprocess_audio_file(ghost)
+    assert stats.skipped
+    assert out_path == ghost
+
+
+# ---------------------------------------------------------------------------
+# Config defaults sanity check
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_match_module_defaults():
+    from backend.config import Settings
+
+    s = Settings()
+    # Off by default — opt-in until post-processing is retuned against
+    # preprocessed signal distribution.
+    assert s.audio_preprocess_enabled is False
+    assert s.audio_preprocess_target_rms_dbfs == DEFAULT_TARGET_RMS_DBFS
+    assert s.audio_preprocess_peak_ceiling_dbfs == DEFAULT_PEAK_CEILING_DBFS

--- a/tests/test_stem_separation.py
+++ b/tests/test_stem_separation.py
@@ -1,0 +1,362 @@
+"""Unit tests for the Demucs stem-separation stage.
+
+The real Demucs inference path is too expensive to exercise in the
+unit suite (htdemucs weights are ~80 MB and inference on a 30-second
+clip takes multiple seconds even on the fastest CPU), so the
+``separate_stems`` entry point is driven by monkeypatching the
+``demucs.apply.apply_model`` call — same pattern the cleanup /
+preprocess tests use to keep CI fast and deterministic.
+
+The bits we *do* exercise for real:
+  * :class:`StemSeparationStats.as_warnings` formatting on every
+    skipped / applied branch.
+  * :class:`SeparatedStems.cleanup` idempotency + tempdir removal.
+  * :func:`separate_stems` graceful degradation when the demucs
+    import fails (simulated by hiding the module from sys.modules).
+  * :func:`separate_stems` end-to-end via a monkeypatched model +
+    apply_model stub that returns a fake (S, C, T) tensor — verifies
+    the tempdir contract and the stem-routing.
+  * Config defaults wire up to the stem_separation module defaults.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.services.stem_separation import (
+    _MODEL_CACHE,
+    DEFAULT_MODEL_NAME,
+    DEFAULT_OVERLAP,
+    DEFAULT_SHIFTS,
+    SeparatedStems,
+    StemSeparationStats,
+    _pick_device,
+    separate_stems,
+)
+
+# ---------------------------------------------------------------------------
+# StemSeparationStats.as_warnings
+# ---------------------------------------------------------------------------
+
+def test_as_warnings_skipped_with_reason():
+    stats = StemSeparationStats(
+        skipped=True,
+        warnings=["missing dep: demucs"],
+    )
+    msgs = stats.as_warnings()
+    assert any("stem separation skipped" in m for m in msgs)
+    assert any("demucs" in m for m in msgs)
+
+
+def test_as_warnings_skipped_no_reason():
+    stats = StemSeparationStats(skipped=True)
+    assert stats.as_warnings() == ["stem separation skipped"]
+
+
+def test_as_warnings_active_includes_model_device_stems_time():
+    stats = StemSeparationStats(
+        model_name="htdemucs",
+        device="cpu",
+        wall_time_sec=12.3,
+        stems_written=["drums", "bass", "other", "vocals"],
+    )
+    msgs = stats.as_warnings()
+    joined = " ".join(msgs)
+    assert "htdemucs" in joined
+    assert "cpu" in joined
+    assert "drums" in joined and "vocals" in joined
+    assert "12.3" in joined
+
+
+def test_as_warnings_active_with_extra_warnings():
+    stats = StemSeparationStats(
+        model_name="htdemucs",
+        device="mps",
+        wall_time_sec=5.0,
+        stems_written=["vocals", "bass"],
+        warnings=["skipped 2 silent chunks"],
+    )
+    msgs = stats.as_warnings()
+    assert any("silent chunks" in m for m in msgs)
+    assert any("htdemucs" in m for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# SeparatedStems.cleanup
+# ---------------------------------------------------------------------------
+
+def test_cleanup_removes_tempdir_and_is_idempotent(tmp_path: Path):
+    # Set up a fake tempdir populated with stem WAV placeholders.
+    tempdir = tmp_path / "demucs-fake"
+    tempdir.mkdir()
+    for name in ("vocals", "bass", "drums", "other"):
+        (tempdir / f"{name}.wav").write_bytes(b"RIFF....WAVEfake")
+
+    stems = SeparatedStems(
+        vocals=tempdir / "vocals.wav",
+        bass=tempdir / "bass.wav",
+        drums=tempdir / "drums.wav",
+        other=tempdir / "other.wav",
+        _tempdir=tempdir,
+    )
+
+    assert tempdir.exists()
+    stems.cleanup()
+    assert not tempdir.exists()
+    # All slots are nilled so accidental reuse is obvious.
+    assert stems.vocals is None
+    assert stems.bass is None
+    assert stems.drums is None
+    assert stems.other is None
+    # Idempotent — second call is a no-op.
+    stems.cleanup()
+
+
+def test_cleanup_handles_missing_tempdir(tmp_path: Path):
+    ghost = tmp_path / "does-not-exist"
+    stems = SeparatedStems(_tempdir=ghost)
+    # Must not raise even though the tempdir was never created.
+    stems.cleanup()
+    assert stems._tempdir is None
+
+
+def test_cleanup_noop_when_tempdir_never_set():
+    stems = SeparatedStems()
+    stems.cleanup()
+    assert stems._tempdir is None
+
+
+# ---------------------------------------------------------------------------
+# _pick_device
+# ---------------------------------------------------------------------------
+
+def test_pick_device_honors_explicit_preference():
+    # Explicit "cpu" short-circuits all probing — safe on any host.
+    assert _pick_device("cpu") == "cpu"
+    assert _pick_device("cuda") == "cuda"
+    assert _pick_device("mps") == "mps"
+
+
+def test_pick_device_falls_back_to_cpu_when_torch_missing(monkeypatch):
+    # Hide torch so the import fails inside _pick_device.
+    monkeypatch.setitem(sys.modules, "torch", None)
+    assert _pick_device(None) == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# separate_stems — graceful degradation
+# ---------------------------------------------------------------------------
+
+def test_separate_stems_missing_file(tmp_path: Path):
+    ghost = tmp_path / "not-there.wav"
+    stems, stats = separate_stems(ghost)
+    assert stems is None
+    assert stats.skipped
+    assert any("missing" in w for w in stats.warnings)
+
+
+def test_separate_stems_graceful_on_missing_demucs(tmp_path: Path, monkeypatch):
+    """When demucs can't be imported we skip cleanly."""
+    # Build a placeholder audio file — separate_stems checks is_file()
+    # *before* touching deps, but the graceful-skip path runs during
+    # the late import.
+    audio = tmp_path / "in.wav"
+    audio.write_bytes(b"RIFF0000WAVEfake")
+
+    # Hide one of the demucs modules so the late import raises.
+    monkeypatch.setitem(sys.modules, "demucs.apply", None)
+
+    stems, stats = separate_stems(audio)
+    assert stems is None
+    assert stats.skipped
+    assert any("missing dep" in w for w in stats.warnings)
+
+
+# ---------------------------------------------------------------------------
+# separate_stems — happy path via monkeypatched demucs internals
+# ---------------------------------------------------------------------------
+
+class _FakeAudioFile:
+    """Stand-in for ``demucs.audio.AudioFile`` — just yields a tensor."""
+    def __init__(self, path):
+        self._path = path
+
+    def read(self, streams: int = 0, samplerate: int = 44_100, channels: int = 2):
+        import torch
+        # 2-channel, 1-second fake waveform at the requested samplerate.
+        return torch.randn(channels, samplerate)
+
+
+def _install_fake_demucs(monkeypatch, stem_names):
+    """Install a fake demucs.{apply, audio, pretrained} trio.
+
+    ``apply_model`` returns a tensor shaped ``(1, S, C, T)`` with one
+    source per ``stem_names`` entry, so the caller sees the normal
+    Demucs contract. ``save_audio`` writes a one-byte placeholder to
+    each stem path so the cleanup path has something to remove.
+    """
+    torch = pytest.importorskip("torch")
+
+    class FakeModel:
+        samplerate = 44_100
+        audio_channels = 2
+        sources = list(stem_names)
+
+        def eval(self):
+            return self
+
+        def to(self, *_args, **_kwargs):
+            return self
+
+    def fake_get_model(name: str):
+        return FakeModel()
+
+    def fake_apply_model(model, mix, **_kwargs):
+        # mix shape: (B, C, T). Return (B, S, C, T) all zeros.
+        b, c, t = mix.shape
+        s = len(model.sources)
+        return torch.zeros((b, s, c, t))
+
+    def fake_save_audio(source, path, **_kwargs):
+        Path(path).write_bytes(b"\x00")
+
+    fake_apply = SimpleNamespace(apply_model=fake_apply_model)
+    fake_audio = SimpleNamespace(AudioFile=_FakeAudioFile, save_audio=fake_save_audio)
+    fake_pretrained = SimpleNamespace(get_model=fake_get_model)
+
+    monkeypatch.setitem(sys.modules, "demucs.apply", fake_apply)
+    monkeypatch.setitem(sys.modules, "demucs.audio", fake_audio)
+    monkeypatch.setitem(sys.modules, "demucs.pretrained", fake_pretrained)
+    # Blow the process-wide model cache so our fake get_model is
+    # actually called — otherwise a real demucs run from a previous
+    # test would still be cached.
+    _MODEL_CACHE.clear()
+
+
+def test_separate_stems_happy_path_four_stems(tmp_path: Path, monkeypatch):
+    """All four stems are written and routed onto the SeparatedStems slots."""
+    pytest.importorskip("torch")
+
+    audio = tmp_path / "in.wav"
+    audio.write_bytes(b"RIFF" + b"\x00" * 100)
+
+    _install_fake_demucs(
+        monkeypatch, ["drums", "bass", "other", "vocals"],
+    )
+
+    stems, stats = separate_stems(audio, device="cpu")
+
+    try:
+        assert stems is not None
+        assert not stats.skipped
+        assert stats.model_name == DEFAULT_MODEL_NAME
+        assert stats.device == "cpu"
+        assert set(stats.stems_written) == {"drums", "bass", "other", "vocals"}
+
+        assert stems.vocals is not None and stems.vocals.exists()
+        assert stems.bass is not None and stems.bass.exists()
+        assert stems.drums is not None and stems.drums.exists()
+        assert stems.other is not None and stems.other.exists()
+
+        # All stems live in the same tempdir so cleanup can rmtree them.
+        assert stems._tempdir is not None
+        assert stems.vocals.parent == stems._tempdir
+        assert stems.bass.parent == stems._tempdir
+    finally:
+        if stems is not None:
+            stems.cleanup()
+
+
+def test_separate_stems_two_stem_bag_leaves_missing_slots_none(
+    tmp_path: Path, monkeypatch,
+):
+    """A custom 2-source bag still works — missing stems stay None."""
+    pytest.importorskip("torch")
+
+    audio = tmp_path / "in.wav"
+    audio.write_bytes(b"RIFF" + b"\x00" * 100)
+
+    # Only vocals + accompaniment (non-standard but valid — tests the
+    # per-slot None fallback without needing a real 2-stem model).
+    _install_fake_demucs(monkeypatch, ["vocals", "other"])
+
+    stems, stats = separate_stems(audio, device="cpu")
+
+    try:
+        assert stems is not None
+        assert not stats.skipped
+        assert stems.vocals is not None
+        assert stems.other is not None
+        # Bass / drums aren't emitted by this fake bag.
+        assert stems.bass is None
+        assert stems.drums is None
+    finally:
+        if stems is not None:
+            stems.cleanup()
+
+
+def test_separate_stems_apply_failure_skips_cleanly(tmp_path: Path, monkeypatch):
+    """apply_model raising must leave no tempdir behind and set skipped."""
+    pytest.importorskip("torch")
+
+    audio = tmp_path / "in.wav"
+    audio.write_bytes(b"RIFF" + b"\x00" * 100)
+
+    class FakeModel:
+        samplerate = 44_100
+        audio_channels = 2
+        sources = ["drums", "bass", "other", "vocals"]
+
+        def eval(self):
+            return self
+
+    def fake_get_model(name):
+        return FakeModel()
+
+    def fake_apply_model(model, mix, **_kwargs):
+        raise RuntimeError("CUDA OOM")
+
+    def fake_save_audio(*_args, **_kwargs):
+        raise AssertionError("save_audio should not be reached")
+
+    fake_apply = SimpleNamespace(apply_model=fake_apply_model)
+    fake_audio = SimpleNamespace(AudioFile=_FakeAudioFile, save_audio=fake_save_audio)
+    fake_pretrained = SimpleNamespace(get_model=fake_get_model)
+
+    monkeypatch.setitem(sys.modules, "demucs.apply", fake_apply)
+    monkeypatch.setitem(sys.modules, "demucs.audio", fake_audio)
+    monkeypatch.setitem(sys.modules, "demucs.pretrained", fake_pretrained)
+    _MODEL_CACHE.clear()
+
+    stems, stats = separate_stems(audio, device="cpu")
+    assert stems is None
+    assert stats.skipped
+    assert any("apply failed" in w for w in stats.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Config defaults sanity check
+# ---------------------------------------------------------------------------
+
+def test_config_defaults_match_module_defaults():
+    from backend.config import Settings
+
+    s = Settings()
+    # On by default — the stems path is the preferred pipeline, with
+    # a transparent fallback to the single-mix path when demucs/torch
+    # aren't installed. Commercial deployments that can't use the
+    # CC BY-NC htdemucs weights must opt out via
+    # OHSHEET_DEMUCS_ENABLED=0.
+    assert s.demucs_enabled is True
+    assert s.demucs_model == DEFAULT_MODEL_NAME
+    assert s.demucs_shifts == DEFAULT_SHIFTS
+    assert s.demucs_overlap == DEFAULT_OVERLAP
+    # Per-consumer flags default on so flipping demucs_enabled alone
+    # wires up all four stems without further config work.
+    assert s.demucs_use_vocals_for_melody is True
+    assert s.demucs_use_bass_stem is True
+    assert s.demucs_use_other_for_chords is True
+    assert s.demucs_use_drums_for_beats is True

--- a/tests/test_transcribe_stems.py
+++ b/tests/test_transcribe_stems.py
@@ -43,14 +43,14 @@ import pytest
 # etc.
 pretty_midi = pytest.importorskip("pretty_midi")
 
-from backend.contracts import InstrumentRole
-from backend.services import transcribe as transcribe_mod
-from backend.services.stem_separation import SeparatedStems, StemSeparationStats
-from backend.services.transcribe import (
+from backend.contracts import InstrumentRole  # noqa: E402
+from backend.services import transcribe as transcribe_mod  # noqa: E402
+from backend.services.stem_separation import SeparatedStems, StemSeparationStats  # noqa: E402
+from backend.services.transcribe import (  # noqa: E402
     _BasicPitchPass,
     _run_with_stems,
 )
-from backend.services.transcription_cleanup import CleanupStats
+from backend.services.transcription_cleanup import CleanupStats  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # helpers

--- a/tests/test_transcribe_stems.py
+++ b/tests/test_transcribe_stems.py
@@ -34,8 +34,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pretty_midi
 import pytest
+
+# pretty_midi ships with the ``basic-pitch`` extra, not with ``dev``, so
+# CI runs that only install ``.[dev]`` must skip this whole module
+# rather than error out during collection. Matches the importorskip
+# convention used in test_bass_extraction.py, test_melody_extraction.py,
+# etc.
+pretty_midi = pytest.importorskip("pretty_midi")
 
 from backend.contracts import InstrumentRole
 from backend.services import transcribe as transcribe_mod
@@ -142,10 +148,11 @@ def test_basic_pitch_single_pass_drops_model_output_when_asked(monkeypatch, tmp_
         pass
 
     # Stub basic_pitch.inference.predict to return our fake output
-    # without touching disk. Basic Pitch's package is installed in
-    # this environment so we can import + patch directly.
-    import basic_pitch.inference as bp_inf
-    import basic_pitch.note_creation as bp_nc
+    # without touching disk. Skip if basic_pitch isn't installed —
+    # pretty_midi can technically be present without basic_pitch even
+    # though the extras group bundles them together.
+    bp_inf = pytest.importorskip("basic_pitch.inference")
+    bp_nc = pytest.importorskip("basic_pitch.note_creation")
     monkeypatch.setattr(
         bp_inf,
         "predict",

--- a/tests/test_transcribe_stems.py
+++ b/tests/test_transcribe_stems.py
@@ -1,0 +1,384 @@
+"""Unit tests for the stems-path orchestration in ``TranscribeService``.
+
+The real Basic Pitch inference is too heavy to exercise in the unit
+suite (see ``test_stem_separation.py`` for the same rationale applied
+to Demucs), so these tests monkeypatch ``_basic_pitch_single_pass``
+and the audio-facing helpers (``tempo_map_from_audio_path``,
+``recognize_chords``) to drive ``_run_with_stems`` with deterministic
+fakes.
+
+Covered behaviors:
+
+* ``_basic_pitch_single_pass(path, keep_model_output=False)`` drops
+  the contour tensor before returning — the review pointed out that
+  the stems path kept three live ``model_output`` dicts alive
+  simultaneously, and this is the guardrail that proves we fixed it.
+* ``_run_with_stems`` parallel path succeeds, populates all three
+  per-role event lists, and never consults ``model_output``
+  downstream (we prove this by passing an empty dict — a real
+  ``model_output.get("note")`` would raise on a plain dict, but the
+  ``events_by_role`` guard makes the branch unreachable).
+* One stem raising inside the worker does not sink the other two —
+  exception isolation matches the pre-parallel behavior.
+* ``demucs_parallel_stems=False`` produces the same result as the
+  parallel path (serial fallback is a 1:1 substitute).
+
+We do **not** test Basic Pitch thread-safety directly here — ONNX
+Runtime / CoreML session thread-safety is an upstream contract and
+would require a real model to exercise. The parallel-path test just
+verifies that the orchestrator correctly submits jobs, gathers
+results in submission order, and survives per-worker exceptions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pretty_midi
+import pytest
+
+from backend.contracts import InstrumentRole
+from backend.services import transcribe as transcribe_mod
+from backend.services.stem_separation import SeparatedStems, StemSeparationStats
+from backend.services.transcribe import (
+    _BasicPitchPass,
+    _run_with_stems,
+)
+from backend.services.transcription_cleanup import CleanupStats
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_pass(
+    label: str,
+    *,
+    model_output: dict[str, Any] | None = None,
+) -> _BasicPitchPass:
+    """Build a fake ``_BasicPitchPass`` shaped like the real thing.
+
+    ``cleaned_events`` carries one note per label so the assertions
+    can tell the three stems apart. The note amplitudes (0.5) keep
+    ``overall_conf`` away from both saturation rails so a confidence
+    assertion stays meaningful if anything downstream uses it.
+    """
+    # (start_sec, end_sec, pitch_midi, amplitude, pitch_bend)
+    pitch = {"vocals": 72, "bass": 36, "other": 60}[label]
+    note = (0.0, 0.5, pitch, 0.5, None)
+    pm = pretty_midi.PrettyMIDI()
+    return _BasicPitchPass(
+        cleaned_events=[note],
+        model_output=model_output if model_output is not None else {},
+        midi_data=pm,
+        preprocess_stats=None,
+        cleanup_stats=CleanupStats(input_count=1, output_count=1),
+    )
+
+
+def _make_stems(tmp_path: Path) -> SeparatedStems:
+    """A ``SeparatedStems`` with four placeholder wav files.
+
+    The files don't need to be valid audio — our monkeypatched
+    ``_basic_pitch_single_pass`` never actually opens them. The real
+    paths exist so ``Path`` attribute access is happy.
+    """
+    tempdir = tmp_path / "stems"
+    tempdir.mkdir()
+    paths = {}
+    for name in ("vocals", "bass", "other", "drums"):
+        p = tempdir / f"{name}.wav"
+        p.write_bytes(b"\x00")
+        paths[name] = p
+    return SeparatedStems(
+        vocals=paths["vocals"],
+        bass=paths["bass"],
+        other=paths["other"],
+        drums=paths["drums"],
+        _tempdir=tempdir,
+    )
+
+
+@pytest.fixture
+def stub_audio_helpers(monkeypatch):
+    """Silence the audio-only stages — tempo + chord recog.
+
+    Both are invoked unconditionally on the stems path (gated only
+    by ``chord_recognition_enabled``), and both hit librosa on a
+    real file. We stub them so the test stays pure.
+    """
+    monkeypatch.setattr(
+        transcribe_mod, "tempo_map_from_audio_path", lambda _path: None
+    )
+
+    def fake_recognize_chords(_path, **_kwargs):
+        from backend.services.chord_recognition import ChordRecognitionStats
+        return [], ChordRecognitionStats(skipped=True)
+
+    monkeypatch.setattr(transcribe_mod, "recognize_chords", fake_recognize_chords)
+
+
+# ---------------------------------------------------------------------------
+# _basic_pitch_single_pass — keep_model_output kwarg
+# ---------------------------------------------------------------------------
+
+def test_basic_pitch_single_pass_drops_model_output_when_asked(monkeypatch, tmp_path):
+    """``keep_model_output=False`` replaces the dict contents with nothing.
+
+    We stub ``predict`` and the cleanup helpers so we don't need a
+    real Basic Pitch model. The assertion is specifically that the
+    returned ``_BasicPitchPass.model_output`` is empty (``.clear()``
+    has run) — this is the "stems path doesn't keep the contour
+    tensor alive" guarantee the review asked for.
+    """
+    import numpy as np
+    big_contour = np.zeros((100, 88), dtype=np.float32)
+    mock_output = {
+        "note": np.zeros((100, 88), dtype=np.float32),
+        "onset": np.zeros((100, 88), dtype=np.float32),
+        "contour": big_contour,
+    }
+
+    class _FakePM:
+        pass
+
+    # Stub basic_pitch.inference.predict to return our fake output
+    # without touching disk. Basic Pitch's package is installed in
+    # this environment so we can import + patch directly.
+    import basic_pitch.inference as bp_inf
+    import basic_pitch.note_creation as bp_nc
+    monkeypatch.setattr(
+        bp_inf,
+        "predict",
+        lambda *_args, **_kwargs: (mock_output, _FakePM(), []),
+    )
+    monkeypatch.setattr(
+        bp_nc,
+        "note_events_to_midi",
+        lambda _events, *_a, **_kw: _FakePM(),
+    )
+    # Short-circuit the preprocess stage — the real one reads audio.
+    from backend.config import settings
+    monkeypatch.setattr(settings, "audio_preprocess_enabled", False)
+    # Skip the model load — ``predict`` is mocked so the model is
+    # never consulted, but ``_load_basic_pitch_model`` would still
+    # try to import and build the real one.
+    monkeypatch.setattr(transcribe_mod, "_load_basic_pitch_model", lambda: object())
+
+    audio_path = tmp_path / "fake.wav"
+    audio_path.write_bytes(b"\x00")
+
+    pass_kept = transcribe_mod._basic_pitch_single_pass(
+        audio_path, keep_model_output=True,
+    )
+    assert pass_kept.model_output is mock_output  # identity: no copy
+    assert "contour" in pass_kept.model_output
+
+    # Reset — the previous call called .clear() paths are exercised
+    # only when keep_model_output=False, but the same mock_output
+    # dict was mutated above if we hit the clear path. Rebuild it.
+    mock_output2 = {
+        "note": np.zeros((10, 88), dtype=np.float32),
+        "onset": np.zeros((10, 88), dtype=np.float32),
+        "contour": np.zeros((10, 88), dtype=np.float32),
+    }
+    monkeypatch.setattr(
+        bp_inf,
+        "predict",
+        lambda *_args, **_kwargs: (mock_output2, _FakePM(), []),
+    )
+    pass_dropped = transcribe_mod._basic_pitch_single_pass(
+        audio_path, keep_model_output=False,
+    )
+    assert pass_dropped.model_output == {}  # contour tensor unreferenced
+    # And the original dict was cleared in place (local name), so
+    # nothing held a reference to the contour array.
+    assert mock_output2 == {}
+
+
+# ---------------------------------------------------------------------------
+# _run_with_stems — parallel happy path
+# ---------------------------------------------------------------------------
+
+def test_run_with_stems_parallel_populates_all_three_roles(
+    monkeypatch, tmp_path, stub_audio_helpers,
+):
+    """Parallel path: three stems in, three roles out."""
+    stems = _make_stems(tmp_path)
+    stem_stats = StemSeparationStats(
+        model_name="htdemucs",
+        device="cpu",
+        wall_time_sec=0.0,
+        stems_written=["vocals", "bass", "other", "drums"],
+    )
+
+    call_log: list[str] = []
+
+    def fake_pass(stem_path: Path, *, keep_model_output: bool = True):
+        # The stems path must always pass keep_model_output=False so
+        # the contour tensor can be GC'd as soon as each stem
+        # finishes. The review explicitly called this out.
+        assert keep_model_output is False, (
+            "stems path must call _basic_pitch_single_pass with "
+            "keep_model_output=False so the contour tensor doesn't "
+            "pin memory across all three concurrent passes"
+        )
+        label = stem_path.stem
+        call_log.append(label)
+        return _make_pass(label)
+
+    monkeypatch.setattr(transcribe_mod, "_basic_pitch_single_pass", fake_pass)
+
+    from backend.config import settings
+    monkeypatch.setattr(settings, "demucs_parallel_stems", True)
+    monkeypatch.setattr(settings, "chord_recognition_enabled", False)
+
+    audio_path = tmp_path / "mix.wav"
+    audio_path.write_bytes(b"\x00")
+
+    result, _midi_bytes = _run_with_stems(audio_path, stems, stem_stats)
+
+    # All three consumer stems were invoked — order is
+    # submission-order (vocals/bass/other) but we don't assert on
+    # order because ThreadPoolExecutor.map() schedules eagerly and
+    # the test would be flaky on that axis.
+    assert set(call_log) == {"vocals", "bass", "other"}
+
+    roles = {t.instrument for t in result.midi_tracks}
+    assert InstrumentRole.MELODY in roles
+    assert InstrumentRole.BASS in roles
+    assert InstrumentRole.CHORDS in roles
+    # No PIANO fallback — the stems path routes every note directly.
+    assert InstrumentRole.PIANO not in roles
+
+
+# ---------------------------------------------------------------------------
+# _run_with_stems — one stem raising must not poison the others
+# ---------------------------------------------------------------------------
+
+def test_run_with_stems_isolates_per_stem_failures(
+    monkeypatch, tmp_path, stub_audio_helpers,
+):
+    """One worker raising leaves the other two roles intact."""
+    stems = _make_stems(tmp_path)
+    stem_stats = StemSeparationStats(stems_written=["vocals", "bass", "other", "drums"])
+
+    def fake_pass(stem_path: Path, *, keep_model_output: bool = True):
+        if stem_path.stem == "bass":
+            raise RuntimeError("simulated BP OOM on bass stem")
+        return _make_pass(stem_path.stem)
+
+    monkeypatch.setattr(transcribe_mod, "_basic_pitch_single_pass", fake_pass)
+
+    from backend.config import settings
+    monkeypatch.setattr(settings, "demucs_parallel_stems", True)
+    monkeypatch.setattr(settings, "chord_recognition_enabled", False)
+
+    audio_path = tmp_path / "mix.wav"
+    audio_path.write_bytes(b"\x00")
+
+    result, _ = _run_with_stems(audio_path, stems, stem_stats)
+
+    roles = {t.instrument for t in result.midi_tracks}
+    assert InstrumentRole.MELODY in roles   # vocals survived
+    assert InstrumentRole.CHORDS in roles   # other survived
+    assert InstrumentRole.BASS not in roles  # bass worker raised
+
+
+# ---------------------------------------------------------------------------
+# _run_with_stems — serial fallback matches parallel output
+# ---------------------------------------------------------------------------
+
+def test_run_with_stems_serial_mode_matches_parallel(
+    monkeypatch, tmp_path, stub_audio_helpers,
+):
+    """``demucs_parallel_stems=False`` still produces the same roles.
+
+    This is the escape hatch for debugging single-thread traces.
+    It should be a behavioral no-op — only the scheduling differs.
+    """
+    stems = _make_stems(tmp_path)
+    stem_stats = StemSeparationStats(stems_written=["vocals", "bass", "other", "drums"])
+
+    def fake_pass(stem_path: Path, *, keep_model_output: bool = True):
+        return _make_pass(stem_path.stem)
+
+    monkeypatch.setattr(transcribe_mod, "_basic_pitch_single_pass", fake_pass)
+
+    from backend.config import settings
+    monkeypatch.setattr(settings, "demucs_parallel_stems", False)
+    monkeypatch.setattr(settings, "chord_recognition_enabled", False)
+
+    audio_path = tmp_path / "mix.wav"
+    audio_path.write_bytes(b"\x00")
+
+    result, _ = _run_with_stems(audio_path, stems, stem_stats)
+
+    roles = {t.instrument for t in result.midi_tracks}
+    assert roles == {InstrumentRole.MELODY, InstrumentRole.BASS, InstrumentRole.CHORDS}
+
+
+# ---------------------------------------------------------------------------
+# _run_with_stems — all stems empty should fall back to single-mix
+# ---------------------------------------------------------------------------
+
+def test_run_with_stems_all_empty_falls_back_to_single_mix(
+    monkeypatch, tmp_path, stub_audio_helpers,
+):
+    """If every stem returns zero notes, fall back to the legacy pipeline.
+
+    This is the existing ``all stems empty`` guard — we verify the
+    parallel refactor didn't accidentally remove it.
+    """
+    stems = _make_stems(tmp_path)
+    stem_stats = StemSeparationStats(stems_written=["vocals", "bass", "other", "drums"])
+
+    def fake_pass(stem_path: Path, *, keep_model_output: bool = True):
+        p = _make_pass(stem_path.stem)
+        p.cleaned_events = []  # empty — forces the fallback branch
+        return p
+
+    monkeypatch.setattr(transcribe_mod, "_basic_pitch_single_pass", fake_pass)
+
+    # Intercept the fallback so we can verify it was called without
+    # actually running the single-mix Basic Pitch pipeline.
+    called = {"fallback": False}
+
+    def fake_single_mix(audio_path, stem_stats):
+        called["fallback"] = True
+        from backend.contracts import (
+            SCHEMA_VERSION,
+            HarmonicAnalysis,
+            QualitySignal,
+            TempoMapEntry,
+            TranscriptionResult,
+        )
+        return (
+            TranscriptionResult(
+                schema_version=SCHEMA_VERSION,
+                midi_tracks=[],
+                analysis=HarmonicAnalysis(
+                    key="C:major",
+                    time_signature=(4, 4),
+                    tempo_map=[TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)],
+                    chords=[],
+                    sections=[],
+                ),
+                quality=QualitySignal(overall_confidence=0.1, warnings=["fallback stub"]),
+            ),
+            None,
+        )
+
+    monkeypatch.setattr(transcribe_mod, "_run_without_stems", fake_single_mix)
+
+    from backend.config import settings
+    monkeypatch.setattr(settings, "demucs_parallel_stems", True)
+    monkeypatch.setattr(settings, "chord_recognition_enabled", False)
+
+    audio_path = tmp_path / "mix.wav"
+    audio_path.write_bytes(b"\x00")
+
+    _run_with_stems(audio_path, stems, stem_stats)
+    assert called["fallback"] is True
+    # The stem_stats should carry the warning marker so the
+    # QualitySignal explains why the stems path bailed.
+    assert any("all stems empty" in w for w in stem_stats.warnings)


### PR DESCRIPTION
## Summary
- Adds an opt-in **audio preprocessing** stage (`backend/services/audio_preprocess.py`) that runs HPSS harmonic extraction + RMS-normalize-with-peak-ceiling before Basic Pitch inference. Off by default — A/B deltas on the rising-sun fixtures are real but marginal (+0.00 to +0.04 confidence) so operators can flip it on per-corpus via `OHSHEET_AUDIO_PREPROCESS_ENABLED=1`.
- Adds **Demucs source separation** (`backend/services/stem_separation.py`) as a new pre-Basic-Pitch stage. On by default, gated behind a new `[demucs]` pyproject extra so default installs stay slim. Any failure (missing dep, load crash, apply OOM, all-stems-empty) transparently falls back to the single-mix Viterbi path.
- Rewires `TranscribeService._run_basic_pitch_sync` to dispatch between two pipelines:
  - **Demucs path** — one Basic Pitch pass per stem (vocals → MELODY, bass → BASS, other → CHORDS), drums → beat tracking, other → chord recognition. Skips the Viterbi melody/bass split (stems render it redundant).
  - **Single-mix path** — the existing preprocess → Basic Pitch → cleanup → Viterbi split → chords pipeline.
- Factors the shared preprocess+predict+cleanup into `_basic_pitch_single_pass` so the stems path can call it once per stem without duplicating boilerplate.
- Adds `scripts/bench_preprocess.py` A/B benchmark harness and unit tests for both new services.

## License note
The default `htdemucs` pretrained weights are CC BY-NC 4.0 (non-commercial). Commercial deployments must set `OHSHEET_DEMUCS_ENABLED=0` or swap in a commercially-licensed model. Documented inline in `pyproject.toml`, `Makefile`, and `backend/config.py`.

## Per-consumer escape hatches
Each routing is gated independently so a single noisy stem can be disabled without touching the others:
- `demucs_use_vocals_for_melody`
- `demucs_use_bass_stem`
- `demucs_use_other_for_chords`
- `demucs_use_drums_for_beats`

## Test plan
- [ ] `pytest tests/test_audio_preprocess.py tests/test_stem_separation.py` green on a box without the `[demucs]` extra (exercises the skipped/fallback paths).
- [ ] `pip install -e ".[demucs]"` then run `TranscribeService` end-to-end on a vocal track — verify all four stems produce non-empty notes and the blob MIDI serializes.
- [ ] Flip `OHSHEET_DEMUCS_ENABLED=0` and re-run; confirm single-mix path still produces identical output to `main`.
- [ ] Flip `OHSHEET_AUDIO_PREPROCESS_ENABLED=1` on a quiet rip; confirm the QualitySignal warnings show `audio preprocess: hpss, rms …→… dBFS`.
- [ ] Sanity-check `scripts/bench_preprocess.py` against `assets/rising-sun-*.mp3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)