### PR TITLE
fix: add pretty_midi and music21 to core deps

### DIFF
--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -62,7 +62,7 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
     try:
         import pretty_midi  # noqa: PLC0415 — optional dep
     except ImportError:
-        log.debug("pretty_midi unavailable; emitting stub MIDI")
+        log.warning("pretty_midi not installed — MIDI output will be a stub. Install with: pip install pretty_midi")
         return _STUB_MIDI
 
     tempo_map = perf.score.metadata.tempo_map
@@ -156,7 +156,7 @@ def _render_musicxml_bytes(
     try:
         import music21  # noqa: PLC0415 — optional heavy dep
     except ImportError:
-        log.debug("music21 unavailable; emitting minimal MusicXML")
+        log.warning("music21 not installed — MusicXML output will be a minimal stub. Install with: pip install music21")
         return _minimal_musicxml(score, title, composer)
 
     try:
@@ -311,6 +311,7 @@ def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
     if not (shutil.which("musescore4") or shutil.which("musescore3")
             or shutil.which("mscore") or shutil.which("MuseScore4")
             or (shutil.which("musicxml2ly") and shutil.which("lilypond"))):
+        log.warning("No PDF renderer found — install LilyPond or MuseScore for real PDF output")
         return _STUB_PDF
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "python-multipart>=0.0.9",
     "websockets>=12.0",
     "yt-dlp>=2024.1",
+    "pretty_midi>=0.2.10",
+    "music21>=9.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Move `pretty_midi` and `music21` from optional to core dependencies in `pyproject.toml`
- Upgrade engrave service fallback logs from DEBUG to WARNING so missing renderers are obvious in production

Both are required by the engrave service regardless of transcription model. Without them, the pipeline silently produces stub output (fake PDF, minimal MIDI).

## Test plan
- [x] All 91 backend tests pass
- [x] `pip install -e .` now installs both packages automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)