### PR TITLE
chore: update branding to 'Oh Sheet!' across frontend

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -29,7 +29,7 @@ class _OhSheetAppState extends State<OhSheetApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Oh Sheet',
+      title: 'Oh Sheet!',
       theme: OhSheetTheme.light,
       home: _AppShell(api: _api),
     );

--- a/frontend/lib/screens/progress_screen.dart
+++ b/frontend/lib/screens/progress_screen.dart
@@ -150,7 +150,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        title: const Text('Oh Sheet'),
+        title: const Text('Oh Sheet!'),
       ),
       body: SafeArea(
         child: OhSheetResponsiveBody(

--- a/frontend/lib/screens/result_screen.dart
+++ b/frontend/lib/screens/result_screen.dart
@@ -161,7 +161,7 @@ class ResultScreen extends StatelessWidget {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        title: const Text('Oh Sheet'),
+        title: const Text('Oh Sheet!'),
       ),
       body: SafeArea(
         child: OhSheetResponsiveBody(

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ohsheet_app
-description: Oh Sheet — cross-platform Flutter client for the FastAPI pipeline.
+description: Oh Sheet! — cross-platform Flutter client for the FastAPI pipeline.
 publish_to: 'none'
 version: 0.1.0+1
 

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Oh Sheet! — audio to piano sheet music.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="ohsheet_app">
+  <meta name="apple-mobile-web-app-title" content="Oh Sheet!">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>Oh Sheet</title>
+  <title>Oh Sheet!</title>
   <link rel="manifest" href="manifest.json">
 
   <!-- MIDI playback web component (Google Magenta) -->


### PR DESCRIPTION
## Summary
Add exclamation mark to app title, meta descriptions, and AppBar titles for consistent branding across the frontend.

**Files changed**: `main.dart`, `progress_screen.dart`, `result_screen.dart`, `pubspec.yaml`, `web/index.html`

## Test plan
- [x] Cosmetic change only — no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)