### PR TITLE
fix: use pre-built images in prod compose + expose commit SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ env:
   PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
   REGION: ${{ vars.GCP_REGION || 'us-central1' }}
   IMAGE: ${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/oh-sheet/app
+  IMAGE_DECOMPOSER: ${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/oh-sheet/decomposer
+  IMAGE_ASSEMBLER: ${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/oh-sheet/assembler
 
 jobs:
   deploy:
@@ -37,11 +39,19 @@ jobs:
       - name: Authorize Docker push
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      - name: Build and push container image
+      - name: Build and push container images
         run: |
           docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
           docker push ${{ env.IMAGE }}:${{ github.sha }}
           docker push ${{ env.IMAGE }}:latest
+
+          docker build -t ${{ env.IMAGE_DECOMPOSER }}:${{ github.sha }} -t ${{ env.IMAGE_DECOMPOSER }}:latest -f svc-decomposer/Dockerfile .
+          docker push ${{ env.IMAGE_DECOMPOSER }}:${{ github.sha }}
+          docker push ${{ env.IMAGE_DECOMPOSER }}:latest
+
+          docker build -t ${{ env.IMAGE_ASSEMBLER }}:${{ github.sha }} -t ${{ env.IMAGE_ASSEMBLER }}:latest -f svc-assembler/Dockerfile .
+          docker push ${{ env.IMAGE_ASSEMBLER }}:${{ github.sha }}
+          docker push ${{ env.IMAGE_ASSEMBLER }}:latest
 
       - name: Deploy to VM
         env:
@@ -60,6 +70,8 @@ jobs:
 
           # Write .env with the image tag and commit SHA for docker compose
           echo "IMAGE=${{ env.IMAGE }}:${{ github.sha }}" > /tmp/.env
+          echo "IMAGE_DECOMPOSER=${{ env.IMAGE_DECOMPOSER }}:${{ github.sha }}" >> /tmp/.env
+          echo "IMAGE_ASSEMBLER=${{ env.IMAGE_ASSEMBLER }}:${{ github.sha }}" >> /tmp/.env
           echo "COMMIT_SHA=${{ github.sha }}" >> /tmp/.env
 
           # Copy compose files to VM (SCP .env to temp name, then atomic mv)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
       retries: 5
 
   orchestrator:
-    build: .
+    image: ${IMAGE}
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 2
     restart: unless-stopped
     ports:
@@ -37,7 +37,7 @@ services:
       start_period: 10s
 
   worker-ingest:
-    build: .
+    image: ${IMAGE}
     command: celery -A backend.workers.celery_app worker -Q ingest -c 1 --loglevel=warning
     restart: unless-stopped
     environment:
@@ -50,7 +50,7 @@ services:
         condition: service_healthy
 
   worker-transcribe:
-    build: .
+    image: ${IMAGE}
     command: celery -A backend.workers.celery_app worker -Q transcribe -c 1 --loglevel=warning
     restart: unless-stopped
     environment:
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
 
   worker-arrange:
-    build: .
+    image: ${IMAGE}
     command: celery -A backend.workers.celery_app worker -Q arrange -c 1 --loglevel=warning
     restart: unless-stopped
     environment:
@@ -76,9 +76,7 @@ services:
         condition: service_healthy
 
   worker-decomposer:
-    build:
-      context: .
-      dockerfile: svc-decomposer/Dockerfile
+    image: ${IMAGE_DECOMPOSER}
     restart: unless-stopped
     environment:
       OHSHEET_BLOB_ROOT: /app/blob
@@ -90,9 +88,7 @@ services:
         condition: service_healthy
 
   worker-assembler:
-    build:
-      context: .
-      dockerfile: svc-assembler/Dockerfile
+    image: ${IMAGE_ASSEMBLER}
     restart: unless-stopped
     environment:
       OHSHEET_BLOB_ROOT: /app/blob
@@ -104,7 +100,7 @@ services:
         condition: service_healthy
 
   worker-humanize:
-    build: .
+    image: ${IMAGE}
     command: celery -A backend.workers.celery_app worker -Q humanize -c 1 --loglevel=warning
     restart: unless-stopped
     environment:
@@ -117,7 +113,7 @@ services:
         condition: service_healthy
 
   worker-engrave:
-    build: .
+    image: ${IMAGE}
     command: celery -A backend.workers.celery_app worker -Q engrave -c 1 --loglevel=warning
     restart: unless-stopped
     environment:
@@ -129,6 +125,22 @@ services:
       redis:
         condition: service_healthy
 
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      orchestrator:
+        condition: service_healthy
+
 volumes:
   redis-data:
   blob-data:
+  caddy-data:
+  caddy-config:


### PR DESCRIPTION
## Summary
- **deploy.yml**: Build and push 3 container images (app, decomposer, assembler) instead of just one; write `IMAGE_DECOMPOSER` and `IMAGE_ASSEMBLER` to the `.env` deployed to the VM
- **docker-compose.prod.yml**: Replace all `build:` directives with `image:` references (`${IMAGE}`, `${IMAGE_DECOMPOSER}`, `${IMAGE_ASSEMBLER}`); add Caddy reverse-proxy service with volume mounts for TLS state

## Test plan
- [ ] Verify the deploy workflow builds and pushes all 3 images to Artifact Registry
- [ ] Verify `.env` on the VM contains `IMAGE_DECOMPOSER` and `IMAGE_ASSEMBLER`
- [ ] Verify `docker compose up` pulls pre-built images instead of building locally
- [ ] Verify Caddy starts and proxies traffic to the orchestrator
- [ ] Verify `/v1/health` returns the correct `commit` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)