### PR TITLE
fix: update Caddyfile to proxy to orchestrator:8000

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,4 @@
 :80 {
-    reverse_proxy app:8080
+    reverse_proxy orchestrator:8000
 }
+


### PR DESCRIPTION
## Summary
The Celery refactor renamed the Docker Compose service from `app` (port 8080) to `orchestrator` (port 8000) but the Caddyfile wasn't updated, causing 502 errors.

## Test plan
- [ ] `http://104.196.254.221/v1/health` returns 200 after deploy (already fixed on VM, this persists it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)