### PR TITLE
feat: Slack notifications for deploy success/failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,3 +88,25 @@ jobs:
         run: |
           sleep 15
           curl -sf --retry 5 --retry-delay 5 "http://${VM_HOST}/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
+
+      - name: Notify Slack on success
+        if: success()
+        run: |
+          COMMIT_SHORT="${{ github.sha }}"
+          COMMIT_SHORT="${COMMIT_SHORT:0:7}"
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-type: application/json' \
+            -d "{
+              \"text\": \":white_check_mark: *oh-sheet deployed* \`${COMMIT_SHORT}\` to \`${{ vars.VM_HOST }}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+            }"
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          COMMIT_SHORT="${{ github.sha }}"
+          COMMIT_SHORT="${COMMIT_SHORT:0:7}"
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-type: application/json' \
+            -d "{
+              \"text\": \":x: *oh-sheet deploy failed* \`${COMMIT_SHORT}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+            }"


### PR DESCRIPTION
## Summary
Adds two steps to the deploy workflow that post to `#oh-sheet-notifications` via Slack webhook:

- **On success**: `:white_check_mark: oh-sheet deployed `fe0ba3e` to `104.196.254.221` — View run`
- **On failure**: `:x: oh-sheet deploy failed `fe0ba3e` — View run`

Uses the `SLACK_WEBHOOK_URL` secret (already configured).

## Test plan
- [ ] Merge and verify Slack message appears in #oh-sheet-notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)