### PR TITLE
fix(transcribe): add mir_eval to [basic-pitch] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,19 @@ youtube = [
 # coremltools + onnxruntime installed and tensorflow absent it falls
 # back to a CoreML or ONNX session without complaint.
 #
+# ``mir_eval`` is listed here because basic-pitch 0.4.0 imports it
+# unconditionally at module load (``basic_pitch/note_creation.py`` —
+# which TranscribeService imports for ``note_events_to_midi``). Without
+# it the ``from basic_pitch.note_creation import …`` in transcribe.py
+# raises ImportError and the service silently falls back to the 4-note
+# stub ("Basic Pitch deps unavailable (No module named 'mir_eval')").
+#
 # Without this extra the TranscribeService falls back to a stub
 # TranscriptionResult.
 basic-pitch = [
     "coremltools; platform_system == 'Darwin'",
     "librosa>=0.8.0",
+    "mir_eval>=0.6.0",
     "numpy>=1.26",
     "onnxruntime>=1.19",
     "pretty_midi>=0.2.10",
@@ -58,8 +66,11 @@ basic-pitch = [
 ]
 # Offline eval harness (scripts/eval_transcription.py) — scores
 # TranscribeService output against clean_midi ground truth via
-# mir_eval. Eval-only, not imported by the backend runtime, so it
-# stays out of the production-facing [basic-pitch] extra.
+# mir_eval. mir_eval is also pulled in by [basic-pitch] (basic-pitch
+# 0.4.0 imports it at module load), so this extra is effectively a
+# subset of [basic-pitch]; kept as a named extra so ``make
+# install-eval`` / the README docs still resolve to something
+# meaningful for reviewers who only want the scoring library.
 eval = [
     "mir_eval>=0.6.0",
 ]


### PR DESCRIPTION
## Summary
- basic-pitch 0.4.0 declares `mir-eval` as a base runtime dependency and imports it unconditionally at module load in `basic_pitch/note_creation.py:21`.
- The Makefile installs basic-pitch with `--no-deps` (to dodge the `tensorflow-macos` pin that has no wheels for Python 3.13) and re-pins its transitive deps via the `[basic-pitch]` extra in `pyproject.toml`. That list was missing `mir_eval`.
- Result: `from basic_pitch.note_creation import note_events_to_midi` at `backend/services/transcribe.py:435` raised `ModuleNotFoundError`, got caught at `transcribe.py:1213`, and the stage silently fell back to the 4-note stub with the warning `Basic Pitch deps unavailable (No module named 'mir_eval') — using stub`.
- Fix: add `mir_eval>=0.6.0` to the `[basic-pitch]` extra, and update the adjacent comments to explain *why* it's there so the next person doing the `--no-deps` dance doesn't strip it back out.

No Dockerfile changes needed — `Dockerfile.dev:14` already installs `.[basic-pitch]`, so the next rebuild of `worker-transcribe` picks up mir_eval automatically. The production `Dockerfile` intentionally skips ML deps (runs the stub), and `svc-decomposer` doesn't import basic-pitch, so both are unchanged.

## Test plan
- [ ] `docker compose build worker-transcribe` (or `make backend` for a full rebuild)
- [ ] Submit an audio upload job and confirm `worker-transcribe` logs no longer contain `Basic Pitch deps unavailable (No module named 'mir_eval')`
- [ ] Confirm `TranscriptionResult` carries real Basic Pitch output (tracks/notes well above the 4-note stub) and the stub warning is absent from `quality.warnings`
- [ ] Local sanity: `pip install -e ".[basic-pitch]"` then `python -c "from basic_pitch.note_creation import note_events_to_midi"` imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)