### PR TITLE
fix: make VM IP a clickable link in Slack deploy notification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             -d "{
-              \"text\": \":white_check_mark: *oh-sheet deployed* \`${COMMIT_SHORT}\` to \`${{ vars.VM_HOST }}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+              \"text\": \":white_check_mark: *oh-sheet deployed* \`${COMMIT_SHORT}\` to <http://${{ vars.VM_HOST }}> — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }"
 
       - name: Notify Slack on failure


### PR DESCRIPTION
## Summary
Changes the success Slack message from `` `104.196.254.221` `` to `http://104.196.254.221` so it renders as a clickable link.

## Test plan
- [ ] Next deploy shows a clickable URL in #oh-sheet-notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)