### PR TITLE
feat: enable HTTPS via oh-sheet.duckdns.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
           VM_HOST: ${{ vars.VM_HOST }}
         run: |
           sleep 15
-          curl -sf --retry 5 --retry-delay 5 "http://${VM_HOST}/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
+          curl -sf --retry 5 --retry-delay 5 "https://oh-sheet.duckdns.org/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
 
       - name: Notify Slack on success
         if: success()
@@ -97,7 +97,7 @@ jobs:
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             -d "{
-              \"text\": \":white_check_mark: *oh-sheet deployed* \`${COMMIT_SHORT}\` to \`${{ vars.VM_HOST }}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+              \"text\": \":white_check_mark: *oh-sheet deployed* \`${COMMIT_SHORT}\` to <https://oh-sheet.duckdns.org> — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }"
 
       - name: Notify Slack on failure

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-:80 {
+oh-sheet.duckdns.org {
     reverse_proxy orchestrator:8000
 }
 


### PR DESCRIPTION
## Summary
- Update Caddyfile to use `oh-sheet.duckdns.org` — Caddy auto-provisions a Let's Encrypt TLS certificate and redirects HTTP → HTTPS
- Update deploy workflow health check to use `https://oh-sheet.duckdns.org`
- Update Slack notification to show clickable `https://oh-sheet.duckdns.org` link

Closes the need for PR #40 (IP link in Slack).

## After merge
The app will be accessible at **https://oh-sheet.duckdns.org**

## Test plan
- [ ] `https://oh-sheet.duckdns.org/v1/health` returns 200 with valid TLS
- [ ] `http://oh-sheet.duckdns.org` redirects to HTTPS
- [ ] Slack notification shows clickable domain link

🤖 Generated with [Claude Code](https://claude.com/claude-code)