### PR TITLE
ci: set up qa + prod environments with branch-guarded release flow

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,25 @@
+name: Branch Guard
+
+# Enforces the release flow: the only way to get code into main is via a PR
+# from the qa branch. This check must be set as a required status check on
+# main's branch protection rules for the guarantee to hold.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  enforce-qa-source:
+    name: PR to main must come from qa
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch is qa
+        run: |
+          if [[ "${{ github.event.pull_request.head.ref }}" != "qa" ]]; then
+            echo "::error::PRs to main must originate from the 'qa' branch."
+            echo "::error::This PR's source is '${{ github.event.pull_request.head.ref }}'."
+            echo "::error::Release flow: feature branch → qa → main."
+            exit 1
+          fi
+          echo "Source branch is qa — OK."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [qa, main]
   pull_request:
-    branches: [main]
+    branches: [qa, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,12 @@ name: Deploy to VM
 
 on:
   push:
-    branches: [main]
+    branches: [qa, main]
   workflow_dispatch:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
@@ -18,8 +18,13 @@ env:
 
 jobs:
   deploy:
-    name: Build & Deploy
+    name: Build & Deploy (${{ github.ref_name }})
     runs-on: ubuntu-latest
+    # Route qa pushes → qa environment, main pushes → prod environment.
+    # Environment-scoped vars/secrets (VM_HOST, PUBLIC_URL) determine the target.
+    environment:
+      name: ${{ github.ref_name == 'main' && 'prod' || 'qa' }}
+      url: ${{ vars.PUBLIC_URL }}
     permissions:
       contents: read
       id-token: write
@@ -74,11 +79,12 @@ jobs:
           SSH="ssh -i ~/.ssh/deploy_key ${VM_USER}@${VM_HOST}"
           SCP="scp -i ~/.ssh/deploy_key"
 
-          # Write .env with the image tag and commit SHA for docker compose
+          # Write .env with image tags, commit SHA, and domain for docker compose
           echo "IMAGE=${{ env.IMAGE }}:${{ github.sha }}" > /tmp/.env
           echo "IMAGE_DECOMPOSER=${{ env.IMAGE_DECOMPOSER }}:${{ github.sha }}" >> /tmp/.env
           echo "IMAGE_ASSEMBLER=${{ env.IMAGE_ASSEMBLER }}:${{ github.sha }}" >> /tmp/.env
           echo "COMMIT_SHA=${{ github.sha }}" >> /tmp/.env
+          echo "DOMAIN=${{ vars.DOMAIN }}" >> /tmp/.env
 
           # Copy compose files to VM (SCP .env to temp name, then atomic mv)
           $SCP docker-compose.prod.yml Caddyfile "${VM_USER}@${VM_HOST}:~/oh-sheet/"
@@ -90,20 +96,21 @@ jobs:
 
       - name: Verify deployment
         env:
-          VM_HOST: ${{ vars.VM_HOST }}
+          PUBLIC_URL: ${{ vars.PUBLIC_URL }}
         run: |
           sleep 15
-          curl -sf --retry 5 --retry-delay 5 "https://oh-sheet.duckdns.org/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
+          curl -sf --retry 5 --retry-delay 5 "${PUBLIC_URL}/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
 
       - name: Notify Slack on success
         if: success()
         run: |
           COMMIT_SHORT="${{ github.sha }}"
           COMMIT_SHORT="${COMMIT_SHORT:0:7}"
+          ENV_NAME="${{ github.ref_name == 'main' && 'PROD' || 'QA' }}"
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             -d "{
-              \"text\": \":white_check_mark: *oh-sheet deployed* v${{ steps.version.outputs.version }} (\`${COMMIT_SHORT}\`) to <https://oh-sheet.duckdns.org> — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+              \"text\": \":white_check_mark: *oh-sheet [${ENV_NAME}] deployed* v${{ steps.version.outputs.version }} (\`${COMMIT_SHORT}\`) to <${{ vars.PUBLIC_URL }}> — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }"
 
       - name: Notify Slack on failure
@@ -111,8 +118,9 @@ jobs:
         run: |
           COMMIT_SHORT="${{ github.sha }}"
           COMMIT_SHORT="${COMMIT_SHORT:0:7}"
+          ENV_NAME="${{ github.ref_name == 'main' && 'PROD' || 'QA' }}"
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             -d "{
-              \"text\": \":x: *oh-sheet deploy failed* \`${COMMIT_SHORT}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+              \"text\": \":x: *oh-sheet [${ENV_NAME}] deploy failed* \`${COMMIT_SHORT}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }"

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,3 @@
-oh-sheet.duckdns.org {
+{$DOMAIN:localhost} {
     reverse_proxy orchestrator:8000
 }
-

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -131,6 +131,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN:-localhost}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,100 @@
+# Deployment & Release Flow
+
+Oh Sheet uses a two-environment release flow with strict branch protection.
+
+## Branches & environments
+
+| Branch | Environment | URL | Approvals |
+|--------|-------------|-----|-----------|
+| `qa`   | **QA**   | https://oh-sheet-qa.duckdns.org | 1 |
+| `main` | **prod** | https://oh-sheet.duckdns.org | 2 |
+
+## Release flow
+
+```
+feature/foo ──► qa ──► main
+              (1 approval)  (2 approvals, only from qa)
+                 │              │
+                 ▼              ▼
+              QA deploy     Prod deploy
+```
+
+1. **Develop on a feature branch** off `qa`.
+2. **Open a PR into `qa`**. CI runs (lint, typecheck, tests). Requires **1 approval** from the team. No direct pushes.
+3. **Merge into `qa`** → the deploy workflow builds images and deploys to the **QA VM** automatically.
+4. **Open a PR from `qa` into `main`** to release. The `Branch Guard` workflow enforces that the source branch is exactly `qa` — no feature branch can bypass QA. Requires **2 approvals**.
+5. **Merge into `main`** → the same deploy workflow builds images and deploys to the **prod VM** automatically.
+
+## How it works
+
+- One `.github/workflows/deploy.yml` runs for both branches. It reads the target environment from `github.ref_name` (`main` → `prod`, anything else → `qa`).
+- GitHub Environments (`qa`, `prod`) provide **environment-scoped secrets and variables**, so `VM_HOST`, `PUBLIC_URL`, and `DOMAIN` automatically point at the right VM and domain.
+- `Caddyfile` uses the Caddy placeholder `{$DOMAIN}` so a single file serves both environments. The deploy workflow writes `DOMAIN` into `.env` on the VM and `docker-compose.prod.yml` passes it to the caddy container, which Caddy expands at startup. Caddy auto-provisions a Let's Encrypt cert for whichever hostname the env var resolves to.
+- `.github/workflows/branch-guard.yml` runs on every PR targeting `main` and **fails the check unless the PR's source branch is `qa`**. Branch protection on `main` requires this check to pass, so feature branches physically cannot merge directly to `main`.
+- Slack notifications are prefixed with `[QA]` or `[PROD]` so the shared `#oh-sheet-notifications` channel clearly indicates which environment was deployed.
+
+## Admin setup (one-time — requires repo admin)
+
+The code changes in this repo enable the flow, but branch protection and GitHub Environments require admin rights to configure.
+
+### 1. Create GitHub Environments
+
+In **Settings → Environments**:
+
+**`qa` environment**:
+- No required reviewers
+- Environment variables:
+  - `VM_HOST = 34.169.16.93`
+  - `VM_USER = deploy`
+  - `PUBLIC_URL = https://oh-sheet-qa.duckdns.org`
+  - `DOMAIN = oh-sheet-qa.duckdns.org`
+- Environment secrets (copy from repo secrets): `VM_SSH_PRIVATE_KEY`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `SLACK_WEBHOOK_URL`
+
+**`prod` environment**:
+- **Required reviewers**: at least 2 team members (optional — the 2-approval rule is also enforced at PR level, but this adds a runtime gate)
+- Environment variables:
+  - `VM_HOST = 104.196.254.221`
+  - `VM_USER = deploy`
+  - `PUBLIC_URL = https://oh-sheet.duckdns.org`
+  - `DOMAIN = oh-sheet.duckdns.org`
+- Environment secrets: same as qa
+
+Once environment-scoped vars/secrets exist, the repo-level `VM_HOST`/`VM_USER` variables can be removed to avoid confusion.
+
+### 2. Branch protection
+
+**`qa` branch**:
+- Require a pull request before merging
+- Require approvals: **1**
+- Dismiss stale pull request approvals when new commits are pushed
+- Require status checks to pass: `Backend Lint`, `Backend Typecheck`, `Backend Tests`, `Frontend Lint`
+- Require branches to be up to date before merging
+- Do not allow bypassing (include admins)
+
+**`main` branch**:
+- Require a pull request before merging
+- Require approvals: **2**
+- Dismiss stale pull request approvals when new commits are pushed
+- Require status checks to pass: `Backend Lint`, `Backend Typecheck`, `Backend Tests`, `Frontend Lint`, **`PR to main must come from qa`** (from `branch-guard.yml`)
+- Require branches to be up to date before merging
+- Do not allow bypassing (include admins)
+
+## Infrastructure
+
+Both VMs live in GCP project `oh-she3t`:
+
+| VM | Zone | Machine | Static IP |
+|----|------|---------|-----------|
+| `oh-sheet-vm` (prod) | `us-west1-b` | `e2-small` | `104.196.254.221` |
+| `oh-sheet-qa-vm` (qa) | `us-west1-b` | `e2-small` | `34.169.16.93` |
+
+Both VMs share the same firewall tag (`oh-sheet-vm`) so the existing rules on ports 22/80/443 apply to both.
+
+## Domains
+
+| Environment | Domain | DNS |
+|-------------|--------|-----|
+| QA          | `oh-sheet-qa.duckdns.org` | DuckDNS A record → `34.169.16.93` |
+| Prod        | `oh-sheet.duckdns.org`    | DuckDNS A record → `104.196.254.221` |
+
+Caddy auto-provisions Let's Encrypt certificates on first deploy for whichever hostname the `DOMAIN` env var resolves to. If you later add a new environment or rename a domain, just update the env-scoped `DOMAIN` variable — no Caddyfile change required.

--- a/tests/test_arrange_simplify.py
+++ b/tests/test_arrange_simplify.py
@@ -6,8 +6,6 @@ and returns a simplified copy suitable for sheet-music engraving.
 """
 from __future__ import annotations
 
-import pytest
-
 from shared.contracts import (
     PianoScore,
     ScoreMetadata,


### PR DESCRIPTION
## Summary
Sets up a two-environment release pipeline so features flow `feature → qa → main`, with branch protection and a branch-guard workflow that blocks anything from bypassing QA.

## Release flow

```
feature/foo ──► qa ──► main
              (1 approval)  (2 approvals, source must be qa)
                 │              │
                 ▼              ▼
          QA VM deploy    Prod VM deploy
```

## Code changes in this PR

| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | Trigger on push to `qa` OR `main`. Uses `environment: qa|prod` so env-scoped vars (`VM_HOST`, `PUBLIC_URL`, `DOMAIN`) pick the right target. Slack messages now prefixed `[QA]` / `[PROD]`. |
| `.github/workflows/branch-guard.yml` | **New.** Runs on PRs to `main`; fails unless `head.ref == 'qa'`. Must be a required status check on `main` for the guarantee to hold. |
| `.github/workflows/ci.yml` | Now triggers on pushes and PRs to both `qa` and `main` (was `main` only). |
| `Caddyfile` | Replace hardcoded domain with Caddy placeholder `{$DOMAIN:localhost}` so a single file serves both environments. |
| `docker-compose.prod.yml` | Pass `DOMAIN` env var to the `caddy` service. |
| `docs/deployment.md` | **New.** Full release-flow guide + admin setup checklist. |

## Infrastructure (already provisioned)

| VM | Zone | Machine | Static IP | Domain |
|----|------|---------|-----------|--------|
| `oh-sheet-vm` (prod) | `us-west1-b` | `e2-small` | `104.196.254.221` | `oh-sheet.duckdns.org` |
| `oh-sheet-qa-vm` (qa) | `us-west1-b` | `e2-small` | `34.169.16.93` | `oh-sheet-qa.duckdns.org` |

Both VMs share the `oh-sheet-vm` firewall tag (ports 22/80/443 open), Docker is installed, and Artifact Registry auth is configured.

## 🚨 Admin setup required after merge (one-time)

I have `maintain` but not `admin` on this repo, so these steps need someone with admin rights. Full details in `docs/deployment.md`.

### 1. Create GitHub Environments

**`qa` environment** — no required reviewers. Variables:
- `VM_HOST = 34.169.16.93`
- `VM_USER = deploy`
- `PUBLIC_URL = https://oh-sheet-qa.duckdns.org`
- `DOMAIN = oh-sheet-qa.duckdns.org`

**`prod` environment** — require 2 reviewers (optional extra gate). Variables:
- `VM_HOST = 104.196.254.221`
- `VM_USER = deploy`
- `PUBLIC_URL = https://oh-sheet.duckdns.org`
- `DOMAIN = oh-sheet.duckdns.org`

Both environments should also have the existing secrets copied in (or inherit from repo): `VM_SSH_PRIVATE_KEY`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `SLACK_WEBHOOK_URL`.

### 2. Branch protection

**`qa` branch**:
- Require PR, 1 approval, dismiss stale approvals
- Required checks: `Backend Lint`, `Backend Typecheck`, `Backend Tests`, `Frontend Lint`
- Include admins

**`main` branch**:
- Require PR, **2 approvals**, dismiss stale approvals
- Required checks: all of the above PLUS **`PR to main must come from qa`** (branch-guard)
- Include admins

## Test plan
- [ ] Merge this PR to `qa` → triggers a QA deploy
- [ ] Verify `https://oh-sheet-qa.duckdns.org/v1/health` returns 200
- [ ] Slack message shows `[QA]` prefix
- [ ] After admin setup, open a PR `qa → main`, verify branch-guard check passes
- [ ] Attempt to open a PR `some-feature → main`, verify branch-guard check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)