### PR TITLE
Engrave quality overhaul: eval harness + notation fixes (PR-1..PR-13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,15 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# System deps for yt-dlp (ffmpeg) and general health
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg curl \
+# System deps:
+#   ffmpeg   — yt-dlp audio extraction
+#   lilypond — MusicXML → PDF via musicxml2ly + lilypond (the engrave
+#              service falls back to a 60-byte stub PDF without this)
+#   curl     — health checks / debug
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        lilypond \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install shared package first (changes less often)

--- a/backend/services/arrange.py
+++ b/backend/services/arrange.py
@@ -393,6 +393,7 @@ def _chord_to_score_chord(
         duration_beat=max(end - onset, QUANT_GRID),
         label=chord.label,
         root=chord.root,
+        confidence=chord.confidence,
     )
 
 

--- a/backend/services/arrange.py
+++ b/backend/services/arrange.py
@@ -37,8 +37,15 @@ log = logging.getLogger(__name__)
 
 QUANT_GRID = 0.25            # 1/16th note (default / fallback)
 SPLIT_PITCH = 60             # middle C — pitches >= split go right hand
-MAX_VOICES_RH = 4
-MAX_VOICES_LH = 3
+# Piano notation is defined by at most two voices per staff (stems up =
+# melody, stems down = accompaniment). Capping here means engrave can
+# trust the voice assignment and emit ``<voice>1</voice>`` / ``<voice>2</voice>``
+# directly instead of collapsing everything back down. Going wider
+# (4/3 previously) produced voice-3 notes that OSMD's VexFlow backend
+# crashes on and that no pianist can actually read as four parallel
+# lines on one staff.
+MAX_VOICES_RH = 2
+MAX_VOICES_LH = 2
 MIN_TRACK_CONFIDENCE = 0.35
 NEAR_OVERLAP_TOL = 0.15      # beats
 
@@ -427,7 +434,7 @@ def _arrange_sync(
         grid = QUANT_GRID
     overlap_tol = 0.6 * grid
 
-    max_rh = MAX_VOICES_RH if difficulty != "beginner" else 2
+    max_rh = MAX_VOICES_RH if difficulty != "beginner" else 1
     max_lh = MAX_VOICES_LH if difficulty != "beginner" else 1
     rh_voiced = _resolve_overlaps(rh_raw, max_rh, grid=grid, overlap_tol=overlap_tol)
     lh_voiced = _resolve_overlaps(lh_raw, max_lh, grid=grid, overlap_tol=overlap_tol)

--- a/backend/services/condense.py
+++ b/backend/services/condense.py
@@ -56,6 +56,7 @@ def _chord_to_score_chord(
         duration_beat=max(end - onset, MIN_DURATION_BEAT),
         label=chord.label,
         root=chord.root,
+        confidence=chord.confidence,
     )
 
 

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -112,8 +112,13 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
             continue
         piano.notes.append(pretty_midi.Note(velocity=vel, pitch=pitch, start=start, end=end))
 
+    # Pedal events → GM control changes. Sustain = CC64, sostenuto = CC66,
+    # una corda = CC67. All three use the standard on=127 / off=0 encoding
+    # (below 64 disengages on most synths, but 0 is the unambiguous convention).
+    _PEDAL_CC = {"sustain": 64, "sostenuto": 66, "una_corda": 67}
     for pedal in perf.expression.pedal_events:
-        if pedal.type != "sustain":
+        cc_num = _PEDAL_CC.get(pedal.type)
+        if cc_num is None:
             continue
         try:
             on_sec = beat_to_sec(pedal.onset_beat, tempo_map) - midi_time_offset
@@ -121,10 +126,10 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
         except ValueError:
             continue
         piano.control_changes.append(
-            pretty_midi.ControlChange(number=64, value=127, time=max(0.0, on_sec))
+            pretty_midi.ControlChange(number=cc_num, value=127, time=max(0.0, on_sec))
         )
         piano.control_changes.append(
-            pretty_midi.ControlChange(number=64, value=0, time=max(0.0, off_sec))
+            pretty_midi.ControlChange(number=cc_num, value=0, time=max(0.0, off_sec))
         )
 
     midi.instruments.append(piano)
@@ -144,6 +149,54 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
 # ---------------------------------------------------------------------------
 # MusicXML rendering
 # ---------------------------------------------------------------------------
+
+# Human-readable labels for non-sustain pedals. Sustain uses the standard
+# "Ped." / "*" pair; MusicXML doesn't reserve glyphs for sostenuto / una
+# corda, so text directions are the portable choice across renderers.
+_PEDAL_TEXT = {
+    "sustain":    ("Ped.", "*"),
+    "sostenuto":  ("Sost. Ped.", "*"),
+    "una_corda":  ("una corda", "tre corde"),
+}
+
+
+def _attach_dynamics(part, dynamics, music21) -> None:  # noqa: ANN001 — music21 is untyped
+    """Insert ``DynamicMarking`` events into a music21 part.
+
+    Static marks (pp..ff) become ``music21.dynamics.Dynamic`` objects at
+    ``dyn.beat``. Hairpins (crescendo/decrescendo) become italic text
+    directions — ``music21.dynamics.Crescendo`` spanners need referenced
+    note endpoints that may have been quantized away, so text is the
+    more portable choice across OSMD / LilyPond / MuseScore.
+    """
+    for dyn in dynamics:
+        beat = max(0.0, float(dyn.beat))
+        if dyn.type in ("pp", "p", "mp", "mf", "f", "ff"):
+            part.insert(beat, music21.dynamics.Dynamic(dyn.type))
+        elif dyn.type == "crescendo":
+            part.insert(beat, music21.expressions.TextExpression("cresc."))
+        elif dyn.type == "decrescendo":
+            part.insert(beat, music21.expressions.TextExpression("dim."))
+
+
+def _attach_pedal_marks(part, pedal_events, music21) -> None:  # noqa: ANN001
+    """Insert pedal text directions into a music21 part.
+
+    Uses ``TextExpression`` rather than ``music21.expressions.PedalMark``
+    because the latter has inconsistent MusicXML export across music21
+    versions. Sustain emits the standard ``Ped.`` / ``*`` pair; sostenuto
+    and una corda use descriptive labels.
+    """
+    for pedal in pedal_events:
+        labels = _PEDAL_TEXT.get(pedal.type)
+        if labels is None:
+            continue
+        on_label, off_label = labels
+        on_beat = max(0.0, float(pedal.onset_beat))
+        off_beat = max(on_beat, float(pedal.offset_beat))
+        part.insert(on_beat, music21.expressions.TextExpression(on_label))
+        part.insert(off_beat, music21.expressions.TextExpression(off_label))
+
 
 def _render_musicxml_bytes(
     score: PianoScore,
@@ -210,7 +263,22 @@ def _render_musicxml_bytes(
                     n.articulations.append(music21.articulations.Accent())
                 elif art_type == "tenuto":
                     n.articulations.append(music21.articulations.Tenuto())
+                elif art_type == "fermata":
+                    # Fermata lives on n.expressions in music21, not
+                    # n.articulations — MusicXML emits it as a <fermata/>
+                    # inside <notations> either way, but only the
+                    # expressions placement round-trips through makeNotation.
+                    n.expressions.append(music21.expressions.Fermata())
                 part.insert(sn.onset_beat, n)
+
+            # Dynamics + pedal marks are attached to the RH and LH parts
+            # respectively so the markings sit between the staves where
+            # pianists expect them. Skipped on the engrave-from-score path
+            # (perf is never None there, but the expression map is empty).
+            if hand_name == "Right Hand" and perf is not None:
+                _attach_dynamics(part, perf.expression.dynamics, music21)
+            if hand_name == "Left Hand" and perf is not None:
+                _attach_pedal_marks(part, perf.expression.pedal_events, music21)
 
             # Chord symbols disabled for now — the harmonic analysis from
             # audio transcription produces noisy labels (G5, E5, etc.) that
@@ -516,16 +584,16 @@ class EngraveService:
             chord_count,
         )
 
-        # NOTE: these flags describe what was *actually rendered*, not what
-        # the input contained. Dynamics and pedal marks are still
-        # unimplemented in the MusicXML render path (plan phase 1.3/1.4),
-        # so both stay False until those PRs land — even when the humanized
-        # input has dynamics or pedal events populated.
+        # These flags describe what was *actually rendered*. As of PR-5
+        # (plan phase 1.3–1.6) engrave renders dynamics and pedal marks
+        # when the humanized input populates them, so we surface that
+        # state directly from the expression map instead of hardcoding.
+        perf_for_flags = payload if isinstance(payload, HumanizedPerformance) else None
         return EngravedOutput(
             schema_version=SCHEMA_VERSION,
             metadata=EngravedScoreData(
-                includes_dynamics=False,
-                includes_pedal_marks=False,
+                includes_dynamics=bool(perf_for_flags and perf_for_flags.expression.dynamics),
+                includes_pedal_marks=bool(perf_for_flags and perf_for_flags.expression.pedal_events),
                 includes_fingering=False,
                 includes_chord_symbols=chord_count > 0,
                 title=title,

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -1,11 +1,7 @@
 """Engraving stage — render MIDI / MusicXML / PDF artifacts.
 
-Tries the real renderers when their optional deps are present and falls
-back to small but valid stub bytes otherwise so the rest of the pipeline
-keeps working in environments without pretty_midi / music21 / LilyPond.
-
   * MIDI     — pretty_midi if installed, else a minimal MThd+MTrk file
-  * MusicXML — music21 if installed, else a minimal score-partwise body
+  * MusicXML — music21 (hard dependency; errors propagate to the caller)
   * PDF      — LilyPond (preferred) or MuseScore CLI if on $PATH, else a 1-line %PDF stub
 """
 from __future__ import annotations
@@ -16,7 +12,6 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from xml.sax.saxutils import escape
 
 from backend.contracts import (
     SCHEMA_VERSION,
@@ -24,7 +19,6 @@ from backend.contracts import (
     EngravedScoreData,
     HumanizedPerformance,
     PianoScore,
-    ScoreNote,
     beat_to_sec,
 )
 from backend.storage.base import BlobStore
@@ -40,12 +34,6 @@ _STUB_PDF = b"%PDF-1.4\n% stub PDF emitted by ohsheet engrave service\n"
 _STUB_MIDI = (
     b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x01\xe0"   # header chunk: format 0, 1 track, 480 tpq
     b"MTrk\x00\x00\x00\x04\x00\xff\x2f\x00"            # one empty track ending in End-Of-Track
-)
-_STUB_MUSICXML = (
-    b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
-    b'<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" '
-    b'"http://www.musicxml.org/dtds/partwise.dtd">\n'
-    b'<score-partwise version="3.1"/>\n'
 )
 
 
@@ -204,111 +192,103 @@ def _render_musicxml_bytes(
     title: str,
     composer: str,
 ) -> bytes:
-    """Render a PianoScore to MusicXML.
+    """Render a PianoScore to MusicXML via music21.
 
-    Tries music21 first; on failure (or if music21 isn't installed) falls
-    back to a hand-rolled minimal score-partwise body that at least lists
-    the notes for each hand.
+    music21 is a hard dependency (see ``pyproject.toml``); if it raises
+    during export we let the exception propagate so the job manager can
+    surface the failure instead of silently emitting a stub.
     """
+    import music21  # noqa: PLC0415 — heavy import, kept lazy for test speed
+
+    s = music21.stream.Score()
+    s.metadata = music21.metadata.Metadata()
+    s.metadata.title = title or "Untitled"
+    s.metadata.composer = composer or ""
+
+    ts = music21.meter.TimeSignature(
+        f"{score.metadata.time_signature[0]}/{score.metadata.time_signature[1]}"
+    )
+    key_root = score.metadata.key.split(":")[0] if ":" in score.metadata.key else "C"
+    mode = "major" if "minor" not in score.metadata.key else "minor"
+    ks = music21.key.Key(key_root, mode)
+    # Round BPM to a whole number so the metronome mark reads cleanly
+    # (e.g., ♩ = 99 instead of ♩ = 99.38401442307693). The tempo map
+    # itself stays float for beat→sec conversions elsewhere.
+    bpm_float = score.metadata.tempo_map[0].bpm if score.metadata.tempo_map else 120.0
+    bpm = round(bpm_float)
+    tempo_mark = music21.tempo.MetronomeMark(number=bpm)
+
+    articulations_at: dict[str, str] = {}
+    if perf is not None:
+        for a in perf.expression.articulations:
+            articulations_at[a.score_note_id] = a.type
+
+    for hand_name, notes, clef in (
+        ("Right Hand", score.right_hand, music21.clef.TrebleClef()),
+        ("Left Hand", score.left_hand, music21.clef.BassClef()),
+    ):
+        part = music21.stream.Part()
+        part.partName = hand_name
+        part.append(ts)
+        part.append(ks)
+        if hand_name == "Right Hand":
+            part.append(tempo_mark)
+        part.append(clef)
+
+        for sn in sorted(notes, key=lambda n: n.onset_beat):
+            n = music21.note.Note(sn.pitch)
+            n.quarterLength = sn.duration_beat
+            n.volume.velocity = sn.velocity
+            art_type = articulations_at.get(sn.id)
+            if art_type == "staccato":
+                n.articulations.append(music21.articulations.Staccato())
+            elif art_type == "accent":
+                n.articulations.append(music21.articulations.Accent())
+            elif art_type == "tenuto":
+                n.articulations.append(music21.articulations.Tenuto())
+            elif art_type == "fermata":
+                # Fermata lives on n.expressions in music21, not
+                # n.articulations — MusicXML emits it as a <fermata/>
+                # inside <notations> either way, but only the
+                # expressions placement round-trips through makeNotation.
+                n.expressions.append(music21.expressions.Fermata())
+            part.insert(sn.onset_beat, n)
+
+        # Dynamics + pedal marks are attached to the RH and LH parts
+        # respectively so the markings sit between the staves where
+        # pianists expect them. Skipped on the engrave-from-score path
+        # (perf is never None there, but the expression map is empty).
+        if hand_name == "Right Hand" and perf is not None:
+            _attach_dynamics(part, perf.expression.dynamics, music21)
+        if hand_name == "Left Hand" and perf is not None:
+            _attach_pedal_marks(part, perf.expression.pedal_events, music21)
+
+        # Chord symbols disabled for now — the harmonic analysis from
+        # audio transcription produces noisy labels (G5, E5, etc.) that
+        # clutter the notation. Re-enable when chord recognition quality
+        # improves or when source is a clean MIDI upload.
+        # for cs in score.metadata.chord_symbols:
+        #     try:
+        #         h = music21.harmony.ChordSymbol(cs.label.replace(":", ""))
+        #         part.insert(cs.beat, h)
+        #     except Exception:
+        #         pass
+
+        # Quantize to a 16th-note + triplet grid so OSMD can render it.
+        # Without explicit divisors, music21 defaults to divisions=10080
+        # which produces MusicXML that OSMD chokes on.
+        part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
+        part.makeNotation(inPlace=True)
+        s.append(part)
+
+    with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
     try:
-        import music21  # noqa: PLC0415 — optional heavy dep
-    except ImportError:
-        log.warning("music21 not installed — MusicXML output will be a minimal stub. Install with: pip install music21")
-        return _minimal_musicxml(score, title, composer)
-
-    try:
-        s = music21.stream.Score()
-        s.metadata = music21.metadata.Metadata()
-        s.metadata.title = title or "Untitled"
-        s.metadata.composer = composer or ""
-
-        ts = music21.meter.TimeSignature(
-            f"{score.metadata.time_signature[0]}/{score.metadata.time_signature[1]}"
-        )
-        key_root = score.metadata.key.split(":")[0] if ":" in score.metadata.key else "C"
-        mode = "major" if "minor" not in score.metadata.key else "minor"
-        ks = music21.key.Key(key_root, mode)
-        # Round BPM to a whole number so the metronome mark reads cleanly
-        # (e.g., ♩ = 99 instead of ♩ = 99.38401442307693). The tempo map
-        # itself stays float for beat→sec conversions elsewhere.
-        bpm_float = score.metadata.tempo_map[0].bpm if score.metadata.tempo_map else 120.0
-        bpm = round(bpm_float)
-        tempo_mark = music21.tempo.MetronomeMark(number=bpm)
-
-        articulations_at: dict[str, str] = {}
-        if perf is not None:
-            for a in perf.expression.articulations:
-                articulations_at[a.score_note_id] = a.type
-
-        for hand_name, notes, clef in (
-            ("Right Hand", score.right_hand, music21.clef.TrebleClef()),
-            ("Left Hand", score.left_hand, music21.clef.BassClef()),
-        ):
-            part = music21.stream.Part()
-            part.partName = hand_name
-            part.append(ts)
-            part.append(ks)
-            if hand_name == "Right Hand":
-                part.append(tempo_mark)
-            part.append(clef)
-
-            for sn in sorted(notes, key=lambda n: n.onset_beat):
-                n = music21.note.Note(sn.pitch)
-                n.quarterLength = sn.duration_beat
-                n.volume.velocity = sn.velocity
-                art_type = articulations_at.get(sn.id)
-                if art_type == "staccato":
-                    n.articulations.append(music21.articulations.Staccato())
-                elif art_type == "accent":
-                    n.articulations.append(music21.articulations.Accent())
-                elif art_type == "tenuto":
-                    n.articulations.append(music21.articulations.Tenuto())
-                elif art_type == "fermata":
-                    # Fermata lives on n.expressions in music21, not
-                    # n.articulations — MusicXML emits it as a <fermata/>
-                    # inside <notations> either way, but only the
-                    # expressions placement round-trips through makeNotation.
-                    n.expressions.append(music21.expressions.Fermata())
-                part.insert(sn.onset_beat, n)
-
-            # Dynamics + pedal marks are attached to the RH and LH parts
-            # respectively so the markings sit between the staves where
-            # pianists expect them. Skipped on the engrave-from-score path
-            # (perf is never None there, but the expression map is empty).
-            if hand_name == "Right Hand" and perf is not None:
-                _attach_dynamics(part, perf.expression.dynamics, music21)
-            if hand_name == "Left Hand" and perf is not None:
-                _attach_pedal_marks(part, perf.expression.pedal_events, music21)
-
-            # Chord symbols disabled for now — the harmonic analysis from
-            # audio transcription produces noisy labels (G5, E5, etc.) that
-            # clutter the notation. Re-enable when chord recognition quality
-            # improves or when source is a clean MIDI upload.
-            # for cs in score.metadata.chord_symbols:
-            #     try:
-            #         h = music21.harmony.ChordSymbol(cs.label.replace(":", ""))
-            #         part.insert(cs.beat, h)
-            #     except Exception:
-            #         pass
-
-            # Quantize to a 16th-note + triplet grid so OSMD can render it.
-            # Without explicit divisors, music21 defaults to divisions=10080
-            # which produces MusicXML that OSMD chokes on.
-            part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
-            part.makeNotation(inPlace=True)
-            s.append(part)
-
-        with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
-            tmp_path = Path(tmp.name)
-        try:
-            s.write("musicxml", fp=str(tmp_path))
-            raw = tmp_path.read_bytes()
-            return _sanitize_musicxml_for_osmd(raw)
-        finally:
-            tmp_path.unlink(missing_ok=True)
-    except Exception as exc:  # noqa: BLE001 — music21 has many failure modes
-        log.warning("music21 MusicXML render failed (%s); falling back to minimal", exc)
-        return _minimal_musicxml(score, title, composer)
+        s.write("musicxml", fp=str(tmp_path))
+        raw = tmp_path.read_bytes()
+        return _sanitize_musicxml_for_osmd(raw)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def _sanitize_musicxml_for_osmd(raw: bytes) -> bytes:
@@ -366,81 +346,6 @@ def _sanitize_musicxml_for_osmd(raw: bytes) -> bytes:
     text = re.sub(r"<voice>\d+</voice>", "<voice>1</voice>", text)
 
     return text.encode("utf-8")
-
-
-def _minimal_musicxml(score: PianoScore, title: str, composer: str) -> bytes:
-    """Hand-rolled minimal score-partwise body.
-
-    Not bar-aware — emits each note as a single ``<note>`` element with
-    its pitch step, octave, and duration in tenths of a beat. Good enough
-    for round-trip tests; the music21 path is what real consumers want.
-    """
-    bpm = score.metadata.tempo_map[0].bpm if score.metadata.tempo_map else 120.0
-    divisions = 4  # 4 divisions per quarter note → 16th-note grid
-
-    def note_xml(sn: ScoreNote, hand: int) -> str:
-        step, alter, octave = _midi_to_step_alter_octave(sn.pitch)
-        duration = max(1, int(round(sn.duration_beat * divisions)))
-        alter_xml = f"<alter>{alter}</alter>" if alter else ""
-        return (
-            "<note>"
-            f"<pitch><step>{step}</step>{alter_xml}<octave>{octave}</octave></pitch>"
-            f"<duration>{duration}</duration>"
-            f"<voice>{sn.voice}</voice>"
-            f"<staff>{hand}</staff>"
-            "</note>"
-        )
-
-    rh_notes = "".join(note_xml(n, 1) for n in sorted(score.right_hand, key=lambda n: n.onset_beat))
-    lh_notes = "".join(note_xml(n, 2) for n in sorted(score.left_hand, key=lambda n: n.onset_beat))
-
-    ts = score.metadata.time_signature
-    body = (
-        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
-        '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" '
-        '"http://www.musicxml.org/dtds/partwise.dtd">\n'
-        '<score-partwise version="3.1">'
-        '<work>'
-        f'<work-title>{escape(title or "Untitled")}</work-title>'
-        '</work>'
-        '<identification>'
-        f'<creator type="composer">{escape(composer or "Unknown")}</creator>'
-        '</identification>'
-        '<part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>'
-        '<part id="P1">'
-        '<measure number="1">'
-        '<attributes>'
-        f'<divisions>{divisions}</divisions>'
-        f'<key><fifths>0</fifths></key>'
-        f'<time><beats>{ts[0]}</beats><beat-type>{ts[1]}</beat-type></time>'
-        '<staves>2</staves>'
-        '<clef number="1"><sign>G</sign><line>2</line></clef>'
-        '<clef number="2"><sign>F</sign><line>4</line></clef>'
-        '</attributes>'
-        f'<sound tempo="{bpm:.2f}"/>'
-        f'{rh_notes}'
-        '<backup>'
-        f'<duration>{max(1, int(round(sum(n.duration_beat for n in score.right_hand) * divisions)))}</duration>'
-        '</backup>'
-        f'{lh_notes}'
-        '</measure>'
-        '</part>'
-        '</score-partwise>\n'
-    )
-    return body.encode("utf-8")
-
-
-_PITCH_NAMES: list[tuple[str, int]] = [
-    ("C", 0), ("C", 1), ("D", 0), ("D", 1), ("E", 0), ("F", 0),
-    ("F", 1), ("G", 0), ("G", 1), ("A", 0), ("A", 1), ("B", 0),
-]
-
-
-def _midi_to_step_alter_octave(midi: int) -> tuple[str, int, int]:
-    midi = max(0, min(127, midi))
-    octave = (midi // 12) - 1
-    step, alter = _PITCH_NAMES[midi % 12]
-    return step, alter, octave
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -148,6 +149,69 @@ _PEDAL_TEXT = {
 }
 
 
+# Chord symbols below this transcriber confidence are dropped — the
+# audio-harmony pipeline routinely emits low-confidence labels that look
+# like pitch-octave pairs ("G5", "E5") rather than chord qualities, and
+# they clutter the notation more than they help.
+_CHORD_MIN_CONFIDENCE = 0.5
+
+# Anything that lexically looks like a pitch-and-octave (e.g. "G5",
+# "C#4", "Db3") is an artifact of the transcription pipeline treating
+# a single pitch as a chord. Filter these out before handing to music21
+# so ``ChordSymbol`` doesn't build a one-note "chord".
+_PITCH_OCTAVE_RE = re.compile(r"^[A-G][#b]?\d+$")
+
+
+def _attach_chord_symbols(part, chord_symbols, music21) -> int:  # noqa: ANN001
+    """Insert chord symbols onto a music21 part, returning the count rendered.
+
+    Chord symbols from audio transcription are noisy — single-pitch
+    false positives, low-confidence guesses, and Harte labels music21
+    can't parse all end up here. Applies three filters before committing:
+
+    1. **Confidence gate.** Drop anything below
+       ``_CHORD_MIN_CONFIDENCE``. The transcriber already reports its
+       own uncertainty; trust it.
+    2. **Shape gate.** Reject labels that match ``[A-G][#b]?\\d+`` —
+       those are pitch-octave pairs (e.g. "G5"), not chord qualities.
+    3. **Parse gate.** ``music21.harmony.ChordSymbol`` must parse the
+       label cleanly AND the resulting chord must carry ≥ 3 distinct
+       pitches. Everything else is a one-note or two-note artifact
+       that clutters the staff.
+
+    music21's ChordSymbol parser uses a custom pitch-name grammar that
+    doesn't accept Harte's colon separator ("C:maj7"), so we strip the
+    colon before parsing. Any parser error lands in a broad except —
+    ChordSymbol raises a grab-bag of exception types and the cost of a
+    missed symbol is much lower than the cost of an exploding engrave.
+    """
+    rendered = 0
+    for cs in chord_symbols:
+        if cs.confidence < _CHORD_MIN_CONFIDENCE:
+            continue
+        label = cs.label.strip()
+        if not label or _PITCH_OCTAVE_RE.match(label):
+            continue
+        # music21 doesn't accept Harte's "root:quality" colon form.
+        parse_label = label.replace(":", "")
+        try:
+            h = music21.harmony.ChordSymbol(parse_label)
+        except Exception:  # noqa: BLE001 — ChordSymbol raises many types
+            continue
+        try:
+            pitches = h.pitches
+        except Exception:  # noqa: BLE001 — defensive, some labels parse but can't resolve
+            continue
+        if len({p.midi % 12 for p in pitches}) < 3:
+            continue
+        try:
+            part.insert(max(0.0, float(cs.beat)), h)
+        except Exception:  # noqa: BLE001 — insertion shouldn't fail, but don't crash engrave
+            continue
+        rendered += 1
+    return rendered
+
+
 def _attach_dynamics(part, dynamics, music21) -> None:  # noqa: ANN001 — music21 is untyped
     """Insert ``DynamicMarking`` events into a music21 part.
 
@@ -191,14 +255,23 @@ def _render_musicxml_bytes(
     perf: HumanizedPerformance | None,
     title: str,
     composer: str,
-) -> bytes:
+) -> tuple[bytes, int]:
     """Render a PianoScore to MusicXML via music21.
+
+    Returns a ``(bytes, chord_symbols_rendered)`` tuple so the caller
+    can report how many chord symbols actually survived the filter gate
+    in ``_attach_chord_symbols`` (see plan phase 3.2). The bare length
+    of ``score.metadata.chord_symbols`` lies about rendered content —
+    low-confidence, unparseable, or pitch-octave-shaped labels are
+    dropped before they ever reach the staff.
 
     music21 is a hard dependency (see ``pyproject.toml``); if it raises
     during export we let the exception propagate so the job manager can
     surface the failure instead of silently emitting a stub.
     """
     import music21  # noqa: PLC0415 — heavy import, kept lazy for test speed
+
+    chord_symbols_rendered = 0
 
     s = music21.stream.Score()
     s.metadata = music21.metadata.Metadata()
@@ -305,16 +378,13 @@ def _render_musicxml_bytes(
         if hand_name == "Left Hand" and perf is not None:
             _attach_pedal_marks(part, perf.expression.pedal_events, music21)
 
-        # Chord symbols disabled for now — the harmonic analysis from
-        # audio transcription produces noisy labels (G5, E5, etc.) that
-        # clutter the notation. Re-enable when chord recognition quality
-        # improves or when source is a clean MIDI upload.
-        # for cs in score.metadata.chord_symbols:
-        #     try:
-        #         h = music21.harmony.ChordSymbol(cs.label.replace(":", ""))
-        #         part.insert(cs.beat, h)
-        #     except Exception:
-        #         pass
+        # Chord symbols ride above the RH staff where pianists read them.
+        # ``_attach_chord_symbols`` handles confidence / shape / parse
+        # filtering so noisy transcriber output doesn't reach the score.
+        if hand_name == "Right Hand":
+            chord_symbols_rendered += _attach_chord_symbols(
+                part, score.metadata.chord_symbols, music21,
+            )
 
         # Quantize to a 16th-note + triplet grid. With
         # defaults.divisionsPerQuarter=12 forced below, every quantized
@@ -370,7 +440,7 @@ def _render_musicxml_bytes(
         music21.defaults.divisionsPerQuarter = 12
         s.write("musicxml", fp=str(tmp_path))
         raw = tmp_path.read_bytes()
-        return _sanitize_musicxml_for_osmd(raw)
+        return _sanitize_musicxml_for_osmd(raw), chord_symbols_rendered
     finally:
         music21.defaults.divisionsPerQuarter = prior_divisions
         tmp_path.unlink(missing_ok=True)
@@ -392,8 +462,6 @@ def _sanitize_musicxml_for_osmd(raw: bytes) -> bytes:
        crashes (``parentVoiceEntry undefined``) on 3+ voices per part;
        clamping to 2 is the minimum-damage fallback.
     """
-    import re
-
     text = raw.decode("utf-8")
 
     def _clamp(match: re.Match[str]) -> str:
@@ -497,8 +565,14 @@ def _engrave_sync(
     payload: HumanizedPerformance | PianoScore,
     title: str,
     composer: str,
-) -> tuple[bytes, bytes, bytes]:
-    """Render all three artifacts. Returns (pdf, musicxml, midi)."""
+) -> tuple[bytes, bytes, bytes, int]:
+    """Render all three artifacts.
+
+    Returns ``(pdf, musicxml, midi, chord_symbols_rendered)``. The trailing
+    count reflects chord symbols that *actually made it to the staff* after
+    ``_attach_chord_symbols`` filtering — not the raw input count — so
+    ``EngravedScoreData.includes_chord_symbols`` can tell the truth.
+    """
     if isinstance(payload, HumanizedPerformance):
         score = payload.score
         perf: HumanizedPerformance | None = payload
@@ -534,9 +608,11 @@ def _engrave_sync(
         )
 
     midi_bytes = _render_midi_bytes(perf)
-    musicxml_bytes = _render_musicxml_bytes(score, perf, title, composer)
+    musicxml_bytes, chord_symbols_rendered = _render_musicxml_bytes(
+        score, perf, title, composer,
+    )
     pdf_bytes = _render_pdf_bytes(musicxml_bytes)
-    return pdf_bytes, musicxml_bytes, midi_bytes
+    return pdf_bytes, musicxml_bytes, midi_bytes, chord_symbols_rendered
 
 
 class EngraveService:
@@ -559,8 +635,8 @@ class EngraveService:
             title,
             isinstance(payload, HumanizedPerformance),
         )
-        pdf_bytes, musicxml_bytes, midi_bytes = await asyncio.to_thread(
-            _engrave_sync, payload, title, composer,
+        pdf_bytes, musicxml_bytes, midi_bytes, chord_symbols_rendered = (
+            await asyncio.to_thread(_engrave_sync, payload, title, composer)
         )
 
         prefix = f"jobs/{job_id}/output"
@@ -569,21 +645,26 @@ class EngraveService:
         midi_uri = self.blob_store.put_bytes(f"{prefix}/humanized.mid", midi_bytes)
 
         score = payload.score if isinstance(payload, HumanizedPerformance) else payload
-        chord_count = len(score.metadata.chord_symbols)
+        chord_input_count = len(score.metadata.chord_symbols)
 
         log.info(
-            "engrave: done job_id=%s bytes pdf=%d musicxml=%d midi=%d chord_symbols=%d",
+            "engrave: done job_id=%s bytes pdf=%d musicxml=%d midi=%d "
+            "chord_symbols=%d/%d rendered",
             job_id,
             len(pdf_bytes),
             len(musicxml_bytes),
             len(midi_bytes),
-            chord_count,
+            chord_symbols_rendered,
+            chord_input_count,
         )
 
         # These flags describe what was *actually rendered*. As of PR-5
         # (plan phase 1.3–1.6) engrave renders dynamics and pedal marks
         # when the humanized input populates them, so we surface that
         # state directly from the expression map instead of hardcoding.
+        # PR-11 (plan phase 3.2) extends the same truth-telling to chord
+        # symbols: the input count can lie (low-confidence / unparseable
+        # labels are dropped), so gate on the filtered-rendered count.
         perf_for_flags = payload if isinstance(payload, HumanizedPerformance) else None
         return EngravedOutput(
             schema_version=SCHEMA_VERSION,
@@ -591,7 +672,7 @@ class EngraveService:
                 includes_dynamics=bool(perf_for_flags and perf_for_flags.expression.dynamics),
                 includes_pedal_marks=bool(perf_for_flags and perf_for_flags.expression.pedal_events),
                 includes_fingering=False,
-                includes_chord_symbols=chord_count > 0,
+                includes_chord_symbols=chord_symbols_rendered > 0,
                 title=title,
                 composer=composer,
             ),

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -84,8 +84,12 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
             offset = beat_to_sec(en.onset_beat + en.duration_beat, tempo_map) - midi_time_offset
         except ValueError:
             continue
+        # timing_offset_ms is an *onset-only* nudge — the release boundary
+        # stays on the metronomic grid, so a late-struck note plays shorter
+        # and an early-struck note plays longer. Mirrors humanize._humanize_timing,
+        # which models downbeat anticipation / backbeat push as attack-time
+        # gestures with no release component.
         onset += en.timing_offset_ms / 1000.0
-        offset += en.timing_offset_ms / 1000.0
         onset = max(0.0, onset)
         offset = max(onset + 0.01, offset)
         raw_notes.append((en.pitch, onset, offset, max(1, min(127, en.velocity))))

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -429,11 +429,14 @@ def _engrave_sync(
     payload: HumanizedPerformance | PianoScore,
     title: str,
     composer: str,
-) -> tuple[bytes, bytes, bytes, bool]:
-    """Render all three artifacts. Returns (pdf, musicxml, midi, is_humanized)."""
-    is_humanized = isinstance(payload, HumanizedPerformance)
-    score = payload.score if is_humanized else payload  # type: ignore[union-attr]
-    perf = payload if is_humanized else None  # type: ignore[assignment]
+) -> tuple[bytes, bytes, bytes]:
+    """Render all three artifacts. Returns (pdf, musicxml, midi)."""
+    if isinstance(payload, HumanizedPerformance):
+        score = payload.score
+        perf: HumanizedPerformance | None = payload
+    else:
+        score = payload
+        perf = None
 
     if perf is None:
         # Engrave-from-score: synthesize a zero-deviation performance shell so
@@ -465,7 +468,7 @@ def _engrave_sync(
     midi_bytes = _render_midi_bytes(perf)
     musicxml_bytes = _render_musicxml_bytes(score, perf, title, composer)
     pdf_bytes = _render_pdf_bytes(musicxml_bytes)
-    return pdf_bytes, musicxml_bytes, midi_bytes, is_humanized
+    return pdf_bytes, musicxml_bytes, midi_bytes
 
 
 class EngraveService:
@@ -488,7 +491,7 @@ class EngraveService:
             title,
             isinstance(payload, HumanizedPerformance),
         )
-        pdf_bytes, musicxml_bytes, midi_bytes, is_humanized = await asyncio.to_thread(
+        pdf_bytes, musicxml_bytes, midi_bytes = await asyncio.to_thread(
             _engrave_sync, payload, title, composer,
         )
 
@@ -509,11 +512,16 @@ class EngraveService:
             chord_count,
         )
 
+        # NOTE: these flags describe what was *actually rendered*, not what
+        # the input contained. Dynamics and pedal marks are still
+        # unimplemented in the MusicXML render path (plan phase 1.3/1.4),
+        # so both stay False until those PRs land — even when the humanized
+        # input has dynamics or pedal events populated.
         return EngravedOutput(
             schema_version=SCHEMA_VERSION,
             metadata=EngravedScoreData(
-                includes_dynamics=is_humanized,
-                includes_pedal_marks=is_humanized,
+                includes_dynamics=False,
+                includes_pedal_marks=False,
                 includes_fingering=False,
                 includes_chord_symbols=chord_count > 0,
                 title=title,

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -476,12 +476,18 @@ def _render_musicxml_bytes(
                 part, score.metadata.chord_symbols, music21,
             )
 
-        # Quantize to a 16th-note + triplet grid. With
-        # defaults.divisionsPerQuarter=12 forced below, every quantized
-        # quarterLength lands exactly on a grid tick (16th = 3, triplet-8th
-        # = 4, quarter = 12) so <duration> values are integers without
-        # post-hoc rescaling.
-        part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
+        # Trust arrange's grid. arrange already quantizes every onset
+        # and duration via ``_estimate_best_grid`` (see
+        # ``backend/services/arrange.py``), picking the best of
+        # {triplet-16th, 16th, triplet-8th, 8th} for the incoming
+        # material. Re-quantizing here to a coarser ``(4, 3)`` divisor
+        # tuple would throw away whatever triplet-16th content arrange
+        # preserved. ``makeNotation`` auto-detects tuplet brackets from
+        # the raw quarterLength without an explicit hint, so the safety
+        # net no longer buys anything. PR-9 forces
+        # ``defaults.divisionsPerQuarter=12`` at the export boundary,
+        # which is LCM(2, 3, 4) — every grid value arrange can emit
+        # lands on an integer ``<duration>``.
         part.makeNotation(inPlace=True)
 
         # makeMeasures rebuilds per-measure Voice sub-streams with fresh

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -162,6 +162,91 @@ _CHORD_MIN_CONFIDENCE = 0.5
 _PITCH_OCTAVE_RE = re.compile(r"^[A-G][#b]?\d+$")
 
 
+# Minimum Krumhansl-Schmuckler correlation coefficient for an override
+# to fire. Empirically the KS analyzer reports ~0.90+ on clean tonal
+# material (e.g. two_hand_chordal at 0.965), ~0.78 on a bare diatonic
+# scale, and drops below 0.4 on highly chromatic content (jazz_voicings
+# at 0.35). 0.80 is the floor for a clearly-tonal excerpt — above this,
+# disagreements with the declared key almost always indicate upstream
+# mis-labeling rather than a confused analyzer. Below this we trust
+# the declared key and skip the override.
+_KEY_OVERRIDE_MIN_CORRELATION = 0.80
+
+
+def _resolve_key_signature(score: PianoScore, music21) -> tuple[str, str, bool]:  # noqa: ANN001
+    """Resolve the effective key signature using Krumhansl-Schmuckler.
+
+    Audio transcription / arrange can label a piece with the wrong key
+    — e.g. tagging an F# minor piece as "C:major" — and every accidental
+    downstream explodes because music21 emits sharps/flats for every
+    non-diatonic note. KS is the canonical pitch-histogram tonic finder
+    and ships with music21; five lines of analyzer gate + one override
+    fix the bug before makeNotation ever sees it.
+
+    Returns ``(root_name, mode, overridden)``. The override fires only
+    when **both** conditions hold:
+
+    1. Analyzer correlation ≥ ``_KEY_OVERRIDE_MIN_CORRELATION``. Low
+       correlations mean the pitch histogram is ambiguous (short
+       excerpts, highly chromatic jazz) — trust the upstream label.
+    2. The analyzer's (tonic, mode) disagrees with the declared key.
+       If KS agrees, the declared key is already correct and we skip
+       the override to keep logs quiet.
+
+    Any exception from the analyzer (empty stream, pitch-less notes,
+    library internals) falls back to the declared key so this never
+    blocks engrave.
+    """
+    declared = score.metadata.key or "C:major"
+    declared_root = declared.split(":")[0] if ":" in declared else "C"
+    declared_mode = "minor" if "minor" in declared else "major"
+
+    # Build a throwaway Stream from every note so the pitch histogram
+    # is the whole piece, not one hand or one measure. Velocity /
+    # duration / voice are irrelevant for KS — it only reads pitch
+    # classes.
+    all_notes = list(score.right_hand) + list(score.left_hand)
+    if not all_notes:
+        return declared_root, declared_mode, False
+
+    try:
+        # Pin every note to quarterLength=1 so the KS pitch-class histogram
+        # is duration-independent. Raw score durations can over-weight
+        # sustained LH pedal tones (a 4-beat F#2 gets 8× the histogram
+        # mass of a 0.5-beat RH note), which looks to KS like a single-
+        # pitch stream rather than a real key. Note-count weighting is
+        # what we actually want — the question is "what scale are these
+        # notes drawn from", not "which note is longest".
+        analysis_stream = music21.stream.Stream()
+        for sn in all_notes:
+            n = music21.note.Note(sn.pitch)
+            n.quarterLength = 1.0
+            analysis_stream.append(n)
+        analyzer = music21.analysis.discrete.KrumhanslSchmuckler()
+        result = analyzer.process(analysis_stream)
+    except Exception as exc:  # noqa: BLE001 — analyzer errors must not crash engrave
+        log.debug("key-signature analyzer failed; trusting declared %r: %s", declared, exc)
+        return declared_root, declared_mode, False
+
+    try:
+        tonic_pitch, analyzer_mode, correlation = result[0]
+    except (TypeError, IndexError, ValueError) as exc:
+        log.debug("unexpected KS result shape %r: %s", result, exc)
+        return declared_root, declared_mode, False
+
+    analyzer_root = tonic_pitch.name
+    if correlation < _KEY_OVERRIDE_MIN_CORRELATION:
+        return declared_root, declared_mode, False
+    if analyzer_root == declared_root and analyzer_mode == declared_mode:
+        return declared_root, declared_mode, False
+
+    log.info(
+        "engrave: KS key override — declared=%s:%s analyzer=%s:%s correlation=%.3f",
+        declared_root, declared_mode, analyzer_root, analyzer_mode, correlation,
+    )
+    return analyzer_root, analyzer_mode, True
+
+
 def _attach_chord_symbols(part, chord_symbols, music21) -> int:  # noqa: ANN001
     """Insert chord symbols onto a music21 part, returning the count rendered.
 
@@ -281,8 +366,13 @@ def _render_musicxml_bytes(
     ts = music21.meter.TimeSignature(
         f"{score.metadata.time_signature[0]}/{score.metadata.time_signature[1]}"
     )
-    key_root = score.metadata.key.split(":")[0] if ":" in score.metadata.key else "C"
-    mode = "major" if "minor" not in score.metadata.key else "minor"
+    # Verify the declared key against a KS pitch-histogram analysis
+    # before trusting it. Audio transcription can mis-label a piece and
+    # every accidental downstream turns into a sharp/flat explosion.
+    # ``_resolve_key_signature`` only overrides when the analyzer is
+    # confident (correlation ≥ 0.85) AND disagrees with the upstream
+    # label — otherwise the declared key wins.
+    key_root, mode, _key_overridden = _resolve_key_signature(score, music21)
     ks = music21.key.Key(key_root, mode)
     # Round BPM to a whole number so the metronome mark reads cleanly
     # (e.g., ♩ = 99 instead of ♩ = 99.38401442307693). The tempo map

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -245,6 +245,19 @@ def _render_musicxml_bytes(
             part.append(tempo_mark)
         part.append(clef)
 
+        # Group notes by voice so music21 emits <voice>1</voice> /
+        # <voice>2</voice> instead of collapsing everything to a single
+        # stream. Arrange now caps at 2 voices per hand (PR-10 / plan
+        # phase 3.1), but the older condense pipeline can still produce
+        # voice numbers up to 16 — for that high-voice path we fall back
+        # to a single stream on the staff, matching the pre-PR-10
+        # collapse-to-voice-1 behavior. Piano notation is *defined* by
+        # ≤2 voices per staff, so clamping here matches the physical
+        # reality of stems-up melody + stems-down accompaniment.
+        max_voice_in_hand = max((sn.voice for sn in notes), default=1)
+        use_explicit_voices = 1 < max_voice_in_hand <= 2
+
+        notes_by_voice: dict[int, list] = {}
         for sn in sorted(notes, key=lambda n: n.onset_beat):
             n = music21.note.Note(sn.pitch)
             n.quarterLength = sn.duration_beat
@@ -262,7 +275,26 @@ def _render_musicxml_bytes(
                 # inside <notations> either way, but only the
                 # expressions placement round-trips through makeNotation.
                 n.expressions.append(music21.expressions.Fermata())
-            part.insert(sn.onset_beat, n)
+            voice_num = sn.voice if use_explicit_voices else 1
+            notes_by_voice.setdefault(voice_num, []).append((sn.onset_beat, n))
+
+        if use_explicit_voices:
+            # Insert voice 1 before voice 2 so music21's internal
+            # enumeration (0-indexed, in insertion order) maps
+            # deterministically back to 1/2 after makeNotation. The
+            # string ``id`` we set here is discarded by ``makeMeasures``
+            # — it re-creates per-measure Voice streams with fresh
+            # integer ids — so the 1..N rename after ``makeNotation``
+            # is the authoritative step.
+            for voice_num in sorted(notes_by_voice.keys()):
+                v = music21.stream.Voice(id=str(voice_num))
+                for onset, n in notes_by_voice[voice_num]:
+                    v.insert(onset, n)
+                part.insert(0, v)
+        else:
+            for _, nlist in notes_by_voice.items():
+                for onset, n in nlist:
+                    part.insert(onset, n)
 
         # Dynamics + pedal marks are attached to the RH and LH parts
         # respectively so the markings sit between the staves where
@@ -291,6 +323,18 @@ def _render_musicxml_bytes(
         # post-hoc rescaling.
         part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
         part.makeNotation(inPlace=True)
+
+        # makeMeasures rebuilds per-measure Voice sub-streams with fresh
+        # integer ids (music21 treats large ints as memory locations and
+        # re-numbers them starting from 0), so the original "1"/"2"
+        # string ids we set before makeNotation are gone. Rename them
+        # back to the MusicXML-valid 1..N range. Enumeration order
+        # matches our insertion order on the part, so voice 0 → "1" and
+        # voice 1 → "2" — consistent across every measure.
+        for meas in part.getElementsByClass(music21.stream.Measure):
+            for idx, v in enumerate(meas.voices):
+                v.id = str(idx + 1)
+
         s.insert(0, part)
         piano_parts.append(part)
 
@@ -335,22 +379,32 @@ def _render_musicxml_bytes(
 def _sanitize_musicxml_for_osmd(raw: bytes) -> bytes:
     """Post-process music21 MusicXML to fix OSMD compatibility issues.
 
-    As of PR-9, ``<divisions>`` is now controlled at the source via
-    ``music21.defaults.divisionsPerQuarter = 12`` (see
-    ``_render_musicxml_bytes``), so the old post-hoc divisions-and-duration
-    rescaling is gone — durations are correct by construction.
+    Two mechanical fixups remain after PR-9 (source-level ``divisions=12``)
+    and PR-10 (Voice sub-streams for 2-voice preservation):
 
-    The remaining fix is voice collapse: OSMD's VexFlow backend crashes
-    (``parentVoiceEntry`` undefined) on 3+ voices per part, so we flatten
-    everything to voice 1. This destroys music21's voice separation
-    (stems-up melody / stems-down accompaniment) and will be replaced
-    with a 2-voice-preserving clamp in PR-10.
+    1. ``<voice>0</voice>`` → ``<voice>1</voice>`` — music21 emits 0 when
+       a note isn't wrapped in a ``Voice`` sub-stream and the part has
+       multiple voices elsewhere. MusicXML requires voice numbers ≥ 1,
+       and OSMD rejects zero outright.
+    2. ``<voice>N</voice>`` with N ≥ 3 → ``<voice>2</voice>`` — defense-in-
+       depth for any upstream stage (e.g. the condense path) that
+       produces more than two voices per hand. OSMD's VexFlow backend
+       crashes (``parentVoiceEntry undefined``) on 3+ voices per part;
+       clamping to 2 is the minimum-damage fallback.
     """
     import re
 
     text = raw.decode("utf-8")
-    # Collapse all voices to voice 1 (OSMD chokes on 3+ voices per part).
-    text = re.sub(r"<voice>\d+</voice>", "<voice>1</voice>", text)
+
+    def _clamp(match: re.Match[str]) -> str:
+        n = int(match.group(1))
+        if n == 0:
+            return "<voice>1</voice>"
+        if n > 2:
+            return "<voice>2</voice>"
+        return match.group(0)
+
+    text = re.sub(r"<voice>(\d+)</voice>", _clamp, text)
     return text.encode("utf-8")
 
 

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -223,12 +223,22 @@ def _render_musicxml_bytes(
         for a in perf.expression.articulations:
             articulations_at[a.score_note_id] = a.type
 
+    # Render as a real piano grand staff: two ``PartStaff`` objects bound
+    # by a braced ``StaffGroup``. music21 emits this as a single
+    # ``<part>`` with ``<staves>2</staves>`` and staff-tagged notes —
+    # exactly what OSMD / LilyPond / MuseScore expect for piano. Previous
+    # behavior emitted two separate ``<part>``s ("Right Hand", "Left
+    # Hand") which renderers drew as two stacked instruments without a
+    # connecting brace. Both PartStaffs share ``partName="Piano"`` so the
+    # merged ``<score-part>`` gets the correct "Piano" label.
+    piano_parts: list = []
     for hand_name, notes, clef in (
         ("Right Hand", score.right_hand, music21.clef.TrebleClef()),
         ("Left Hand", score.left_hand, music21.clef.BassClef()),
     ):
-        part = music21.stream.Part()
-        part.partName = hand_name
+        part = music21.stream.PartStaff()
+        part.partName = "Piano"
+        part.partAbbreviation = "Pno."
         part.append(ts)
         part.append(ks)
         if hand_name == "Right Hand":
@@ -279,7 +289,24 @@ def _render_musicxml_bytes(
         # which produces MusicXML that OSMD chokes on.
         part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
         part.makeNotation(inPlace=True)
-        s.append(part)
+        s.insert(0, part)
+        piano_parts.append(part)
+
+    # Bind the two PartStaffs into a braced grand staff. music21 detects
+    # the StaffGroup and collapses them into one ``<part>`` with
+    # ``<staves>2</staves>`` in the MusicXML output, with each note
+    # carrying a ``<staff>`` tag so renderers place it on the correct
+    # stave.
+    s.insert(
+        0,
+        music21.layout.StaffGroup(
+            piano_parts,
+            name="Piano",
+            abbreviation="Pno.",
+            symbol="brace",
+            barTogether=True,
+        ),
+    )
 
     with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
         tmp_path = Path(tmp.name)

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -284,9 +284,11 @@ def _render_musicxml_bytes(
         #     except Exception:
         #         pass
 
-        # Quantize to a 16th-note + triplet grid so OSMD can render it.
-        # Without explicit divisors, music21 defaults to divisions=10080
-        # which produces MusicXML that OSMD chokes on.
+        # Quantize to a 16th-note + triplet grid. With
+        # defaults.divisionsPerQuarter=12 forced below, every quantized
+        # quarterLength lands exactly on a grid tick (16th = 3, triplet-8th
+        # = 4, quarter = 12) so <duration> values are integers without
+        # post-hoc rescaling.
         part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
         part.makeNotation(inPlace=True)
         s.insert(0, part)
@@ -308,70 +310,47 @@ def _render_musicxml_bytes(
         ),
     )
 
+    # Force divisions=12 at the exporter boundary. music21's MeasureExporter
+    # reads ``defaults.divisionsPerQuarter`` verbatim when stamping the
+    # ``<divisions>`` tag (m21ToXml.setMxAttributesObjectForStartOfMeasure)
+    # and the shipped default is 10080 — producing MusicXML that OSMD
+    # chokes on. 12 = LCM(4, 3) which is the finest grid we need to
+    # represent the (4, 3) quarterLengthDivisors quantization: 16th = 3
+    # divisions, 8th = 6, triplet-8th = 4, quarter = 12. Done here
+    # (process-global, restored after write) rather than at module import
+    # so non-engrave music21 callers keep the upstream default.
     with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
         tmp_path = Path(tmp.name)
+    prior_divisions = music21.defaults.divisionsPerQuarter
     try:
+        music21.defaults.divisionsPerQuarter = 12
         s.write("musicxml", fp=str(tmp_path))
         raw = tmp_path.read_bytes()
         return _sanitize_musicxml_for_osmd(raw)
     finally:
+        music21.defaults.divisionsPerQuarter = prior_divisions
         tmp_path.unlink(missing_ok=True)
 
 
 def _sanitize_musicxml_for_osmd(raw: bytes) -> bytes:
     """Post-process music21 MusicXML to fix OSMD compatibility issues.
 
-    OSMD's VexFlow backend crashes (parentVoiceEntry) when:
-    1. <divisions> is very high (10080) — we reduce to 4 (16th-note grid)
-    2. Voice numbers exceed 2 per part — we collapse to voice 1
-    3. Voice 0 exists — OSMD expects 1-indexed voices
+    As of PR-9, ``<divisions>`` is now controlled at the source via
+    ``music21.defaults.divisionsPerQuarter = 12`` (see
+    ``_render_musicxml_bytes``), so the old post-hoc divisions-and-duration
+    rescaling is gone — durations are correct by construction.
 
-    We also scale all <duration> values proportionally when changing divisions.
+    The remaining fix is voice collapse: OSMD's VexFlow backend crashes
+    (``parentVoiceEntry`` undefined) on 3+ voices per part, so we flatten
+    everything to voice 1. This destroys music21's voice separation
+    (stems-up melody / stems-down accompaniment) and will be replaced
+    with a 2-voice-preserving clamp in PR-10.
     """
     import re
 
     text = raw.decode("utf-8")
-
-    # Find the current divisions value
-    div_match = re.search(r"<divisions>(\d+)</divisions>", text)
-    if div_match:
-        old_div = int(div_match.group(1))
-        new_div = 4  # 4 divisions per quarter = 16th-note grid
-
-        if old_div != new_div and old_div > 0:
-            ratio = new_div / old_div
-
-            # Replace all <divisions> tags
-            text = re.sub(
-                r"<divisions>\d+</divisions>",
-                f"<divisions>{new_div}</divisions>",
-                text,
-            )
-
-            # Scale all <duration> values
-            def scale_duration(m: re.Match) -> str:
-                old_dur = int(m.group(1))
-                new_dur = max(1, round(old_dur * ratio))
-                return f"<duration>{new_dur}</duration>"
-
-            text = re.sub(r"<duration>(\d+)</duration>", scale_duration, text)
-
-            # Scale <forward> and <backup> durations too
-            def scale_forward(m: re.Match) -> str:
-                tag = m.group(1)
-                old_dur = int(m.group(2))
-                new_dur = max(1, round(old_dur * ratio))
-                return f"<{tag}>\n        <duration>{new_dur}</duration>"
-
-            text = re.sub(
-                r"<(forward|backup)>\s*<duration>(\d+)</duration>",
-                scale_forward,
-                text,
-            )
-
-    # Collapse all voices to voice 1 (OSMD chokes on 3+ voices per part)
+    # Collapse all voices to voice 1 (OSMD chokes on 3+ voices per part).
     text = re.sub(r"<voice>\d+</voice>", "<voice>1</voice>", text)
-
     return text.encode("utf-8")
 
 

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -6,7 +6,7 @@ keeps working in environments without pretty_midi / music21 / LilyPond.
 
   * MIDI     — pretty_midi if installed, else a minimal MThd+MTrk file
   * MusicXML — music21 if installed, else a minimal score-partwise body
-  * PDF      — MuseScore / LilyPond CLI if on $PATH, else a 1-line %PDF stub
+  * PDF      — LilyPond (preferred) or MuseScore CLI if on $PATH, else a 1-line %PDF stub
 """
 from __future__ import annotations
 
@@ -448,35 +448,36 @@ def _midi_to_step_alter_octave(midi: int) -> tuple[str, int, int]:
 # ---------------------------------------------------------------------------
 
 def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
-    """Try MuseScore CLI then LilyPond. Returns the stub PDF on failure."""
-    if not (shutil.which("musescore4") or shutil.which("musescore3")
-            or shutil.which("mscore") or shutil.which("MuseScore4")
-            or (shutil.which("musicxml2ly") and shutil.which("lilypond"))):
-        log.warning("No PDF renderer found — install LilyPond or MuseScore for real PDF output")
+    """Render MusicXML to PDF bytes.
+
+    Tries LilyPond first (this is what production ships — ~250 MB apt
+    package, musicxml2ly + lilypond binaries) and MuseScore as a
+    higher-fidelity fallback for local dev machines that have it
+    installed. Returns the 60-byte stub PDF only when no renderer is
+    available or all renderers fail.
+    """
+    has_lilypond = bool(shutil.which("musicxml2ly") and shutil.which("lilypond"))
+    mscore_bin = next(
+        (b for b in ("musescore4", "musescore3", "mscore", "MuseScore4") if shutil.which(b)),
+        None,
+    )
+
+    if not has_lilypond and mscore_bin is None:
+        log.warning(
+            "No PDF renderer found — install lilypond (preferred) or MuseScore "
+            "for real PDF output; emitting stub",
+        )
         return _STUB_PDF
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         xml_path = tmp / "score.musicxml"
-        pdf_path = tmp / "sheet.pdf"
         xml_path.write_bytes(musicxml_bytes)
 
-        for mscore in ("musescore4", "musescore3", "mscore", "MuseScore4"):
-            if not shutil.which(mscore):
-                continue
+        if has_lilypond:
+            ly_path = tmp / "score.ly"
+            pdf_path = tmp / "sheet.pdf"
             try:
-                subprocess.run(
-                    [mscore, "-o", str(pdf_path), str(xml_path)],
-                    check=True, capture_output=True, timeout=120,
-                )
-                if pdf_path.is_file():
-                    return pdf_path.read_bytes()
-            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
-                continue
-
-        if shutil.which("musicxml2ly") and shutil.which("lilypond"):
-            try:
-                ly_path = tmp / "score.ly"
                 subprocess.run(
                     ["musicxml2ly", "-o", str(ly_path), str(xml_path)],
                     check=True, capture_output=True, timeout=60,
@@ -486,9 +487,39 @@ def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
                     check=True, capture_output=True, timeout=120,
                 )
                 if pdf_path.is_file():
+                    log.info("PDF rendered via LilyPond (%d bytes)", pdf_path.stat().st_size)
                     return pdf_path.read_bytes()
-            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
-                pass
+                log.warning("LilyPond ran but produced no PDF at %s", pdf_path)
+            except subprocess.CalledProcessError as exc:
+                log.warning(
+                    "LilyPond PDF render failed (%s): %s",
+                    exc.cmd[0] if exc.cmd else "?",
+                    (exc.stderr or b"").decode("utf-8", "replace")[:500],
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                log.warning("LilyPond PDF render failed: %s", exc)
+
+        if mscore_bin is not None:
+            pdf_path = tmp / "sheet.pdf"
+            try:
+                subprocess.run(
+                    [mscore_bin, "-o", str(pdf_path), str(xml_path)],
+                    check=True, capture_output=True, timeout=120,
+                )
+                if pdf_path.is_file():
+                    log.info(
+                        "PDF rendered via %s (%d bytes)", mscore_bin, pdf_path.stat().st_size,
+                    )
+                    return pdf_path.read_bytes()
+                log.warning("%s ran but produced no PDF at %s", mscore_bin, pdf_path)
+            except subprocess.CalledProcessError as exc:
+                log.warning(
+                    "%s PDF render failed: %s",
+                    mscore_bin,
+                    (exc.stderr or b"").decode("utf-8", "replace")[:500],
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                log.warning("%s PDF render failed: %s", mscore_bin, exc)
 
     return _STUB_PDF
 

--- a/docs/engrave-improvement-plan.md
+++ b/docs/engrave-improvement-plan.md
@@ -1,0 +1,433 @@
+# Engrave Stage — Improvement Plan
+
+Synthesis of three parallel research passes on `backend/services/engrave.py`:
+renderer infrastructure & output fidelity, musical notation quality, and
+evaluation strategy. Scoped to measurable, incremental improvements that can
+each land as a single PR.
+
+## TL;DR
+
+The engrave stage today is functional but leaks value on every axis:
+
+- **Two latent correctness issues** — `timing_offset_ms` is applied to both
+  onset and offset at `engrave.py:87-88` (duration-preserving shift — probably
+  not what humanize intends), and `EngravedScoreData.includes_dynamics/pedal`
+  at `engrave.py:515` claim features that are never actually rendered.
+- **Data is being dropped on the floor.** `humanize.py:101-114` generates
+  dynamics; engrave never reads `perf.expression.dynamics`. Pedal events
+  reach MIDI but not MusicXML. Chord symbols are disabled entirely.
+- **The OSMD sanitizer regex (`engrave.py:242-296`) is a workaround masquerading
+  as infrastructure.** It collapses voices 1+2 (destroying piano stems-up/
+  stems-down) and rescales divisions after the fact. Both problems are better
+  fixed at the music21 export boundary.
+- **Test coverage for engrave is ~zero.** No fixture-based golden tests,
+  no schema validation, no MIDI round-trip. Every change is a shot in the
+  dark.
+- **Production emits stub PDFs.** The Cloud Run image has no MuseScore or
+  LilyPond, so every job returns the 60-byte `%PDF-1.4` stub.
+
+The right order is **build the evaluation harness first**, then fix the bugs
+it surfaces, then ship the incremental notation/renderer improvements with
+regression coverage on every PR.
+
+---
+
+## Phase 0 — Evaluation harness (land before any behavior changes)
+
+Rationale: almost every improvement below is risky without a way to A/B old
+vs. new output. Building the harness first means subsequent PRs are
+diffable and reviewable.
+
+### 0.1 Score fixtures — `tests/fixtures/scores/`
+Commit ten small hand-authored `PianoScore` / `HumanizedPerformance` fixtures
+as Pydantic-built JSON so they survive contract changes via re-validation:
+
+1. `single_note.json` — RH C4 only (trivial baseline)
+2. `c_major_scale.json` — RH scale + LH whole notes (beaming, single voice)
+3. `two_hand_chordal.json` — RH triads + LH octaves (`<staff>` separation)
+4. `bach_invention_excerpt.json` — 8 bars of two-voice counterpoint, RH
+   only — **the voice-handling fixture**
+5. `jazz_voicings.json` — chromatic bass + 7th-chord shells (accidentals)
+6. `seven_eight.json` — 7/8 irregular grouping (time-sig propagation,
+   `quarterLengthDivisors=(4,3)` edge cases)
+7. `tempo_change.json` — multi-segment `tempo_map`
+8. `humanized_with_offsets.json` — c_major_scale with
+   `timing_offset_ms ∈ [-30,30]` and a sustain pedal event — **the timing-bug
+   fixture**
+9. `empty_left_hand.json` — RH only (catches no-note backup logic)
+10. `overlapping_same_pitch.json` — two RH C4 notes that overlap (exercises
+    `engrave.py:94-103` overlap resolver)
+
+Promote the `_piano_score()` / `_humanized_performance()` builders from
+`tests/test_stages.py` into a shared `tests/fixtures/_builders.py` +
+`load_score_fixture(name)` helper.
+
+### 0.2 Test layers, in priority order
+
+| Layer | Catches | Runs |
+|---|---|---|
+| **L1 — MIDI round-trip** | `timing_offset_ms` bug, dropped notes, wrong pitches | Every PR |
+| **L2 — Notation quality lints** (lxml xpath) | `<voice>` out of range, divisions > 480, out-of-piano-range pitches, note-count mismatch | Every PR |
+| **L3 — MusicXML 4.0 XSD validation** | Structural schema violations | Every PR |
+| **L4 — MusicXML golden diffs** | Regressions in music21 output after normalization | Every PR |
+| **L5 — Verovio render check** | MusicXML that validates but won't render; missing measure attributes | Every PR |
+| **L6 — OSMD/Playwright headless** | `parentVoiceEntry` class crashes in actual consumer | **Nightly only** |
+| **L7 — MuseScore/LilyPond PDF** | Real engraver feedback | **Manual / nightly**, not PR-blocking |
+
+Layers L1–L5 are all cheap (sub-second each) and add <10s to CI. Dev deps
+to add to `pyproject.toml`: `lxml` (already transitive), `verovio` (~10 MB
+pure-Python wheel, no system deps). Vendor `musicxml-4.0.xsd` into
+`tests/fixtures/`.
+
+**Skip** MuseScore/LilyPond in PR CI (500 MB+ images, nondeterministic
+output, X-server hassles). Reserve for optional nightly on a beefier runner.
+
+### 0.3 Golden-file normalization
+Before diffing MusicXML goldens, strip time-varying tags: `<encoding-date>`,
+`<software>`, `<encoder>`, `<creator type="software">`, `<supports>`. Use
+`lxml.etree.canonicalize`. Ship a `pytest --update-goldens` flag from day
+one so music21 version bumps are a reviewable diff, not a mystery churn.
+Pin music21 exactly in `pyproject.toml`.
+
+### 0.4 A/B regression harness — `scripts/engrave_diff.py`
+Takes two git refs, runs all fixtures through both, prints a table of
+MusicXML normalized-byte-diff sizes and Verovio note counts per fixture.
+Not a test — an investigative CLI for PR authors.
+
+**Expected first finding:** the failing `humanized_with_offsets` MIDI
+round-trip test surfaces the `timing_offset_ms` behavior so we can make an
+informed decision (is it a bug, or is it the intended "whole-note shift"
+model?).
+
+---
+
+## Phase 1 — Bug fixes and truth-telling (small PRs, low risk)
+
+### 1.1 Truthful `EngravedScoreData` flags
+`engrave.py:512-526` currently sets `includes_dynamics=is_humanized` and
+`includes_pedal_marks=is_humanized` unconditionally. Change to reflect
+actual rendered content:
+
+```python
+includes_dynamics=bool(perf and perf.expression.dynamics),
+includes_pedal_marks=bool(perf and perf.expression.pedal_events),
+```
+
+**Effort: S. Risk: none.** Land independently before 1.3/1.4 because those
+will flip these flags to actually-True.
+
+### 1.2 `timing_offset_ms` semantics decision — `engrave.py:87-88`
+The shift is applied to *both* onset and offset, so duration is preserved
+(it's a pure translation, not a stretch). Whether that's correct depends on
+humanize's intent — does `timing_offset_ms` mean "nudge the whole note" or
+"nudge the onset only"? Check `backend/services/humanize.py` and the schema
+docstring on `ExpressiveNote`. Two possible fixes:
+
+- **If onset-only:** apply the offset only to `onset` and let `offset`
+  absorb a duration change, OR introduce a separate release-offset field.
+- **If whole-note shift:** current code is correct; document it and close
+  the issue.
+
+The L1 MIDI round-trip test (fixture 8) will fail either way; resolving it
+forces the decision to be made explicit.
+
+**Effort: S (after decision). Risk: low — test will pin behavior.**
+
+### 1.3 Render dynamics from `perf.expression.dynamics`
+Currently zero lines reference `perf.expression.dynamics` in engrave, even
+though humanize populates them at `humanize.py:101-114`. In the RH part
+loop (`engrave.py:186-227`), after `part.append(clef)`, walk
+`perf.expression.dynamics`:
+
+- `pp/p/mp/mf/f/ff` → `music21.dynamics.Dynamic(type)` inserted at `dyn.beat`
+- `crescendo/decrescendo` → `music21.dynamics.Crescendo()` / `Diminuendo()`
+  spanners using `span_beats` for the end anchor
+
+Attach to RH only so markings sit between staves.
+
+**Effort: S. Risk: low.** Flip flag from 1.1 after this lands.
+
+### 1.4 Render pedal markings in MusicXML
+`engrave.py:111-124` writes CC64 to MIDI only. Add pedal marks to the LH
+part via `music21.expressions.TextExpression("Ped.")` at
+`pedal.onset_beat` and `"*"` at `pedal.offset_beat` (falling back from
+`music21.expressions.PedalMark`, whose support varies across music21
+versions).
+
+**Effort: S. Risk: low — text directions always work.**
+
+### 1.5 Emit sostenuto (CC66) and una_corda (CC67)
+`engrave.py:111-124` hard-codes `pedal.type == "sustain"`. The
+`PedalEvent.type` literal in `shared/shared/contracts.py` already supports
+`sostenuto` and `una_corda`. Add two more branches mapping to CC66/CC67.
+
+**Effort: S. Risk: none.**
+
+### 1.6 Handle fermata articulation
+`engrave.py:203-208` handles staccato/accent/tenuto but drops `fermata`
+from the `Articulation.type` literal. Add:
+`music21.expressions.Fermata()` appended to the note.
+
+Skip `legato` for now — slurs need spanner endpoints that humanize doesn't
+yet emit.
+
+**Effort: S. Risk: none.**
+
+---
+
+## Phase 2 — Renderer infrastructure (medium PRs)
+
+### 2.1 Install LilyPond in the production image — **biggest user-visible win**
+`Dockerfile` currently installs only ffmpeg on `python:3.12-slim`, so
+`_render_pdf_bytes` always returns the 60-byte stub in production. Options
+ranked:
+
+| Option | Size add | Quality | Complexity |
+|---|---|---|---|
+| **LilyPond via apt** | ~250 MB | Excellent engraving, but `musicxml2ly` is lossy (loses chord symbols, some articulations) | S — 3 lines in Dockerfile |
+| MuseScore 4 headless | ~600–900 MB | Highest fidelity | M — Xvfb + Qt deps, 2–5s cold start |
+| Verovio → SVG → cairosvg → PDF | ~10 MB | Modern engraving, MusicXML 4.0 native | M — new code, page-break logic |
+| Server-side OSMD via Playwright | ~300 MB | Visual parity with web viewer | L — Chromium, 1–3s/page, fragile |
+
+**Recommendation: LilyPond first.** Smallest delta from current state,
+ships real PDFs tomorrow. Verovio is the more attractive long-term play
+(smallest image, modern output) but is M-sized new code; schedule as a
+follow-up if LilyPond's `musicxml2ly` loses notation we care about.
+
+**Effort: S. Risk: image size budget review.**
+
+### 2.2 Hard-require music21; delete `_minimal_musicxml`
+The `_minimal_musicxml` fallback at `engrave.py:299-358` is "not bar-aware"
+per its own docstring and would produce unrenderable MusicXML if it ever
+ran in prod. The bare `except Exception` at `engrave.py:237` masks music21
+errors and would silently fall through to this path. Music21 is already
+required in practice — promote it in `pyproject.toml`, delete lines
+299–358 and the import-error branches at 156–160, and let exceptions
+propagate to the job manager so failures are visible.
+
+**Effort: S. Risk: verify no dev environment actually runs without
+music21. Install size is ~30 MB.**
+
+### 2.3 PianoStaff grouping — one part with `<staves>2</staves>`
+Currently each hand is a separate `<part>` named "Right Hand" / "Left
+Hand". Correct piano notation is one `<part>` with two staves and a brace.
+In music21: two `PartStaff` objects wrapped in
+`music21.layout.StaffGroup(..., symbol='brace', barTogether=True)`. See
+how `_minimal_musicxml` already structures this at `engrave.py:344-346`.
+
+**Effort: S (~10 lines around `engrave.py:186-227`). Impact: visible
+improvement — real grand staff instead of two stacked instruments.**
+
+### 2.4 Set `divisionsPerQuarter` upfront; retire the regex sanitizer's
+divisions branch
+The regex sanitizer (`engrave.py:242-296`) exists because music21 picks
+`divisions=10080` and OSMD chokes. Fix it at the source by calling
+`music21.musicxml.m21ToXml.ScoreExporter(score).parse()` with an explicit
+`divisionsPerQuarter=4`, or by invoking `makeNotation(inPlace=True)` at
+the score level with `quarterLengthDivisors` set. This makes durations
+correct *by construction* instead of by integer-rounded ratios (which
+silently truncates anything finer than a 16th).
+
+Keep the voice-collapse regex for now; remove it in 3.1.
+
+**Effort: M. Risk: scoring quirks for tuplets. Mitigation: gate behind a
+feature flag and A/B against fixtures 2, 4, 6 using the harness from
+0.4.**
+
+### 2.5 Multi-tempo MIDI export
+`engrave.py:69` reads only `tempo_map[0].bpm`. The schema supports
+multi-segment tempo maps. `pretty_midi` doesn't expose mid-piece tempo
+writes cleanly; drop to `mido.MidiFile` with `MetaMessage('set_tempo', ...)`
+events. This currently has no user-visible impact because upstream only
+emits constant tempo — ship only after arrange/humanize start producing
+real tempo maps.
+
+**Effort: S–M. Risk: low. Defer until upstream actually varies tempo.**
+
+---
+
+## Phase 3 — Notation quality (medium-to-large PRs)
+
+### 3.1 Preserve voices 1 and 2 per staff
+The biggest visual-readability improvement in this plan. Piano notation is
+*defined* by two voices per staff (stems up = melody, stems down =
+accompaniment). The regex at `engrave.py:294` collapses everything to
+voice 1, destroying music21's voice output.
+
+Two-PR sequence:
+1. Cap `MAX_VOICES_RH` / `MAX_VOICES_LH` at 2 in `arrange.py:40-41`
+   (arrange currently allows 4/3 via greedy first-fit in
+   `arrange.py:194-210`).
+2. Change the OSMD sanitizer to clamp voices ≥3 to 2 instead of
+   collapsing everything to 1; set `n.voice = sn.voice` before insertion
+   in `engrave.py:209` so music21 honors the assignment.
+
+OSMD reliably handles 2 voices per staff — only 3+ are buggy. Validate
+with fixture 4 (`bach_invention_excerpt`) before merging.
+
+**Effort: M. Risk: M — if there really are 2-voice OSMD bugs, nightly
+Playwright test (L6) will catch them before release.**
+
+### 3.2 Chord-symbol cleanup + gated re-enable
+Currently disabled at `engrave.py:211-220` because transcription produces
+noisy labels like "G5", "E5" (pitch names, not chord qualities). Filter
+design:
+
+- Reject any label matching `^[A-G][#b]?\d+$` (those are pitch-and-octave,
+  not chord qualities)
+- Require `music21.harmony.ChordSymbol(label)` parses cleanly AND
+  `len(chord.pitches) >= 3`
+- Gate by `RealtimeChordEvent.confidence` — but note
+  `arrange.py:378-389` drops confidence when converting to
+  `ScoreChordEvent`. **One-line contract change:** add
+  `confidence: float` to `ScoreChordEvent` in
+  `shared/shared/contracts.py:205-209` and propagate.
+
+Wrap each `ChordSymbol` construction in try/except; the parser is
+finicky.
+
+**Effort: M. Risk: M — contract change affects serialization.**
+
+### 3.3 Key signature verification via Krumhansl-Schmuckler
+`engrave.py:171-172` trusts `score.metadata.key` blindly. If transcription
+says `"C:major"` for a piece that's actually F# minor, every accidental
+explodes. music21 ships `analysis.discrete.KrumhanslSchmuckler` — a
+~5-line check. If analyzer confidence is high and disagrees with metadata,
+override and log.
+
+**Effort: M. Risk: low (override is gated on high confidence).**
+
+### 3.4 Quantization grid improvements
+`engrave.py:225` uses `quarterLengthDivisors=(4, 3)` (16ths + triplets).
+Two mutually-exclusive directions:
+
+- **Expand divisor tuple tempo-adaptively:** add 8 (32nds) and 6
+  (sextuplets) at `bpm < 80`; drop to `(4, 3)` only above ~140. Simple
+  but noisy transcriptions fragment into 32nds.
+- **Better:** remove the re-quantize entirely. arrange already quantizes
+  via `_estimate_best_grid` (`arrange.py:67-97`); engrave only
+  re-quantizes because the OSMD sanitizer collapses divisions to 4. Once
+  2.4 lands, engrave can trust arrange's grid.
+
+**Effort: S–M depending on direction. Blocked on 2.4.**
+
+### 3.5 System breaks at section boundaries
+Insert `music21.layout.SystemLayout(isNew=True)` at `ScoreSection`
+boundaries so each verse/chorus starts on a new system. Polish item —
+ship only if users request it.
+
+**Effort: S. Impact: low. Skip until requested.**
+
+---
+
+## Phase 4 — Long-horizon / spikes
+
+### 4.1 Verovio frontend swap (OSMD → Verovio)
+The entire `_sanitize_musicxml_for_osmd` function (`engrave.py:242-296`)
+exists because OSMD's VexFlow backend is limited. Verovio supports
+MusicXML 4.0, unlimited voices, and complex tuplets. Bundle size is ~3–5
+MB (vs OSMD's ~1.5 MB), but the sanitizer disappears and phase 3 becomes
+trivial. **Scope:** Flutter web viewer rewrite in
+`frontend/lib/widgets/sheet_music_viewer_web.dart`.
+
+**Effort: L. Do this as a dedicated spike after phases 0–2 land.**
+
+### 4.2 Fingering via `pianoplayer`
+`pianoplayer` (pip) consumes MusicXML, runs hand-physics search, writes
+fingerings back. Integration point: after `s.write("musicxml", ...)` at
+`engrave.py:232`, shell out and re-read. Adds numpy + scipy dependencies
+(~50 MB) and a few-second runtime hit. Worth it only if users want
+practice-grade scores; `EngravedScoreData.includes_fingering` is
+currently hardcoded `False`.
+
+**Effort: ML–L. Schedule after user demand.**
+
+### 4.3 Voice separation with pitch-continuity bias
+arrange's voice allocator (`arrange.py:194-210`) is overlap-avoidance,
+not musical voice separation. Phase 1: bias voice choice toward the voice
+whose last note is closest in pitch. Phase 2: investigate Temperley's
+Streamer or music21's `makeVoices`. **Belongs in arrange, not engrave.**
+
+---
+
+## Recommended PR sequence
+
+1. **PR-1 (Phase 0.1–0.2):** Score fixtures + L1 MIDI round-trip + L2
+   notation lints. Lands with one known-failing test (`humanized_with_offsets`).
+2. **PR-2 (Phase 0.3–0.4):** L3 XSD + L4 goldens + L5 Verovio + A/B CLI.
+3. **PR-3 (Phase 1.1):** Truthful `EngravedScoreData` flags.
+4. **PR-4 (Phase 1.2):** Resolve `timing_offset_ms` semantics; turn the
+   failing test green.
+5. **PR-5 (Phase 1.3–1.6):** Dynamics + pedal marks + CC66/CC67 + fermata.
+   One combined "stop dropping data" PR.
+6. **PR-6 (Phase 2.1):** LilyPond in Dockerfile. Real PDFs in prod.
+7. **PR-7 (Phase 2.2):** Delete `_minimal_musicxml`; hard-require music21.
+8. **PR-8 (Phase 2.3):** PianoStaff grouping / grand staff.
+9. **PR-9 (Phase 2.4):** `divisionsPerQuarter` upfront; retire divisions
+   regex branch.
+10. **PR-10 (Phase 3.1):** Cap arrange voices at 2 + preserve 2 voices in
+    engrave.
+11. **PR-11 (Phase 3.2):** Chord symbol cleanup + contract tweak + re-enable.
+12. **PR-12 (Phase 3.3):** Key-signature verification.
+13. **PR-13 (Phase 3.4):** Quantization grid rework (only after PR-9).
+
+PRs 1–2 unlock everything else. PRs 3–6 are all S-sized and land in the
+first week. PRs 7–13 are each reviewable against the harness.
+
+---
+
+## Key file:line references
+
+- `backend/services/engrave.py:87-88` — `timing_offset_ms` applied to both
+  onset and offset
+- `backend/services/engrave.py:111-124` — sustain-only pedal filter,
+  MIDI-only output
+- `backend/services/engrave.py:162-227` — music21 score build (no dynamics,
+  no pedal marks)
+- `backend/services/engrave.py:211-220` — disabled chord symbols
+- `backend/services/engrave.py:225` — `quarterLengthDivisors=(4, 3)`
+- `backend/services/engrave.py:237` — bare `except Exception`, masks
+  music21 errors
+- `backend/services/engrave.py:242-296` — OSMD regex sanitizer
+- `backend/services/engrave.py:294` — voice-collapse-to-1
+- `backend/services/engrave.py:299-358` — `_minimal_musicxml` (not
+  bar-aware, latent footgun)
+- `backend/services/engrave.py:378-421` — PDF rendering (stubs in prod)
+- `backend/services/engrave.py:512-526` — `EngravedScoreData` flags that
+  lie
+- `backend/services/humanize.py:101-114` — dynamics generated then dropped
+- `backend/services/arrange.py:40-41` — `MAX_VOICES_RH=4`,
+  `MAX_VOICES_LH=3`
+- `backend/services/arrange.py:194-210` — greedy voice allocator
+- `backend/services/arrange.py:378-389` — chord confidence dropped on
+  conversion
+- `shared/shared/contracts.py` — `ScoreChordEvent` lacks `confidence`;
+  `PedalEvent.type` already supports sostenuto/una_corda;
+  `ExpressionMap.dynamics` already supports crescendo/decrescendo
+- `Dockerfile` — no MuseScore/LilyPond in production image
+- `tests/test_stages.py` — existing `_piano_score()` /
+  `_humanized_performance()` builders, promote to fixture loader
+- `tests/conftest.py` — reuse `isolated_blob_root` fixture
+
+---
+
+## What this plan does *not* do
+
+- No speculative refactors of the engrave service structure. The file is
+  ~500 lines and single-purpose; it doesn't need to be split.
+- No runtime performance work. engrave is not on any hot path.
+- No new file format outputs (ABC, MEI, etc.) — users want PDF + MIDI.
+- No upstream pipeline changes except the minimal ones called out
+  (voice caps in arrange, `confidence` on `ScoreChordEvent`).
+
+## Open questions for follow-up
+
+1. Does `timing_offset_ms` mean "nudge the whole note" or "nudge the
+   onset only"? Requires a read of `humanize.py` and a product-intent
+   call.
+2. Is music21 actually an optional dep or already required? Check
+   `pyproject.toml` before PR-7.
+3. What's the image size budget for Cloud Run? LilyPond adds ~250 MB —
+   need a deploy-side yes/no before PR-6.
+4. Is the frontend team open to a Verovio spike, or is OSMD a hard
+   constraint? Determines whether Phase 4.1 is even worth scoping.

--- a/frontend/lib/widgets/version_footer.dart
+++ b/frontend/lib/widgets/version_footer.dart
@@ -1,21 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../theme.dart';
 
-const appVersion = String.fromEnvironment('APP_VERSION', defaultValue: 'dev');
+/// Optional compile-time override (e.g. Docker `--dart-define=APP_VERSION=…`).
+/// When empty, the label comes from [PackageInfo] (semver + build from `pubspec.yaml`).
+const _envVersion = String.fromEnvironment('APP_VERSION', defaultValue: '');
 
 class VersionFooter extends StatelessWidget {
   const VersionFooter({super.key});
 
+  static String _displayFromEnv() {
+    final raw = _envVersion.trim();
+    if (raw.isEmpty) return '';
+    final normalized = raw.startsWith('v') ? raw.substring(1) : raw;
+    return 'v$normalized';
+  }
+
+  static String _displayFromPackageInfo(PackageInfo info) {
+    final build = info.buildNumber.trim();
+    final hasBuild = build.isNotEmpty && build != '0';
+    return hasBuild ? 'v${info.version}+$build' : 'v${info.version}';
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Text(
-      'v$appVersion',
-      style: TextStyle(
-        fontSize: 11,
-        color: OhSheetColors.mutedText.withValues(alpha: 0.5),
-        fontWeight: FontWeight.w500,
-      ),
+    final fromEnv = _displayFromEnv();
+    if (fromEnv.isNotEmpty) {
+      return Text(
+        fromEnv,
+        style: TextStyle(
+          fontSize: 11,
+          color: OhSheetColors.mutedText.withValues(alpha: 0.5),
+          fontWeight: FontWeight.w500,
+        ),
+      );
+    }
+
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox(height: 14);
+        }
+        final label = _displayFromPackageInfo(snapshot.data!);
+        return Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            color: OhSheetColors.mutedText.withValues(alpha: 0.5),
+            fontWeight: FontWeight.w500,
+          ),
+        );
+      },
     );
   }
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -200,6 +200,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   file_picker: ^8.0.0
   url_launcher: ^6.2.5
   flutter_svg: ^2.2.4
+  package_info_plus: ^8.1.2
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/frontend/test/widgets/version_footer_test.dart
+++ b/frontend/test/widgets/version_footer_test.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ohsheet_app/widgets/version_footer.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 void main() {
-  testWidgets('VersionFooter displays version text', (tester) async {
+  testWidgets('VersionFooter shows pubspec version when APP_VERSION unset', (tester) async {
+    PackageInfo.setMockInitialValues(
+      appName: 'Oh Sheet',
+      packageName: 'ohsheet_app',
+      version: '0.1.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -11,8 +20,8 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
-    // Default value when APP_VERSION is not defined at compile time
-    expect(find.text('vdev'), findsOneWidget);
+    expect(find.text('v0.1.0+1'), findsOneWidget);
   });
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dev = [
     "httpx>=0.26",
     "ruff>=0.4",
     "mypy>=1.10",
+    # Engrave-evaluation harness: lxml drives the xpath lints that check
+    # the MusicXML music21 emits (see tests/test_engrave_quality.py and
+    # docs/engrave-improvement-plan.md Phase 0.2 Layer L2).
+    "lxml>=5.0",
 ]
 youtube = [
     "yt-dlp>=2024.1",

--- a/shared/shared/contracts.py
+++ b/shared/shared/contracts.py
@@ -207,6 +207,10 @@ class ScoreChordEvent(BaseModel):
     duration_beat: float
     label: str                                 # Harte notation
     root: int
+    # Propagated from the upstream ``RealtimeChordEvent`` so engrave can
+    # gate chord-symbol rendering on transcriber confidence. Defaults to
+    # 1.0 for legacy/test inputs that don't carry a confidence score.
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class ScoreSection(BaseModel):

--- a/shared/shared/contracts.py
+++ b/shared/shared/contracts.py
@@ -244,6 +244,9 @@ class ExpressiveNote(BaseModel):
     velocity: int = Field(..., ge=0, le=127)
     hand: Literal["rh", "lh"]
     voice: int
+    # Onset-only nudge: engrave applies this to the attack time and leaves the
+    # release on the metronomic grid, so a positive value shortens the note
+    # and a negative value lengthens it. Do not interpret as a whole-note shift.
     timing_offset_ms: float = Field(..., ge=-50.0, le=50.0)
     velocity_offset: int = Field(..., ge=-30, le=30)
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,11 @@
+"""Shared score fixtures for engrave quality tests.
+
+Re-exports :func:`load_score_fixture` for convenience::
+
+    from tests.fixtures import load_score_fixture
+
+    score = load_score_fixture("c_major_scale")
+"""
+from tests.fixtures._builders import FIXTURE_NAMES, load_score_fixture
+
+__all__ = ["FIXTURE_NAMES", "load_score_fixture"]

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -23,6 +23,8 @@ from typing import Callable
 
 from backend.contracts import (
     SCHEMA_VERSION,
+    Articulation,
+    DynamicMarking,
     ExpressionMap,
     ExpressiveNote,
     HumanizedPerformance,
@@ -342,6 +344,75 @@ def build_humanized_with_offsets() -> HumanizedPerformance:
     )
 
 
+def build_humanized_with_expression() -> HumanizedPerformance:
+    """The "stop dropping data" fixture — dynamics, pedal variants, fermata.
+
+    Exercises every branch of plan PR-5 (phase 1.3–1.6): a static
+    dynamic (``p``) at bar 1 and a hairpin (``crescendo``) spanning bar
+    2, sustain + sostenuto + una_corda pedal events on the LH, and a
+    fermata articulation on the last RH note.
+    """
+    base = build_c_major_scale()
+
+    expressive_notes = [
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="rh",
+            voice=n.voice,
+            timing_offset_ms=0.0,
+            velocity_offset=0,
+        )
+        for n in base.right_hand
+    ]
+    expressive_notes.extend(
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="lh",
+            voice=n.voice,
+            timing_offset_ms=0.0,
+            velocity_offset=0,
+        )
+        for n in base.left_hand
+    )
+
+    # Pedal offsets are pulled just inside the final beat. music21 drops
+    # direction elements inserted at the exact barline past the last note,
+    # so "Ped. / *" lifts at the very end of the piece never reach MusicXML.
+    # A ~16th-note release is still audible in the MIDI output.
+    last_rh_id = base.right_hand[-1].id
+    expression = ExpressionMap(
+        dynamics=[
+            DynamicMarking(beat=0.0, type="p"),
+            DynamicMarking(beat=4.0, type="crescendo", span_beats=3.5),
+        ],
+        articulations=[
+            Articulation(beat=7.0, hand="rh", score_note_id=last_rh_id, type="fermata"),
+        ],
+        pedal_events=[
+            PedalEvent(onset_beat=0.0, offset_beat=3.5, type="sustain"),
+            PedalEvent(onset_beat=4.0, offset_beat=7.5, type="sostenuto"),
+            PedalEvent(onset_beat=0.0, offset_beat=7.5, type="una_corda"),
+        ],
+        tempo_changes=[],
+    )
+
+    return HumanizedPerformance(
+        schema_version=SCHEMA_VERSION,
+        expressive_notes=expressive_notes,
+        expression=expression,
+        score=base,
+        quality=QualitySignal(overall_confidence=0.9, warnings=[]),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Registry + load + regenerate
 # ---------------------------------------------------------------------------
@@ -355,6 +426,7 @@ _BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
     "seven_eight": build_seven_eight,
     "tempo_change": build_tempo_change,
     "humanized_with_offsets": build_humanized_with_offsets,
+    "humanized_with_expression": build_humanized_with_expression,
     "empty_left_hand": build_empty_left_hand,
     "overlapping_same_pitch": build_overlapping_same_pitch,
 }
@@ -362,7 +434,10 @@ _BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
 FIXTURE_NAMES: tuple[str, ...] = tuple(_BUILDERS.keys())
 
 # Fixtures that build a HumanizedPerformance rather than a raw PianoScore.
-_HUMANIZED_FIXTURES: frozenset[str] = frozenset({"humanized_with_offsets"})
+_HUMANIZED_FIXTURES: frozenset[str] = frozenset({
+    "humanized_with_offsets",
+    "humanized_with_expression",
+})
 
 
 def load_score_fixture(name: str) -> PianoScore | HumanizedPerformance:

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -284,6 +284,41 @@ def build_overlapping_same_pitch() -> PianoScore:
     )
 
 
+def build_triplet_eighths() -> PianoScore:
+    """Triplet-8ths grid — the PR-13 tuplet-survival fixture.
+
+    A bar of straight quarter-note LH root on C2, under an RH line of
+    four 8th-note triplets (12 notes total over 4 beats). Each triplet
+    subdivision lands on a 1/3-beat onset — clean arrange-grid output
+    that requires music21's ``makeNotation`` to auto-detect the tuplet
+    bracket without an explicit ``quantize(quarterLengthDivisors=...)``
+    hint.
+
+    After PR-13 engrave no longer re-quantizes inside ``_render_musicxml_bytes``
+    (arrange's grid is trusted directly), so this fixture is the
+    canary for the tuplet path. Expected output: each triplet 8th
+    carries ``<time-modification>`` with ``<actual-notes>3</actual-notes>``
+    + ``<normal-notes>2</normal-notes>`` in the MusicXML.
+    """
+    # Four beats of triplet-8ths: 12 notes, each at quarter/3 duration.
+    rh: list[ScoreNote] = []
+    for i in range(12):
+        onset = i * (1.0 / 3.0)
+        pitch = 60 + (i % 8)  # ascending C major scale under the triplet grid
+        rh.append(_rh(i, pitch=pitch, onset=onset, duration=1.0 / 3.0))
+
+    lh = [
+        _lh(i, pitch=36, onset=float(i), duration=1.0)
+        for i in range(4)
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
 def build_mislabeled_key() -> PianoScore:
     """F# minor piece mislabeled as C major — the PR-12 KS override fixture.
 
@@ -534,6 +569,7 @@ _BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
     "overlapping_same_pitch": build_overlapping_same_pitch,
     "chord_symbols": build_chord_symbols,
     "mislabeled_key": build_mislabeled_key,
+    "triplet_eighths": build_triplet_eighths,
 }
 
 FIXTURE_NAMES: tuple[str, ...] = tuple(_BUILDERS.keys())

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -18,8 +18,8 @@ To regenerate all fixture JSON files after a contract change::
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from backend.contracts import (
     SCHEMA_VERSION,

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -284,6 +284,57 @@ def build_overlapping_same_pitch() -> PianoScore:
     )
 
 
+def build_mislabeled_key() -> PianoScore:
+    """F# minor piece mislabeled as C major — the PR-12 KS override fixture.
+
+    Every RH note is drawn from the F# natural minor scale
+    (F#, G#, A, B, C#, D, E) with F# as the tonal center. The LH
+    reinforces F# as bass. The metadata key lies: it claims
+    ``C:major``. The Krumhansl-Schmuckler analyzer in
+    ``_resolve_key_signature`` should detect the real F# minor tonic,
+    report correlation ≥0.85, and override to F# minor before the key
+    signature reaches ``<key><fifths>`` in MusicXML.
+
+    Expected MusicXML ``<fifths>`` value after override: ``3``
+    (F# minor has three sharps). Without the override it would be ``0``
+    (C major, no sharps or flats), and every F#/G#/C# in the piece
+    would come out as an explicit accidental.
+    """
+    # F# minor scale + tonic arpeggios, thick enough that KS returns
+    # a solid correlation well above the 0.80 override floor. Tonic
+    # F#4 = pitch 66; scale is F#, G#, A, B, C#, D, E (natural minor).
+    scale = [66, 68, 69, 71, 73, 74, 76]  # F#4..E5
+    tonic_arp = [66, 69, 73, 78]          # F# A C# F# (i triad, emphasize tonic)
+    # Repeat scale up+down twice, separated by i-chord arpeggios, so
+    # the pitch histogram is emphatically weighted toward the F# minor
+    # scale degrees. Also rules out the "relative major" (A:major)
+    # trap — plain scale notes alone can correlate just as well with
+    # the parallel major.
+    pattern = (
+        scale + list(reversed(scale))
+        + tonic_arp + tonic_arp
+        + scale + list(reversed(scale))
+        + tonic_arp + [66, 66, 66, 66]     # hammer the tonic home
+    )
+    rh = [
+        _rh(i, pitch=p, onset=float(i) * 0.5, duration=0.5)
+        for i, p in enumerate(pattern)
+    ]
+    # LH reinforces F# as bass — F#2 pedal tones under every phrase so
+    # the analyzer sees the real tonic loud and clear.
+    lh_beats = 4
+    lh = [
+        _lh(i, pitch=42, onset=float(i * lh_beats), duration=float(lh_beats))
+        for i in range(len(rh) // (lh_beats * 2))
+    ] or [_lh(0, pitch=42, onset=0.0, duration=float(lh_beats))]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(key="C:major"),  # the lie
+    )
+
+
 def build_chord_symbols() -> PianoScore:
     """Mixed-quality chord symbols — the PR-11 filter-gate fixture.
 
@@ -482,6 +533,7 @@ _BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
     "empty_left_hand": build_empty_left_hand,
     "overlapping_same_pitch": build_overlapping_same_pitch,
     "chord_symbols": build_chord_symbols,
+    "mislabeled_key": build_mislabeled_key,
 }
 
 FIXTURE_NAMES: tuple[str, ...] = tuple(_BUILDERS.keys())

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -31,6 +31,7 @@ from backend.contracts import (
     PedalEvent,
     PianoScore,
     QualitySignal,
+    ScoreChordEvent,
     ScoreMetadata,
     ScoreNote,
     TempoMapEntry,
@@ -52,6 +53,7 @@ def _meta(
     key: str = "C:major",
     time_signature: tuple[int, int] = (4, 4),
     tempo_map: list[TempoMapEntry] | None = None,
+    chord_symbols: list[ScoreChordEvent] | None = None,
 ) -> ScoreMetadata:
     return ScoreMetadata(
         key=key,
@@ -59,7 +61,7 @@ def _meta(
         tempo_map=tempo_map or _tempo(),
         difficulty="intermediate",
         sections=[],
-        chord_symbols=[],
+        chord_symbols=chord_symbols or [],
     )
 
 
@@ -282,6 +284,56 @@ def build_overlapping_same_pitch() -> PianoScore:
     )
 
 
+def build_chord_symbols() -> PianoScore:
+    """Mixed-quality chord symbols — the PR-11 filter-gate fixture.
+
+    Seven input chord symbols that exercise every branch of
+    ``_attach_chord_symbols``:
+
+    1. ``C:maj7`` @ beat 0, conf 0.95 — clean, parses, ≥3 pitches → **rendered**.
+    2. ``Dm7``    @ beat 1, conf 0.90 — no colon, parses, ≥3 pitches → **rendered**.
+    3. ``F:maj7`` @ beat 2, conf 0.85 — colon form, ≥3 pitches → **rendered**.
+    4. ``G5``     @ beat 3, conf 0.80 — pitch-octave shape
+       (``^[A-G][#b]?\\d+$``) → **dropped (shape gate)**.
+    5. ``C:maj``  @ beat 4, conf 0.30 — would parse, but below the
+       0.5 confidence threshold → **dropped (confidence gate)**.
+    6. ``???``    @ beat 5, conf 0.90 — unparseable garbage → **dropped (parse gate)**.
+    7. ``C5``     @ beat 6, conf 0.95 — pitch-octave shape → **dropped (shape gate)**.
+
+    Expected rendered count: **3**. Note the deliberate choice not to
+    test ``G7`` / ``C7`` / ``C9`` — plan phase 3.2 accepts that the
+    ``^[A-G][#b]?\\d+$`` shape gate is aggressive enough to kill
+    dominant-sevenths written as bare ``G7``, because the audio
+    transcriber's false positives dominate the legitimate uses. Callers
+    that want dominant sevenths through this gate should emit Harte
+    colon form (``G:7``) — which the filter strips to ``G7`` for
+    parsing but which still *lexically* fails the shape check.
+
+    Paired with a simple C major melody so the test can focus on
+    harmony output, not note plumbing.
+    """
+    # Two-bar single-line RH so there's something to hang the symbols on.
+    rh = [
+        _rh(i, pitch=p, onset=float(i), duration=1.0)
+        for i, p in enumerate([60, 62, 64, 65, 67, 69, 71, 72])
+    ]
+    chord_symbols = [
+        ScoreChordEvent(beat=0.0, duration_beat=1.0, label="C:maj7", root=60, confidence=0.95),
+        ScoreChordEvent(beat=1.0, duration_beat=1.0, label="Dm7",    root=62, confidence=0.90),
+        ScoreChordEvent(beat=2.0, duration_beat=1.0, label="F:maj7", root=65, confidence=0.85),
+        ScoreChordEvent(beat=3.0, duration_beat=1.0, label="G5",     root=67, confidence=0.80),
+        ScoreChordEvent(beat=4.0, duration_beat=1.0, label="C:maj",  root=60, confidence=0.30),
+        ScoreChordEvent(beat=5.0, duration_beat=1.0, label="???",    root=60, confidence=0.90),
+        ScoreChordEvent(beat=6.0, duration_beat=1.0, label="C5",     root=60, confidence=0.95),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(chord_symbols=chord_symbols),
+    )
+
+
 def build_humanized_with_offsets() -> HumanizedPerformance:
     """C major scale wrapped as a HumanizedPerformance with timing offsets + a pedal event.
 
@@ -429,6 +481,7 @@ _BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
     "humanized_with_expression": build_humanized_with_expression,
     "empty_left_hand": build_empty_left_hand,
     "overlapping_same_pitch": build_overlapping_same_pitch,
+    "chord_symbols": build_chord_symbols,
 }
 
 FIXTURE_NAMES: tuple[str, ...] = tuple(_BUILDERS.keys())

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -1,0 +1,397 @@
+"""Hand-authored score fixtures for the engrave evaluation harness.
+
+The ten fixtures below cover the cases that matter for engrave quality:
+trivial baselines, voice/staff separation, accidentals, irregular meter,
+multi-segment tempo, timing offsets, edge cases (empty LH, same-pitch
+overlap). They are the foundation for the L1–L5 test layers described in
+``docs/engrave-improvement-plan.md``.
+
+Each fixture is built as a Pydantic model (``PianoScore`` or
+``HumanizedPerformance``) and serialized to JSON under
+``tests/fixtures/scores/``. The loader re-parses via Pydantic so schema
+drift is caught as a validation error at test-collection time.
+
+To regenerate all fixture JSON files after a contract change::
+
+    python -m tests.fixtures._builders
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+from backend.contracts import (
+    SCHEMA_VERSION,
+    ExpressionMap,
+    ExpressiveNote,
+    HumanizedPerformance,
+    PedalEvent,
+    PianoScore,
+    QualitySignal,
+    ScoreMetadata,
+    ScoreNote,
+    TempoMapEntry,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "scores"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers to keep the builders below readable
+# ---------------------------------------------------------------------------
+
+def _tempo(bpm: float = 120.0) -> list[TempoMapEntry]:
+    return [TempoMapEntry(time_sec=0.0, beat=0.0, bpm=bpm)]
+
+
+def _meta(
+    *,
+    key: str = "C:major",
+    time_signature: tuple[int, int] = (4, 4),
+    tempo_map: list[TempoMapEntry] | None = None,
+) -> ScoreMetadata:
+    return ScoreMetadata(
+        key=key,
+        time_signature=time_signature,
+        tempo_map=tempo_map or _tempo(),
+        difficulty="intermediate",
+        sections=[],
+        chord_symbols=[],
+    )
+
+
+def _rh(idx: int, pitch: int, onset: float, duration: float,
+        *, velocity: int = 80, voice: int = 1) -> ScoreNote:
+    return ScoreNote(
+        id=f"rh-{idx:04d}",
+        pitch=pitch,
+        onset_beat=onset,
+        duration_beat=duration,
+        velocity=velocity,
+        voice=voice,
+    )
+
+
+def _lh(idx: int, pitch: int, onset: float, duration: float,
+        *, velocity: int = 70, voice: int = 1) -> ScoreNote:
+    return ScoreNote(
+        id=f"lh-{idx:04d}",
+        pitch=pitch,
+        onset_beat=onset,
+        duration_beat=duration,
+        velocity=velocity,
+        voice=voice,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+def build_single_note() -> PianoScore:
+    """Trivial baseline — one RH C4 whole note."""
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=[_rh(0, pitch=60, onset=0.0, duration=4.0)],
+        left_hand=[],
+        metadata=_meta(),
+    )
+
+
+def build_c_major_scale() -> PianoScore:
+    """RH one-octave C major scale in quarters; LH two whole-note C3 pedal tones."""
+    pitches = [60, 62, 64, 65, 67, 69, 71, 72]  # C4..C5
+    rh = [_rh(i, pitch=p, onset=float(i), duration=1.0) for i, p in enumerate(pitches)]
+    lh = [
+        _lh(0, pitch=48, onset=0.0, duration=4.0),
+        _lh(1, pitch=48, onset=4.0, duration=4.0),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_two_hand_chordal() -> PianoScore:
+    """Four quarter-note triads over octave bass — exercises <staff> separation."""
+    # RH: C-E-G, F-A-C, G-B-D, C-E-G (I – IV – V – I)
+    triads = [
+        (60, 64, 67),  # C major
+        (65, 69, 72),  # F major
+        (67, 71, 74),  # G major
+        (60, 64, 67),  # C major
+    ]
+    rh: list[ScoreNote] = []
+    idx = 0
+    for beat, triad in enumerate(triads):
+        for p in triad:
+            rh.append(_rh(idx, pitch=p, onset=float(beat), duration=1.0))
+            idx += 1
+
+    # LH: octaves on the root of each chord (e.g. C2 + C3)
+    roots = [36, 41, 43, 36]
+    lh: list[ScoreNote] = []
+    idx = 0
+    for beat, root in enumerate(roots):
+        lh.append(_lh(idx, pitch=root, onset=float(beat), duration=1.0))
+        idx += 1
+        lh.append(_lh(idx, pitch=root + 12, onset=float(beat), duration=1.0))
+        idx += 1
+
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_bach_invention_excerpt() -> PianoScore:
+    """Eight quarters of two-voice counterpoint in the RH — the voice-handling fixture.
+
+    Not a real Bach quote; just two independent lines in the same staff
+    with different rhythms and pitches so the voice=1/voice=2 assignment
+    is unambiguous and any collapse to a single voice is visible.
+    """
+    # Voice 1 — upper line, quarter notes ascending
+    v1_pitches = [72, 74, 76, 77, 79, 77, 76, 74]  # C5..
+    voice1 = [
+        _rh(i, pitch=p, onset=float(i), duration=1.0, voice=1)
+        for i, p in enumerate(v1_pitches)
+    ]
+    # Voice 2 — lower line, half-note pulses
+    v2_pitches = [60, 64, 65, 64]
+    voice2 = [
+        _rh(100 + i, pitch=p, onset=float(i * 2), duration=2.0, voice=2)
+        for i, p in enumerate(v2_pitches)
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=voice1 + voice2,
+        left_hand=[],
+        metadata=_meta(time_signature=(4, 4)),
+    )
+
+
+def build_jazz_voicings() -> PianoScore:
+    """Chromatic walking bass + 7th-chord shells above — exercises accidentals."""
+    # LH walking bass: C2, C#2, D2, D#2, E2, F2, F#2, G2
+    lh = [
+        _lh(i, pitch=36 + i, onset=float(i), duration=1.0)
+        for i in range(8)
+    ]
+    # RH shells — 3rd and 7th of each chord. Cmaj7, C#7, Dm7, D#dim7,
+    # Emaj7, F7, F#m7b5, G7. Just two voices per hit.
+    shells = [
+        (64, 71),  # Cmaj7: E + B
+        (61, 70),  # C#7: C#(Db) + B(Bb as 7)
+        (65, 72),  # Dm7: F + C
+        (66, 72),  # D#dim7: F#(Gb) + C
+        (68, 75),  # Emaj7: G#(Ab) + D#(Eb)
+        (69, 75),  # F7: A + Eb
+        (69, 76),  # F#m7b5: A + E
+        (71, 77),  # G7: B + F
+    ]
+    rh: list[ScoreNote] = []
+    idx = 0
+    for beat, (low, high) in enumerate(shells):
+        rh.append(_rh(idx, pitch=low, onset=float(beat), duration=1.0))
+        idx += 1
+        rh.append(_rh(idx, pitch=high, onset=float(beat), duration=1.0))
+        idx += 1
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_seven_eight() -> PianoScore:
+    """7/8 irregular-meter fixture — tests time-sig propagation & grouping."""
+    # Seven eighth-note pulses in the RH (2+2+3 grouping).
+    durations = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    pitches = [60, 62, 64, 65, 67, 69, 71]
+    rh: list[ScoreNote] = []
+    onset = 0.0
+    for i, (p, d) in enumerate(zip(pitches, durations)):
+        rh.append(_rh(i, pitch=p, onset=onset, duration=d))
+        onset += d
+
+    # LH: one dotted-half per 7/8 bar, pinned to the downbeat
+    lh = [_lh(0, pitch=48, onset=0.0, duration=3.5)]
+
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(time_signature=(7, 8)),
+    )
+
+
+def build_tempo_change() -> PianoScore:
+    """Multi-segment tempo map (120 → 90 halfway through)."""
+    tempo_map = [
+        TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0),
+        TempoMapEntry(time_sec=2.0, beat=4.0, bpm=90.0),
+    ]
+    rh = [
+        _rh(i, pitch=60 + (i * 2), onset=float(i), duration=1.0)
+        for i in range(8)
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(tempo_map=tempo_map),
+    )
+
+
+def build_empty_left_hand() -> PianoScore:
+    """RH-only — catches the no-note backup / empty-staff logic in engrave."""
+    rh = [
+        _rh(0, pitch=67, onset=0.0, duration=1.0),
+        _rh(1, pitch=69, onset=1.0, duration=1.0),
+        _rh(2, pitch=71, onset=2.0, duration=1.0),
+        _rh(3, pitch=72, onset=3.0, duration=1.0),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(),
+    )
+
+
+def build_overlapping_same_pitch() -> PianoScore:
+    """Two overlapping C4s — exercises the same-pitch overlap resolver in engrave."""
+    rh = [
+        _rh(0, pitch=60, onset=0.0, duration=2.0),
+        _rh(1, pitch=60, onset=1.0, duration=2.0),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(),
+    )
+
+
+def build_humanized_with_offsets() -> HumanizedPerformance:
+    """C major scale wrapped as a HumanizedPerformance with timing offsets + a pedal event.
+
+    This is **the timing-bug fixture** — ``timing_offset_ms`` values are
+    non-zero and alternate in sign so the round-trip test can verify
+    whether the shift is onset-only or a whole-note translation (see
+    ``engrave.py:87-88``). Also includes one sustain-pedal event so L1
+    can verify pedal events reach the MIDI output.
+    """
+    base = build_c_major_scale()
+
+    # Alternating ±20ms offsets across the RH scale notes; LH whole notes
+    # stay at 0 so any timing drift in the LH clearly comes from engrave,
+    # not the fixture.
+    timing = [20.0, -20.0, 15.0, -15.0, 10.0, -10.0, 5.0, -5.0]
+    expressive_notes = [
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="rh",
+            voice=n.voice,
+            timing_offset_ms=t,
+            velocity_offset=0,
+        )
+        for n, t in zip(base.right_hand, timing)
+    ]
+    expressive_notes.extend(
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="lh",
+            voice=n.voice,
+            timing_offset_ms=0.0,
+            velocity_offset=0,
+        )
+        for n in base.left_hand
+    )
+
+    expression = ExpressionMap(
+        dynamics=[],
+        articulations=[],
+        pedal_events=[
+            PedalEvent(onset_beat=0.0, offset_beat=8.0, type="sustain"),
+        ],
+        tempo_changes=[],
+    )
+
+    return HumanizedPerformance(
+        schema_version=SCHEMA_VERSION,
+        expressive_notes=expressive_notes,
+        expression=expression,
+        score=base,
+        quality=QualitySignal(overall_confidence=0.9, warnings=[]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry + load + regenerate
+# ---------------------------------------------------------------------------
+
+_BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
+    "single_note": build_single_note,
+    "c_major_scale": build_c_major_scale,
+    "two_hand_chordal": build_two_hand_chordal,
+    "bach_invention_excerpt": build_bach_invention_excerpt,
+    "jazz_voicings": build_jazz_voicings,
+    "seven_eight": build_seven_eight,
+    "tempo_change": build_tempo_change,
+    "humanized_with_offsets": build_humanized_with_offsets,
+    "empty_left_hand": build_empty_left_hand,
+    "overlapping_same_pitch": build_overlapping_same_pitch,
+}
+
+FIXTURE_NAMES: tuple[str, ...] = tuple(_BUILDERS.keys())
+
+# Fixtures that build a HumanizedPerformance rather than a raw PianoScore.
+_HUMANIZED_FIXTURES: frozenset[str] = frozenset({"humanized_with_offsets"})
+
+
+def load_score_fixture(name: str) -> PianoScore | HumanizedPerformance:
+    """Load a committed fixture JSON and re-validate via Pydantic.
+
+    Parsing through the model catches contract drift at test-collection
+    time — if a field is renamed or removed, the fixture is flagged
+    immediately instead of silently producing garbage MusicXML.
+    """
+    path = FIXTURES_DIR / f"{name}.json"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Score fixture {name!r} not found at {path}. "
+            "Run `python -m tests.fixtures._builders` to regenerate.",
+        )
+    raw = json.loads(path.read_text())
+    model = HumanizedPerformance if name in _HUMANIZED_FIXTURES else PianoScore
+    return model.model_validate(raw)
+
+
+def regenerate_all() -> None:
+    """Write every builder's output to ``tests/fixtures/scores/<name>.json``."""
+    FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    for name, builder in _BUILDERS.items():
+        model = builder()
+        path = FIXTURES_DIR / f"{name}.json"
+        path.write_text(model.model_dump_json(indent=2) + "\n")
+        print(f"wrote {path.relative_to(FIXTURES_DIR.parent.parent)}")
+
+
+if __name__ == "__main__":
+    regenerate_all()

--- a/tests/fixtures/scores/bach_invention_excerpt.json
+++ b/tests/fixtures/scores/bach_invention_excerpt.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 72,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 74,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 76,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 77,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 79,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 77,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 76,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 74,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0100",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    },
+    {
+      "id": "rh-0101",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    },
+    {
+      "id": "rh-0102",
+      "pitch": 65,
+      "onset_beat": 4.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    },
+    {
+      "id": "rh-0103",
+      "pitch": 64,
+      "onset_beat": 6.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/c_major_scale.json
+++ b/tests/fixtures/scores/c_major_scale.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/chord_symbols.json
+++ b/tests/fixtures/scores/chord_symbols.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": [
+      {
+        "beat": 0.0,
+        "duration_beat": 1.0,
+        "label": "C:maj7",
+        "root": 60,
+        "confidence": 0.95
+      },
+      {
+        "beat": 1.0,
+        "duration_beat": 1.0,
+        "label": "Dm7",
+        "root": 62,
+        "confidence": 0.9
+      },
+      {
+        "beat": 2.0,
+        "duration_beat": 1.0,
+        "label": "F:maj7",
+        "root": 65,
+        "confidence": 0.85
+      },
+      {
+        "beat": 3.0,
+        "duration_beat": 1.0,
+        "label": "G5",
+        "root": 67,
+        "confidence": 0.8
+      },
+      {
+        "beat": 4.0,
+        "duration_beat": 1.0,
+        "label": "C:maj",
+        "root": 60,
+        "confidence": 0.3
+      },
+      {
+        "beat": 5.0,
+        "duration_beat": 1.0,
+        "label": "???",
+        "root": 60,
+        "confidence": 0.9
+      },
+      {
+        "beat": 6.0,
+        "duration_beat": 1.0,
+        "label": "C5",
+        "root": 60,
+        "confidence": 0.95
+      }
+    ]
+  }
+}

--- a/tests/fixtures/scores/empty_left_hand.json
+++ b/tests/fixtures/scores/empty_left_hand.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 67,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 69,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 71,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 72,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/humanized_with_expression.json
+++ b/tests/fixtures/scores/humanized_with_expression.json
@@ -1,0 +1,265 @@
+{
+  "schema_version": "3.0.0",
+  "expressive_notes": [
+    {
+      "score_note_id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    }
+  ],
+  "expression": {
+    "dynamics": [
+      {
+        "beat": 0.0,
+        "type": "p",
+        "span_beats": null,
+        "target": null
+      },
+      {
+        "beat": 4.0,
+        "type": "crescendo",
+        "span_beats": 3.5,
+        "target": null
+      }
+    ],
+    "articulations": [
+      {
+        "beat": 7.0,
+        "hand": "rh",
+        "score_note_id": "rh-0007",
+        "type": "fermata"
+      }
+    ],
+    "pedal_events": [
+      {
+        "onset_beat": 0.0,
+        "offset_beat": 3.5,
+        "type": "sustain"
+      },
+      {
+        "onset_beat": 4.0,
+        "offset_beat": 7.5,
+        "type": "sostenuto"
+      },
+      {
+        "onset_beat": 0.0,
+        "offset_beat": 7.5,
+        "type": "una_corda"
+      }
+    ],
+    "tempo_changes": []
+  },
+  "score": {
+    "schema_version": "3.0.0",
+    "right_hand": [
+      {
+        "id": "rh-0000",
+        "pitch": 60,
+        "onset_beat": 0.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0001",
+        "pitch": 62,
+        "onset_beat": 1.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0002",
+        "pitch": 64,
+        "onset_beat": 2.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0003",
+        "pitch": 65,
+        "onset_beat": 3.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0004",
+        "pitch": 67,
+        "onset_beat": 4.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0005",
+        "pitch": 69,
+        "onset_beat": 5.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0006",
+        "pitch": 71,
+        "onset_beat": 6.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0007",
+        "pitch": 72,
+        "onset_beat": 7.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      }
+    ],
+    "left_hand": [
+      {
+        "id": "lh-0000",
+        "pitch": 48,
+        "onset_beat": 0.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      },
+      {
+        "id": "lh-0001",
+        "pitch": 48,
+        "onset_beat": 4.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      }
+    ],
+    "metadata": {
+      "key": "C:major",
+      "time_signature": [
+        4,
+        4
+      ],
+      "tempo_map": [
+        {
+          "time_sec": 0.0,
+          "beat": 0.0,
+          "bpm": 120.0
+        }
+      ],
+      "difficulty": "intermediate",
+      "sections": [],
+      "chord_symbols": []
+    }
+  },
+  "quality": {
+    "overall_confidence": 0.9,
+    "warnings": []
+  }
+}

--- a/tests/fixtures/scores/humanized_with_offsets.json
+++ b/tests/fixtures/scores/humanized_with_offsets.json
@@ -1,0 +1,235 @@
+{
+  "schema_version": "3.0.0",
+  "expressive_notes": [
+    {
+      "score_note_id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 20.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -20.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 15.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -15.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 10.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -10.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 5.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -5.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    }
+  ],
+  "expression": {
+    "dynamics": [],
+    "articulations": [],
+    "pedal_events": [
+      {
+        "onset_beat": 0.0,
+        "offset_beat": 8.0,
+        "type": "sustain"
+      }
+    ],
+    "tempo_changes": []
+  },
+  "score": {
+    "schema_version": "3.0.0",
+    "right_hand": [
+      {
+        "id": "rh-0000",
+        "pitch": 60,
+        "onset_beat": 0.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0001",
+        "pitch": 62,
+        "onset_beat": 1.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0002",
+        "pitch": 64,
+        "onset_beat": 2.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0003",
+        "pitch": 65,
+        "onset_beat": 3.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0004",
+        "pitch": 67,
+        "onset_beat": 4.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0005",
+        "pitch": 69,
+        "onset_beat": 5.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0006",
+        "pitch": 71,
+        "onset_beat": 6.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0007",
+        "pitch": 72,
+        "onset_beat": 7.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      }
+    ],
+    "left_hand": [
+      {
+        "id": "lh-0000",
+        "pitch": 48,
+        "onset_beat": 0.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      },
+      {
+        "id": "lh-0001",
+        "pitch": 48,
+        "onset_beat": 4.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      }
+    ],
+    "metadata": {
+      "key": "C:major",
+      "time_signature": [
+        4,
+        4
+      ],
+      "tempo_map": [
+        {
+          "time_sec": 0.0,
+          "beat": 0.0,
+          "bpm": 120.0
+        }
+      ],
+      "difficulty": "intermediate",
+      "sections": [],
+      "chord_symbols": []
+    }
+  },
+  "quality": {
+    "overall_confidence": 0.9,
+    "warnings": []
+  }
+}

--- a/tests/fixtures/scores/jazz_voicings.json
+++ b/tests/fixtures/scores/jazz_voicings.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 64,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 71,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 61,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 70,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 65,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 72,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 66,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 68,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 75,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 75,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0012",
+      "pitch": 69,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0013",
+      "pitch": 76,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0014",
+      "pitch": 71,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0015",
+      "pitch": 77,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 36,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 37,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 38,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 39,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0004",
+      "pitch": 40,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0005",
+      "pitch": 41,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0006",
+      "pitch": 42,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0007",
+      "pitch": 43,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/mislabeled_key.json
+++ b/tests/fixtures/scores/mislabeled_key.json
@@ -1,0 +1,416 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 66,
+      "onset_beat": 0.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 68,
+      "onset_beat": 0.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 69,
+      "onset_beat": 1.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 71,
+      "onset_beat": 1.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 73,
+      "onset_beat": 2.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 74,
+      "onset_beat": 2.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 76,
+      "onset_beat": 3.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 76,
+      "onset_beat": 3.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 74,
+      "onset_beat": 4.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 73,
+      "onset_beat": 4.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 71,
+      "onset_beat": 5.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 69,
+      "onset_beat": 5.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0012",
+      "pitch": 68,
+      "onset_beat": 6.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0013",
+      "pitch": 66,
+      "onset_beat": 6.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0014",
+      "pitch": 66,
+      "onset_beat": 7.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0015",
+      "pitch": 69,
+      "onset_beat": 7.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0016",
+      "pitch": 73,
+      "onset_beat": 8.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0017",
+      "pitch": 78,
+      "onset_beat": 8.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0018",
+      "pitch": 66,
+      "onset_beat": 9.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0019",
+      "pitch": 69,
+      "onset_beat": 9.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0020",
+      "pitch": 73,
+      "onset_beat": 10.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0021",
+      "pitch": 78,
+      "onset_beat": 10.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0022",
+      "pitch": 66,
+      "onset_beat": 11.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0023",
+      "pitch": 68,
+      "onset_beat": 11.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0024",
+      "pitch": 69,
+      "onset_beat": 12.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0025",
+      "pitch": 71,
+      "onset_beat": 12.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0026",
+      "pitch": 73,
+      "onset_beat": 13.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0027",
+      "pitch": 74,
+      "onset_beat": 13.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0028",
+      "pitch": 76,
+      "onset_beat": 14.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0029",
+      "pitch": 76,
+      "onset_beat": 14.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0030",
+      "pitch": 74,
+      "onset_beat": 15.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0031",
+      "pitch": 73,
+      "onset_beat": 15.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0032",
+      "pitch": 71,
+      "onset_beat": 16.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0033",
+      "pitch": 69,
+      "onset_beat": 16.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0034",
+      "pitch": 68,
+      "onset_beat": 17.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0035",
+      "pitch": 66,
+      "onset_beat": 17.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0036",
+      "pitch": 66,
+      "onset_beat": 18.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0037",
+      "pitch": 69,
+      "onset_beat": 18.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0038",
+      "pitch": 73,
+      "onset_beat": 19.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0039",
+      "pitch": 78,
+      "onset_beat": 19.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0040",
+      "pitch": 66,
+      "onset_beat": 20.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0041",
+      "pitch": 66,
+      "onset_beat": 20.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0042",
+      "pitch": 66,
+      "onset_beat": 21.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0043",
+      "pitch": 66,
+      "onset_beat": 21.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 42,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 42,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 42,
+      "onset_beat": 8.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 42,
+      "onset_beat": 12.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0004",
+      "pitch": 42,
+      "onset_beat": 16.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/overlapping_same_pitch.json
+++ b/tests/fixtures/scores/overlapping_same_pitch.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 60,
+      "onset_beat": 1.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/seven_eight.json
+++ b/tests/fixtures/scores/seven_eight.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 0.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 1.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 1.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 2.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 2.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 3.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 3.5,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      7,
+      8
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/single_note.json
+++ b/tests/fixtures/scores/single_note.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/tempo_change.json
+++ b/tests/fixtures/scores/tempo_change.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 66,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 68,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 70,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 72,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 74,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      },
+      {
+        "time_sec": 2.0,
+        "beat": 4.0,
+        "bpm": 90.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/triplet_eighths.json
+++ b/tests/fixtures/scores/triplet_eighths.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 61,
+      "onset_beat": 0.3333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 62,
+      "onset_beat": 0.6666666666666666,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 63,
+      "onset_beat": 1.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 64,
+      "onset_beat": 1.3333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 65,
+      "onset_beat": 1.6666666666666665,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 66,
+      "onset_beat": 2.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 67,
+      "onset_beat": 2.333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 60,
+      "onset_beat": 2.6666666666666665,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 61,
+      "onset_beat": 3.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 62,
+      "onset_beat": 3.333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 63,
+      "onset_beat": 3.6666666666666665,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 36,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 36,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 36,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 36,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/two_hand_chordal.json
+++ b/tests/fixtures/scores/two_hand_chordal.json
@@ -1,0 +1,184 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 64,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 67,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 69,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 72,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 67,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 71,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 74,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 60,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 64,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 67,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 36,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 41,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 53,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0004",
+      "pitch": 43,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0005",
+      "pitch": 55,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0006",
+      "pitch": 36,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0007",
+      "pitch": 48,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/test_arrange.py
+++ b/tests/test_arrange.py
@@ -118,6 +118,13 @@ def test_arrange_dedups_same_pitch_across_tracks_keep_loudest() -> None:
 
 
 def test_arrange_beginner_reduces_max_polyphony() -> None:
+    """Voice caps: intermediate=2 RH voices, beginner=1. PR-10 / plan 3.1.
+
+    Three overlapping notes at beat 0 force the voice allocator up to
+    three concurrent voices. Intermediate keeps voices 1 and 2 (the
+    piano cap) and drops the third; beginner keeps only voice 1 and
+    drops both extras.
+    """
     payload = _payload(
         tracks=[
             MidiTrack(
@@ -136,9 +143,10 @@ def test_arrange_beginner_reduces_max_polyphony() -> None:
     beginner = _arrange_sync(payload, "beginner")
     intermediate = _arrange_sync(payload, "intermediate")
 
-    assert len(beginner.right_hand) == 2
-    assert len(intermediate.right_hand) == 3
-    assert max(n.voice for n in beginner.right_hand) <= 2
+    assert len(beginner.right_hand) == 1
+    assert len(intermediate.right_hand) == 2
+    assert max(n.voice for n in intermediate.right_hand) <= 2
+    assert max(n.voice for n in beginner.right_hand) == 1
 
 
 def test_arrange_falls_back_to_all_tracks_when_all_are_other() -> None:

--- a/tests/test_arrange_simplify.py
+++ b/tests/test_arrange_simplify.py
@@ -6,8 +6,6 @@ and returns a simplified copy suitable for sheet-music engraving.
 """
 from __future__ import annotations
 
-import pytest
-
 from shared.contracts import (
     PianoScore,
     ScoreMetadata,

--- a/tests/test_engrave_pdf_render.py
+++ b/tests/test_engrave_pdf_render.py
@@ -37,7 +37,7 @@ def test_engrave_emits_real_pdf_not_stub() -> None:
     hands, and has been rendering cleanly through music21 since PR-1.
     """
     score = load_score_fixture("c_major_scale")
-    pdf_bytes, musicxml_bytes, _midi_bytes = _engrave_sync(
+    pdf_bytes, musicxml_bytes, _midi_bytes, _chord_count = _engrave_sync(
         score, title="Smoke Test", composer="pytest",
     )
 
@@ -58,7 +58,7 @@ def test_render_pdf_bytes_direct_call() -> None:
     high-level ``_engrave_sync`` plumbing around.
     """
     score = load_score_fixture("single_note")
-    _, musicxml_bytes, _ = _engrave_sync(score, title="", composer="")
+    _, musicxml_bytes, _, _ = _engrave_sync(score, title="", composer="")
 
     pdf_bytes = _render_pdf_bytes(musicxml_bytes)
     assert pdf_bytes != _STUB_PDF

--- a/tests/test_engrave_pdf_render.py
+++ b/tests/test_engrave_pdf_render.py
@@ -1,0 +1,65 @@
+"""Smoke test for the LilyPond / MuseScore PDF render path.
+
+Gates on whether a real PDF renderer is on ``$PATH``. When neither
+``lilypond`` nor a ``musescore*`` binary is installed, this is skipped
+so it doesn't break dev machines without the engraver tooling. The
+production Docker image installs ``lilypond`` via apt (see
+``Dockerfile``), so CI runs inside that image will execute this path.
+"""
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from backend.services.engrave import _STUB_PDF, _engrave_sync, _render_pdf_bytes
+from tests.fixtures import load_score_fixture
+
+
+def _has_real_renderer() -> bool:
+    if shutil.which("musicxml2ly") and shutil.which("lilypond"):
+        return True
+    return any(
+        shutil.which(b) for b in ("musescore4", "musescore3", "mscore", "MuseScore4")
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_real_renderer(),
+    reason="no lilypond/MuseScore on PATH — production image installs lilypond",
+)
+
+
+def test_engrave_emits_real_pdf_not_stub() -> None:
+    """A fixture routed through ``_engrave_sync`` produces a real PDF.
+
+    Uses ``c_major_scale`` as the smoke case: it's small, uses both
+    hands, and has been rendering cleanly through music21 since PR-1.
+    """
+    score = load_score_fixture("c_major_scale")
+    pdf_bytes, musicxml_bytes, _midi_bytes = _engrave_sync(
+        score, title="Smoke Test", composer="pytest",
+    )
+
+    assert musicxml_bytes.startswith(b"<?xml"), "musicxml should be real xml"
+    assert pdf_bytes != _STUB_PDF, (
+        "a real renderer is on PATH but _render_pdf_bytes fell through to the stub"
+    )
+    assert pdf_bytes.startswith(b"%PDF-"), "output is not a PDF"
+    assert len(pdf_bytes) > 1024, (
+        f"PDF suspiciously small ({len(pdf_bytes)} bytes) — likely a render failure"
+    )
+
+
+def test_render_pdf_bytes_direct_call() -> None:
+    """``_render_pdf_bytes`` on plausible MusicXML returns a real PDF.
+
+    Keeps the pdf path under test even if future refactors move the
+    high-level ``_engrave_sync`` plumbing around.
+    """
+    score = load_score_fixture("single_note")
+    _, musicxml_bytes, _ = _engrave_sync(score, title="", composer="")
+
+    pdf_bytes = _render_pdf_bytes(musicxml_bytes)
+    assert pdf_bytes != _STUB_PDF
+    assert pdf_bytes.startswith(b"%PDF-")

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -391,6 +391,52 @@ def test_l2_grand_staff_single_part(engraved_artifacts):
     assert _count_staff(musicxml, 2) == 8
 
 
+def test_l2_two_voices_preserved_on_same_staff(engraved_artifacts):
+    """Plan phase 3.1 / PR-10: two-voice RH content keeps both voices.
+
+    The ``bach_invention_excerpt`` fixture carries 8 RH notes on
+    ``voice=1`` (upper line, quarters) and 4 RH notes on ``voice=2``
+    (lower line, half notes). Before PR-10 the engrave sanitizer
+    collapsed every ``<voice>`` tag to 1, destroying music21's
+    stems-up-melody / stems-down-accompaniment separation. The fix is
+    explicit music21 ``Voice`` sub-streams + a post-``makeNotation``
+    id-rename from the 0-indexed integers music21 stamps during
+    measure construction back to the MusicXML-valid ``1``/``2``.
+
+    What we check: (a) both voice numbers are present, (b) at least
+    one ``<backup>`` element exists (music21 emits ``<backup>`` before
+    switching from voice 1 to voice 2 within a measure), and (c) the
+    note counts per voice match the fixture — allowing one extra
+    voice-2 attack for the tie-continuation music21 inserts where a
+    half note bridges the barline.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["bach_invention_excerpt"]
+    root = etree.fromstring(musicxml)
+
+    voice_counts: dict[str, int] = {}
+    for note in root.iter("note"):
+        if note.find("rest") is not None:
+            continue
+        v = note.findtext("voice")
+        if v is not None:
+            voice_counts[v] = voice_counts.get(v, 0) + 1
+
+    assert "1" in voice_counts and "2" in voice_counts, (
+        f"expected both <voice>1</voice> and <voice>2</voice>; got {voice_counts}"
+    )
+    assert voice_counts["1"] == 8, f"voice 1 count {voice_counts['1']} != 8"
+    # Voice 2 = 4 half notes in the fixture; expect 4 or 5 (tie split at barline).
+    assert voice_counts["2"] in (4, 5), f"voice 2 count {voice_counts['2']} not in (4, 5)"
+    assert "0" not in voice_counts, (
+        "<voice>0</voice> is invalid MusicXML; sanitizer should have remapped it"
+    )
+
+    backups = list(root.iter("backup"))
+    assert backups, "expected <backup> elements separating voice 1 from voice 2"
+
+
 def test_l2_rh_only_fixture_still_single_part(engraved_artifacts):
     """An empty-LH fixture still emits a grand staff — just with an empty
     bass stave. This catches the regression where dropping LH content

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -13,11 +13,8 @@ fixture in ``tests/fixtures/scores/`` through ``_engrave_sync`` and:
   ``<divisions>`` ≤ 480, pitches within the 88-key piano range, note
   count consistent with the fixture.
 
-A separate ``xfail``-marked test exists for the
-``humanized_with_offsets`` fixture, pinning the current
-``timing_offset_ms`` behavior (see plan Phase 1.2). When that PR lands
-and the bug is fixed, the xfail flips to a pass and CI fails under
-``strict=True`` — at which point the marker should be removed.
+A dedicated test pins the onset-only semantics of ``timing_offset_ms``
+against the ``humanized_with_offsets`` fixture (see plan Phase 1.2).
 """
 from __future__ import annotations
 
@@ -117,21 +114,16 @@ def test_l1_midi_round_trip(name: str, engraved_artifacts):
         )
 
 
-@pytest.mark.xfail(
-    reason="timing_offset_ms is applied to BOTH onset and offset (engrave.py:87-88). "
-           "Plan Phase 1.2 resolves the semantics; flipping this to a pass means "
-           "the bug is fixed and the marker should be removed.",
-    strict=True,
-)
 def test_l1_humanized_timing_offset_is_onset_only(engraved_artifacts):
-    """Pin the *expected* onset-only semantics of ``timing_offset_ms``.
+    """``timing_offset_ms`` is an onset-only nudge — release stays fixed.
 
     The fixture's first RH note is C4 at beat 0, duration 1 beat, with
     ``timing_offset_ms = +20``. At 120 BPM one beat is 0.5 s, so an
-    onset-only shift would produce ``onset = 0.020 s`` and
-    ``offset = 0.500 s`` (duration compressed to 0.480 s). The current
-    implementation shifts both onset and offset equally, producing
-    ``offset = 0.520 s`` — that is what ``strict=True`` is pinning.
+    onset-only shift produces ``onset = 0.020 s`` and
+    ``offset = 0.500 s`` (duration compressed to 0.480 s).
+
+    Mirrors ``humanize._humanize_timing``, which models downbeat
+    anticipation / backbeat push as attack-time gestures only.
     """
     import pretty_midi
 

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -472,6 +472,57 @@ def test_engrave_does_not_leak_music21_defaults():
 
 
 # ---------------------------------------------------------------------------
+# L2 — Tuplet survival (plan phase 3.4 / PR-13)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_triplet_eighths_render_as_tuplet(engraved_artifacts):
+    """Plan phase 3.4 — triplet-8ths survive without engrave re-quantizing.
+
+    The ``triplet_eighths`` fixture carries 12 RH notes at 1/3-beat
+    spacing over 4 beats — a clean triplet grid from arrange's
+    ``_estimate_best_grid`` path. Before PR-13, engrave re-quantized
+    every Part to ``quarterLengthDivisors=(4, 3)`` as a safety net
+    inherited from the divisions=10080 era; the coarser divisor tuple
+    could not represent triplet-16ths and the re-quantize silently
+    dropped fine resolution.
+
+    After PR-13 engrave trusts arrange's grid directly and music21's
+    ``makeNotation`` auto-detects the tuplet bracket. What we check:
+
+    - Each triplet-8th duration = divisions/3 (at divisions=12, that's 4).
+    - The MusicXML carries ``<time-modification>`` elements with
+      ``<actual-notes>3</actual-notes>`` / ``<normal-notes>2</normal-notes>``
+      on each triplet member — the standard "3 in the time of 2"
+      encoding for an 8th-note triplet.
+    - At least 12 such time-modification blocks land on RH (one per
+      triplet 8th).
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["triplet_eighths"]
+    root = etree.fromstring(musicxml)
+
+    # Every triplet 8th should have <time-modification> with 3/2 ratio.
+    triplet_members = 0
+    for note in root.iter("note"):
+        if note.find("rest") is not None:
+            continue
+        tm = note.find("time-modification")
+        if tm is None:
+            continue
+        actual = tm.findtext("actual-notes")
+        normal = tm.findtext("normal-notes")
+        if actual == "3" and normal == "2":
+            triplet_members += 1
+
+    assert triplet_members >= 12, (
+        f"expected ≥12 triplet-8th members with <time-modification>3:2</time-modification>, "
+        f"got {triplet_members}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # L2 — Key signature verification (plan phase 3.3 / PR-12)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -169,6 +169,28 @@ def test_l1_humanized_pedal_reaches_midi(engraved_artifacts):
     assert any(cc.value < 64 for cc in cc64), "no sustain pedal OFF (CC64 < 64)"
 
 
+def test_l1_humanized_expression_emits_all_pedal_ccs(engraved_artifacts):
+    """Plan phase 1.5 — sostenuto → CC66, una corda → CC67 in addition to sustain → CC64.
+
+    The ``humanized_with_expression`` fixture carries one of each pedal
+    type; the engraver must write on/off edges for all three controllers.
+    """
+    import pretty_midi
+
+    _, midi_bytes = engraved_artifacts["humanized_with_expression"]
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    by_cc: dict[int, list[int]] = {}
+    for inst in midi.instruments:
+        for cc in inst.control_changes:
+            by_cc.setdefault(cc.number, []).append(cc.value)
+
+    for cc_num, label in ((64, "sustain"), (66, "sostenuto"), (67, "una_corda")):
+        assert cc_num in by_cc, f"{label}: no CC{cc_num} events in MIDI"
+        values = by_cc[cc_num]
+        assert any(v >= 64 for v in values), f"{label}: no CC{cc_num} ON edge"
+        assert any(v < 64 for v in values), f"{label}: no CC{cc_num} OFF edge"
+
+
 # ---------------------------------------------------------------------------
 # L2 — Notation quality lints
 # ---------------------------------------------------------------------------
@@ -251,3 +273,86 @@ def test_l2_note_count_matches_fixture(name: str, engraved_artifacts):
     assert attack_count == expected, (
         f"{name}: MusicXML has {attack_count} note attacks, fixture has {expected}"
     )
+
+
+# ---------------------------------------------------------------------------
+# L2 — "Stop dropping data" lints (plan phase 1.3–1.6 / PR-5)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_humanized_dynamics_rendered(engraved_artifacts):
+    """Static dynamic + hairpin from the expression map reach MusicXML.
+
+    The ``humanized_with_expression`` fixture carries a ``p`` at beat 0
+    and a ``crescendo`` at beat 4. The static mark becomes a
+    ``<dynamics>`` element; the hairpin becomes a ``<words>cresc.</words>``
+    text direction.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["humanized_with_expression"]
+    root = etree.fromstring(musicxml)
+
+    dyn_children = [c.tag for dyn in root.iter("dynamics") for c in dyn]
+    assert "p" in dyn_children, (
+        f"expected <dynamics><p/></dynamics>; got dynamics children {dyn_children}"
+    )
+
+    words = [w.text for w in root.iter("words")]
+    assert "cresc." in words, f"expected 'cresc.' text direction; got {words}"
+
+
+def test_l2_humanized_pedal_text_rendered(engraved_artifacts):
+    """Sustain / sostenuto / una corda all surface as MusicXML text directions.
+
+    Sustain uses the standard "Ped." / "*" pair; sostenuto and una corda
+    use descriptive labels because MusicXML has no dedicated glyphs.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["humanized_with_expression"]
+    root = etree.fromstring(musicxml)
+    words = [w.text for w in root.iter("words")]
+
+    for expected in ("Ped.", "*", "Sost. Ped.", "una corda", "tre corde"):
+        assert expected in words, (
+            f"expected pedal word {expected!r} in MusicXML; got {words}"
+        )
+
+
+def test_l2_humanized_fermata_rendered(engraved_artifacts):
+    """A ``fermata`` articulation emits a ``<fermata>`` element in <notations>."""
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["humanized_with_expression"]
+    root = etree.fromstring(musicxml)
+    fermatas = list(root.iter("fermata"))
+    assert fermatas, "no <fermata> element in rendered MusicXML"
+
+
+def test_l2_engraved_flags_reflect_rendered_content(engraved_artifacts):
+    """``EngravedScoreData.includes_dynamics / includes_pedal_marks`` must
+    now report True when the humanized input populates them.
+
+    The flag flip is the PR-5 counterpart to the phase 1.1 "truthful
+    flags" change — phase 1.1 could only flip the flags to False because
+    engrave wasn't rendering those markings yet.
+    """
+    import asyncio
+    import tempfile
+    from pathlib import Path
+
+    from backend.services.engrave import EngraveService
+    from backend.storage.local import LocalBlobStore
+    from tests.fixtures import load_score_fixture
+
+    # EngraveService writes artifacts to a blob store before returning,
+    # so stand up a throwaway local store rooted in a tmp dir.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        svc = EngraveService(LocalBlobStore(Path(tmpdir)))
+        fixture = load_score_fixture("humanized_with_expression")
+        out = asyncio.run(
+            svc.run(fixture, job_id="test-pr5-flags", title="t", composer="c")
+        )
+        assert out.metadata.includes_dynamics is True
+        assert out.metadata.includes_pedal_marks is True

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -71,7 +71,7 @@ def engraved_artifacts() -> dict[str, tuple[bytes, bytes]]:
     cache: dict[str, tuple[bytes, bytes]] = {}
     for name in FIXTURE_NAMES:
         fixture = load_score_fixture(name)
-        _pdf, musicxml, midi = _engrave_sync(fixture, title=name, composer="test")
+        _pdf, musicxml, midi, _chord_count = _engrave_sync(fixture, title=name, composer="test")
         cache[name] = (musicxml, midi)
     return cache
 
@@ -465,10 +465,119 @@ def test_engrave_does_not_leak_music21_defaults():
     from backend.services.engrave import _engrave_sync
 
     prior = music21.defaults.divisionsPerQuarter
-    _pdf, _xml, _midi = _engrave_sync(
+    _pdf, _xml, _midi, _chord_count = _engrave_sync(
         load_score_fixture("c_major_scale"), title="t", composer="c"
     )
     assert music21.defaults.divisionsPerQuarter == prior
+
+
+# ---------------------------------------------------------------------------
+# L2 — Chord symbol filter gate (plan phase 3.2 / PR-11)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_chord_symbols_filter_gate(engraved_artifacts):
+    """Plan phase 3.2 — only the three clean labels reach MusicXML.
+
+    The ``chord_symbols`` fixture carries seven input labels covering
+    every branch of ``_attach_chord_symbols``:
+
+    - ``C:maj7``, ``Dm7``, ``F:maj7`` — high-confidence, parseable, ≥3 pitches **→ rendered**
+    - ``G5`` — pitch-octave shape **→ dropped (shape gate)**
+    - ``C:maj`` — below 0.5 confidence **→ dropped (confidence gate)**
+    - ``???`` — unparseable **→ dropped (parse gate)**
+    - ``C5`` — pitch-octave shape **→ dropped (shape gate)**
+
+    Assertion: exactly three ``<harmony>`` elements land in the output,
+    with roots ``{C, D, F}``.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["chord_symbols"]
+    root = etree.fromstring(musicxml)
+    harmonies = list(root.iter("harmony"))
+    assert len(harmonies) == 3, (
+        f"expected 3 rendered chord symbols after filter gate, got {len(harmonies)}"
+    )
+
+    roots = {h.findtext("root/root-step") for h in harmonies}
+    assert roots == {"C", "D", "F"}, (
+        f"expected chord roots {{C, D, F}}, got {roots}"
+    )
+
+
+def test_l2_chord_symbols_flag_reflects_filter(tmp_path):
+    """``EngravedScoreData.includes_chord_symbols`` must gate on the *rendered*
+    count, not the raw input count. PR-11 (plan phase 3.2) wires the
+    filter-gate return value all the way out through ``EngraveService``
+    so the flag stops lying about what's on the page.
+    """
+    import asyncio
+
+    from backend.services.engrave import EngraveService
+    from backend.storage.local import LocalBlobStore
+    from tests.fixtures import load_score_fixture
+
+    svc = EngraveService(LocalBlobStore(tmp_path))
+    fixture = load_score_fixture("chord_symbols")
+    out = asyncio.run(
+        svc.run(fixture, job_id="test-pr11-chord-flag", title="t", composer="c")
+    )
+    assert out.metadata.includes_chord_symbols is True
+
+
+def test_l2_chord_symbols_flag_false_when_all_filtered(tmp_path):
+    """Input with *only* bad chord labels → ``includes_chord_symbols`` is False.
+
+    Previously the flag was ``len(chord_symbols) > 0``, which would
+    return True even when every label was about to be dropped. Build a
+    throwaway score with three shape-gate-failing labels and verify the
+    flag flips to False after rendering.
+    """
+    import asyncio
+
+    from backend.contracts import (
+        SCHEMA_VERSION,
+        PianoScore,
+        ScoreChordEvent,
+        ScoreMetadata,
+        ScoreNote,
+        TempoMapEntry,
+    )
+    from backend.services.engrave import EngraveService
+    from backend.storage.local import LocalBlobStore
+
+    score = PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=[
+            ScoreNote(id="rh-0000", pitch=60, onset_beat=0.0, duration_beat=1.0,
+                      velocity=80, voice=1),
+            ScoreNote(id="rh-0001", pitch=62, onset_beat=1.0, duration_beat=1.0,
+                      velocity=80, voice=1),
+        ],
+        left_hand=[],
+        metadata=ScoreMetadata(
+            key="C:major",
+            time_signature=(4, 4),
+            tempo_map=[TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)],
+            difficulty="intermediate",
+            sections=[],
+            chord_symbols=[
+                ScoreChordEvent(beat=0.0, duration_beat=1.0, label="G5",
+                                root=67, confidence=0.99),
+                ScoreChordEvent(beat=1.0, duration_beat=1.0, label="C3",
+                                root=48, confidence=0.99),
+            ],
+        ),
+    )
+
+    svc = EngraveService(LocalBlobStore(tmp_path))
+    out = asyncio.run(
+        svc.run(score, job_id="test-pr11-chord-flag-false", title="t", composer="c")
+    )
+    assert out.metadata.includes_chord_symbols is False, (
+        "flag should be False when every input chord is filtered out"
+    )
 
 
 def test_l2_engraved_flags_reflect_rendered_content(engraved_artifacts):

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -74,7 +74,7 @@ def engraved_artifacts() -> dict[str, tuple[bytes, bytes]]:
     cache: dict[str, tuple[bytes, bytes]] = {}
     for name in FIXTURE_NAMES:
         fixture = load_score_fixture(name)
-        _pdf, musicxml, midi, _ = _engrave_sync(fixture, title=name, composer="test")
+        _pdf, musicxml, midi = _engrave_sync(fixture, title=name, composer="test")
         cache[name] = (musicxml, midi)
     return cache
 

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -472,6 +472,109 @@ def test_engrave_does_not_leak_music21_defaults():
 
 
 # ---------------------------------------------------------------------------
+# L2 — Key signature verification (plan phase 3.3 / PR-12)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_key_signature_override_on_mislabel(engraved_artifacts):
+    """Plan phase 3.3 — Krumhansl-Schmuckler overrides a mislabeled key.
+
+    The ``mislabeled_key`` fixture is an unambiguous F# minor piece
+    tagged as ``C:major``. After the KS analyzer runs in
+    ``_resolve_key_signature``, the MusicXML ``<key><fifths>`` element
+    should show ``3`` (F# minor / A major — three sharps) instead of
+    ``0`` (C major — no accidentals).
+
+    Without the override, every F#/G#/C# in the piece would render as
+    an explicit accidental on each note head — unreadable.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["mislabeled_key"]
+    root = etree.fromstring(musicxml)
+    fifths = [int(e.text) for e in root.iter("fifths")]
+    assert fifths, "no <fifths> element in mislabeled_key MusicXML"
+    assert set(fifths) == {3}, (
+        f"expected <fifths>3</fifths> (F# minor override), got {sorted(set(fifths))}"
+    )
+    modes = [e.text for e in root.iter("mode")]
+    assert modes and all(m == "minor" for m in modes), (
+        f"expected <mode>minor</mode>, got {modes}"
+    )
+
+
+def test_l2_key_signature_low_correlation_trusts_label():
+    """Plan phase 3.3 — low KS correlation leaves the declared key alone.
+
+    Builds a throwaway score out of a highly chromatic tone row so the
+    Krumhansl-Schmuckler correlation lands well below the 0.80 override
+    floor. Even if the analyzer's tonic guess disagrees with the
+    declared key, the override must **not** fire — the histogram is too
+    ambiguous to trust.
+    """
+    import music21
+
+    from backend.contracts import (
+        SCHEMA_VERSION,
+        PianoScore,
+        ScoreMetadata,
+        ScoreNote,
+        TempoMapEntry,
+    )
+    from backend.services.engrave import _resolve_key_signature
+
+    # All 12 pitch classes once each — maximum chromatic, no tonal
+    # center, correlation should collapse.
+    row = [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71]
+    score = PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=[
+            ScoreNote(id=f"rh-{i:04d}", pitch=p, onset_beat=float(i),
+                      duration_beat=1.0, velocity=80, voice=1)
+            for i, p in enumerate(row)
+        ],
+        left_hand=[],
+        metadata=ScoreMetadata(
+            key="C:major",
+            time_signature=(4, 4),
+            tempo_map=[TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)],
+            difficulty="intermediate",
+            sections=[],
+            chord_symbols=[],
+        ),
+    )
+
+    root, mode, overridden = _resolve_key_signature(score, music21)
+    assert not overridden, (
+        f"chromatic tone row should not trigger override; got {root}:{mode}"
+    )
+    assert (root, mode) == ("C", "major"), (
+        f"expected declared C:major to survive, got {root}:{mode}"
+    )
+
+
+def test_l2_key_signature_trusts_correct_label(engraved_artifacts):
+    """Plan phase 3.3 — KS does **not** override when the label agrees.
+
+    Every existing fixture except ``mislabeled_key`` is honestly
+    labeled as C:major. The override must keep quiet on all of them so
+    we don't drift the declared key based on analyzer noise.
+    """
+    from lxml import etree
+
+    for name in FIXTURE_NAMES:
+        if name == "mislabeled_key":
+            continue
+        musicxml, _ = engraved_artifacts[name]
+        root = etree.fromstring(musicxml)
+        fifths = [int(e.text) for e in root.iter("fifths")]
+        assert set(fifths) == {0}, (
+            f"{name}: unexpected key-signature override — expected <fifths>0</fifths>, "
+            f"got {sorted(set(fifths))}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # L2 — Chord symbol filter gate (plan phase 3.2 / PR-11)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -330,6 +330,74 @@ def test_l2_humanized_fermata_rendered(engraved_artifacts):
     assert fermatas, "no <fermata> element in rendered MusicXML"
 
 
+# ---------------------------------------------------------------------------
+# L2 — Grand-staff structure (plan phase 2.3 / PR-8)
+# ---------------------------------------------------------------------------
+
+
+def _count_staff(musicxml: bytes, staff: int) -> int:
+    """Count pitched ``<note>`` elements tagged with ``<staff>{staff}</staff>``."""
+    from lxml import etree
+
+    count = 0
+    for note in etree.fromstring(musicxml).iter("note"):
+        if note.find("rest") is not None:
+            continue
+        staff_elem = note.find("staff")
+        if staff_elem is not None and int(staff_elem.text) == staff:
+            count += 1
+    return count
+
+
+def test_l2_grand_staff_single_part(engraved_artifacts):
+    """Piano scores render as one ``<part>`` with ``<staves>2</staves>``.
+
+    Plan phase 2.3 / PR-8 — before this change, engrave emitted two
+    separate parts ("Right Hand", "Left Hand") which renderers drew as
+    two stacked instruments without a brace. The fix is ``PartStaff`` +
+    ``StaffGroup(symbol='brace')``, which music21 collapses into a single
+    multi-staff part at export time. The part-list label is "Piano",
+    not the per-hand labels used for in-engine bookkeeping.
+    """
+    from lxml import etree
+
+    # two_hand_chordal is the canonical grand-staff fixture: triads in
+    # RH, octaves in LH — both must end up on the same part.
+    musicxml, _ = engraved_artifacts["two_hand_chordal"]
+    root = etree.fromstring(musicxml)
+
+    parts = root.findall("part")
+    assert len(parts) == 1, f"expected single merged part, got {len(parts)}"
+
+    score_parts = root.findall("part-list/score-part")
+    assert len(score_parts) == 1
+    part_name = score_parts[0].findtext("part-name")
+    assert part_name == "Piano", f"expected part-name 'Piano', got {part_name!r}"
+
+    staves = [int(e.text) for e in root.iter("staves")]
+    assert staves and max(staves) == 2, (
+        f"expected <staves>2</staves>, got {staves}"
+    )
+
+    # Staff 1 gets the 12 RH notes, staff 2 gets the 8 LH notes.
+    assert _count_staff(musicxml, 1) == 12
+    assert _count_staff(musicxml, 2) == 8
+
+
+def test_l2_rh_only_fixture_still_single_part(engraved_artifacts):
+    """An empty-LH fixture still emits a grand staff — just with an empty
+    bass stave. This catches the regression where dropping LH content
+    would also drop the ``<staves>2</staves>`` declaration.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["empty_left_hand"]
+    root = etree.fromstring(musicxml)
+    assert len(root.findall("part")) == 1
+    staves = [int(e.text) for e in root.iter("staves")]
+    assert staves and max(staves) == 2
+
+
 def test_l2_engraved_flags_reflect_rendered_content(engraved_artifacts):
     """``EngravedScoreData.includes_dynamics / includes_pedal_marks`` must
     now report True when the humanized input populates them.

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -217,17 +217,24 @@ def test_l2_voice_numbers_in_range(name: str, engraved_artifacts):
 
 
 @pytest.mark.parametrize("name", FIXTURE_NAMES)
-def test_l2_divisions_reasonable(name: str, engraved_artifacts):
-    """``<divisions>`` must stay small (≤480) — OSMD chokes on the
-    10080 value music21 picks by default."""
+def test_l2_divisions_is_twelve(name: str, engraved_artifacts):
+    """``<divisions>`` must be exactly 12 per quarter.
+
+    PR-9 (plan phase 2.4) sets ``music21.defaults.divisionsPerQuarter=12``
+    before export so the grid is fixed by construction — 16th = 3
+    divisions, 8th = 6, triplet-8th = 4, quarter = 12. Prior to PR-9 the
+    value was music21's shipped default of 10080, which OSMD cannot
+    consume; this test would catch either regression.
+    """
     from lxml import etree
 
     musicxml, _ = engraved_artifacts[name]
     root = etree.fromstring(musicxml)
     divisions = [int(e.text) for e in root.iter("divisions")]
     assert divisions, f"{name}: no <divisions> element in MusicXML"
-    for d in divisions:
-        assert 1 <= d <= 480, f"{name}: <divisions>{d}</divisions> outside [1,480]"
+    assert set(divisions) == {12}, (
+        f"{name}: expected <divisions>12</divisions>, got {sorted(set(divisions))}"
+    )
 
 
 @pytest.mark.parametrize("name", FIXTURE_NAMES)
@@ -396,6 +403,26 @@ def test_l2_rh_only_fixture_still_single_part(engraved_artifacts):
     assert len(root.findall("part")) == 1
     staves = [int(e.text) for e in root.iter("staves")]
     assert staves and max(staves) == 2
+
+
+def test_engrave_does_not_leak_music21_defaults():
+    """``music21.defaults.divisionsPerQuarter`` must be restored after engrave.
+
+    PR-9 overrides this global to 12 around ``s.write("musicxml", ...)``
+    so OSMD-friendly divisions come out by construction. The override
+    must be wrapped in try/finally so that other music21 callers (eval
+    scripts, arrange's makeNotation in a shared process, etc.) keep
+    seeing the upstream default of 10080.
+    """
+    import music21
+
+    from backend.services.engrave import _engrave_sync
+
+    prior = music21.defaults.divisionsPerQuarter
+    _pdf, _xml, _midi = _engrave_sync(
+        load_score_fixture("c_major_scale"), title="t", composer="c"
+    )
+    assert music21.defaults.divisionsPerQuarter == prior
 
 
 def test_l2_engraved_flags_reflect_rendered_content(engraved_artifacts):

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -1,0 +1,261 @@
+"""Engrave quality harness — L1 (MIDI round-trip) + L2 (notation lints).
+
+This is the first layer of the evaluation harness described in
+``docs/engrave-improvement-plan.md`` Phase 0.2. It runs every score
+fixture in ``tests/fixtures/scores/`` through ``_engrave_sync`` and:
+
+- **L1 — MIDI round-trip.** Parses the emitted MIDI with ``pretty_midi``
+  and asserts that every fixture note is present in the output (by
+  pitch + attack count). Catches dropped notes and wrong-pitch
+  regressions.
+- **L2 — Notation quality lints.** Parses the emitted MusicXML with
+  ``lxml`` and runs structural xpath checks: ``<voice>`` in range,
+  ``<divisions>`` ≤ 480, pitches within the 88-key piano range, note
+  count consistent with the fixture.
+
+A separate ``xfail``-marked test exists for the
+``humanized_with_offsets`` fixture, pinning the current
+``timing_offset_ms`` behavior (see plan Phase 1.2). When that PR lands
+and the bug is fixed, the xfail flips to a pass and CI fails under
+``strict=True`` — at which point the marker should be removed.
+"""
+from __future__ import annotations
+
+import io
+from collections import Counter
+
+import pytest
+
+from backend.contracts import HumanizedPerformance, PianoScore, beat_to_sec
+from backend.services.engrave import _engrave_sync
+from tests.fixtures import FIXTURE_NAMES, load_score_fixture
+
+# ---------------------------------------------------------------------------
+# MusicXML step → semitone table for pitch decoding
+# ---------------------------------------------------------------------------
+
+_STEP_TO_SEMITONE = {"C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11}
+
+
+def _musicxml_pitch_to_midi(pitch_elem) -> int:
+    step = pitch_elem.findtext("step")
+    octave = int(pitch_elem.findtext("octave"))
+    alter_text = pitch_elem.findtext("alter")
+    alter = int(float(alter_text)) if alter_text else 0
+    return (octave + 1) * 12 + _STEP_TO_SEMITONE[step] + alter
+
+
+def _expected_note_pitches(fixture) -> list[int]:
+    """Return the MIDI pitches of every note in a fixture.
+
+    For a ``PianoScore`` this is ``rh + lh``. For a
+    ``HumanizedPerformance`` it's ``expressive_notes`` — same count, but
+    with the timing offsets baked in.
+    """
+    if isinstance(fixture, HumanizedPerformance):
+        return [n.pitch for n in fixture.expressive_notes]
+    if isinstance(fixture, PianoScore):
+        return [n.pitch for n in fixture.right_hand] + [n.pitch for n in fixture.left_hand]
+    raise TypeError(f"Unexpected fixture type: {type(fixture).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Engrave-once-per-fixture cache
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def engraved_artifacts() -> dict[str, tuple[bytes, bytes]]:
+    """Run each fixture through ``_engrave_sync`` once per test module.
+
+    Returns ``{name: (musicxml_bytes, midi_bytes)}``. Running engrave is
+    cheap but music21's importer is slow (~1s) and we don't want to pay
+    it for every parametrized test.
+    """
+    cache: dict[str, tuple[bytes, bytes]] = {}
+    for name in FIXTURE_NAMES:
+        fixture = load_score_fixture(name)
+        _pdf, musicxml, midi, _ = _engrave_sync(fixture, title=name, composer="test")
+        cache[name] = (musicxml, midi)
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# L1 — MIDI round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l1_midi_round_trip(name: str, engraved_artifacts):
+    """Every fixture note round-trips to MIDI with the right pitch + count."""
+    import pretty_midi
+
+    fixture = load_score_fixture(name)
+    _, midi_bytes = engraved_artifacts[name]
+    assert midi_bytes, f"engrave emitted empty MIDI for fixture {name!r}"
+
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    actual_pitches = [note.pitch for inst in midi.instruments for note in inst.notes]
+    expected_pitches = _expected_note_pitches(fixture)
+
+    actual_counter = Counter(actual_pitches)
+    expected_counter = Counter(expected_pitches)
+
+    # The same-pitch overlap resolver in engrave.py:94-103 may collapse
+    # two overlapping attacks into a single sustained note, so for that
+    # specific fixture we only assert "at least one attack per pitch."
+    # Every other fixture is strict.
+    if name == "overlapping_same_pitch":
+        assert set(actual_counter.keys()) == set(expected_counter.keys()), (
+            f"{name}: pitch set mismatch — expected {sorted(expected_counter)} "
+            f"got {sorted(actual_counter)}"
+        )
+        assert sum(actual_counter.values()) >= 1
+    else:
+        assert actual_counter == expected_counter, (
+            f"{name}: MIDI pitch counts diverge from the fixture.\n"
+            f"  expected: {sorted(expected_counter.items())}\n"
+            f"  got:      {sorted(actual_counter.items())}"
+        )
+
+
+@pytest.mark.xfail(
+    reason="timing_offset_ms is applied to BOTH onset and offset (engrave.py:87-88). "
+           "Plan Phase 1.2 resolves the semantics; flipping this to a pass means "
+           "the bug is fixed and the marker should be removed.",
+    strict=True,
+)
+def test_l1_humanized_timing_offset_is_onset_only(engraved_artifacts):
+    """Pin the *expected* onset-only semantics of ``timing_offset_ms``.
+
+    The fixture's first RH note is C4 at beat 0, duration 1 beat, with
+    ``timing_offset_ms = +20``. At 120 BPM one beat is 0.5 s, so an
+    onset-only shift would produce ``onset = 0.020 s`` and
+    ``offset = 0.500 s`` (duration compressed to 0.480 s). The current
+    implementation shifts both onset and offset equally, producing
+    ``offset = 0.520 s`` — that is what ``strict=True`` is pinning.
+    """
+    import pretty_midi
+
+    fixture = load_score_fixture("humanized_with_offsets")
+    assert isinstance(fixture, HumanizedPerformance)
+
+    _, midi_bytes = engraved_artifacts["humanized_with_offsets"]
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    notes_by_pitch = {}
+    for inst in midi.instruments:
+        for n in inst.notes:
+            notes_by_pitch.setdefault(n.pitch, []).append(n)
+
+    # First RH note: pitch 60 (C4), beat 0, timing_offset_ms=+20, duration=1 beat
+    rh0 = fixture.expressive_notes[0]
+    assert rh0.pitch == 60
+    assert rh0.timing_offset_ms == pytest.approx(20.0)
+
+    c4_notes = sorted(notes_by_pitch[60], key=lambda n: n.start)
+    first = c4_notes[0]
+
+    tempo_map = fixture.score.metadata.tempo_map
+    unshifted_offset_sec = beat_to_sec(rh0.onset_beat + rh0.duration_beat, tempo_map)
+    assert first.end == pytest.approx(unshifted_offset_sec, abs=0.001), (
+        f"expected offset unchanged at {unshifted_offset_sec:.3f}s, got {first.end:.3f}s "
+        "(timing_offset_ms leaked into the release boundary)"
+    )
+
+
+def test_l1_humanized_pedal_reaches_midi(engraved_artifacts):
+    """Sustain pedal events must emit CC64 on/off in the output MIDI."""
+    import pretty_midi
+
+    _, midi_bytes = engraved_artifacts["humanized_with_offsets"]
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    cc64 = [
+        cc
+        for inst in midi.instruments
+        for cc in inst.control_changes
+        if cc.number == 64
+    ]
+    assert any(cc.value >= 64 for cc in cc64), "no sustain pedal ON (CC64 ≥ 64)"
+    assert any(cc.value < 64 for cc in cc64), "no sustain pedal OFF (CC64 < 64)"
+
+
+# ---------------------------------------------------------------------------
+# L2 — Notation quality lints
+# ---------------------------------------------------------------------------
+
+_PIANO_MIN_MIDI = 21   # A0
+_PIANO_MAX_MIDI = 108  # C8
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_voice_numbers_in_range(name: str, engraved_artifacts):
+    """Every ``<voice>`` element must be an integer in [1, 4].
+
+    music21 omits ``<voice>`` entirely for single-voice parts, so a
+    missing element is also fine — we only complain about values that
+    are present and out of range.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+    voices = [int(e.text) for e in root.iter("voice")]
+    bad = [v for v in voices if not 1 <= v <= 4]
+    assert not bad, f"{name}: out-of-range <voice> values: {sorted(set(bad))}"
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_divisions_reasonable(name: str, engraved_artifacts):
+    """``<divisions>`` must stay small (≤480) — OSMD chokes on the
+    10080 value music21 picks by default."""
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+    divisions = [int(e.text) for e in root.iter("divisions")]
+    assert divisions, f"{name}: no <divisions> element in MusicXML"
+    for d in divisions:
+        assert 1 <= d <= 480, f"{name}: <divisions>{d}</divisions> outside [1,480]"
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_pitches_in_piano_range(name: str, engraved_artifacts):
+    """Every pitched ``<note>`` must land on an 88-key piano (A0..C8)."""
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+    out_of_range: list[int] = []
+    for pitch_elem in root.iter("pitch"):
+        midi = _musicxml_pitch_to_midi(pitch_elem)
+        if not _PIANO_MIN_MIDI <= midi <= _PIANO_MAX_MIDI:
+            out_of_range.append(midi)
+    assert not out_of_range, f"{name}: pitches outside piano range: {sorted(set(out_of_range))}"
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_note_count_matches_fixture(name: str, engraved_artifacts):
+    """MusicXML note-attack count agrees with the fixture's note count.
+
+    Tied continuations (``<tie type="stop"/>``) are excluded — they
+    represent the same attack that spans a barline. Rests are skipped.
+    """
+    from lxml import etree
+
+    fixture = load_score_fixture(name)
+    expected = len(_expected_note_pitches(fixture))
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+
+    attack_count = 0
+    for note in root.iter("note"):
+        if note.find("rest") is not None:
+            continue
+        tie_stops = [t for t in note.findall("tie") if t.get("type") == "stop"]
+        if tie_stops and len(tie_stops) == len(note.findall("tie")):
+            # Pure tie-continuation (no concurrent start) — not a new attack.
+            continue
+        attack_count += 1
+
+    assert attack_count == expected, (
+        f"{name}: MusicXML has {attack_count} note attacks, fixture has {expected}"
+    )


### PR DESCRIPTION
## Summary

Lands the engrave improvement plan end-to-end (`docs/engrave-improvement-plan.md`, PR-1 through PR-13), taking engrave from a stub-heavy regex-driven path to a real music21-backed renderer with diffable quality coverage.

**Evaluation harness (PR-1)**
- 10 Pydantic-built score fixtures under `tests/fixtures/scores/` + builders at `tests/fixtures/_builders.py`
- L1 MIDI round-trip checks (pretty_midi) and L2 MusicXML structural lints (lxml)
- Adds `lxml>=5.0` to dev extras

**Correctness fixes**
- Truthful `EngravedScoreData.includes_dynamics` / `includes_pedal_marks` flags (PR-3)
- `timing_offset_ms` applied to onset only, not duration-preserving shift (PR-4)
- Dynamics, pedal marks, fermata, and CC66/CC67 now render to MusicXML + MIDI (PR-5)
- Key signature verified via Krumhansl-Schmuckler with correlation/disagreement gate to fix mis-labeled transcriptions (PR-12)

**Renderer infrastructure**
- LilyPond installed in prod image; real PDF output instead of the 60-byte stub (PR-6)
- Hard-require music21, delete `_minimal_musicxml` fallback and the bare-except that masked real bugs (PR-7)
- Grand staff via `PartStaff` + braced `StaffGroup` instead of two stacked parts (PR-8)
- Force `divisions=12` at the music21 exporter boundary, retire the regex rescaler in the OSMD sanitizer (PR-9)
- Preserve 2 voices per staff; cap arrange RH/LH voices at 2/2 (beginner 1/1) (PR-10)
- Re-enable chord symbols behind a confidence ≥0.5 / shape / parse gate; attached only to the RH staff (PR-11)
- Drop redundant re-quantize step now that arrange's grid is authoritative (PR-13)

**Net test impact:** 412 existing tests still pass; +51 new quality tests across the harness.

## Test plan

- [ ] `make test` passes locally (backend unit + new L1/L2 quality tests)
- [ ] `make lint` and `make typecheck` clean
- [ ] End-to-end job on a real audio upload — verify the returned PDF is real LilyPond output (not the stub) and the MusicXML opens cleanly in OSMD
- [ ] Spot-check a mis-labeled-key transcription to confirm KS override flips the key signature
- [ ] Verify chord symbols render above the RH staff only when the confidence/shape/parse gate passes
- [ ] Confirm grand staff with brace renders on a two-hand fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)