### PR TITLE
update from main

### DIFF
--- a/frontend/lib/widgets/version_footer.dart
+++ b/frontend/lib/widgets/version_footer.dart
@@ -1,21 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../theme.dart';
 
-const appVersion = String.fromEnvironment('APP_VERSION', defaultValue: 'dev');
+/// Optional compile-time override (e.g. Docker `--dart-define=APP_VERSION=…`).
+/// When empty, the label comes from [PackageInfo] (semver + build from `pubspec.yaml`).
+const _envVersion = String.fromEnvironment('APP_VERSION', defaultValue: '');
 
 class VersionFooter extends StatelessWidget {
   const VersionFooter({super.key});
 
+  static String _displayFromEnv() {
+    final raw = _envVersion.trim();
+    if (raw.isEmpty) return '';
+    final normalized = raw.startsWith('v') ? raw.substring(1) : raw;
+    return 'v$normalized';
+  }
+
+  static String _displayFromPackageInfo(PackageInfo info) {
+    final build = info.buildNumber.trim();
+    final hasBuild = build.isNotEmpty && build != '0';
+    return hasBuild ? 'v${info.version}+$build' : 'v${info.version}';
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Text(
-      'v$appVersion',
-      style: TextStyle(
-        fontSize: 11,
-        color: OhSheetColors.mutedText.withValues(alpha: 0.5),
-        fontWeight: FontWeight.w500,
-      ),
+    final fromEnv = _displayFromEnv();
+    if (fromEnv.isNotEmpty) {
+      return Text(
+        fromEnv,
+        style: TextStyle(
+          fontSize: 11,
+          color: OhSheetColors.mutedText.withValues(alpha: 0.5),
+          fontWeight: FontWeight.w500,
+        ),
+      );
+    }
+
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox(height: 14);
+        }
+        final label = _displayFromPackageInfo(snapshot.data!);
+        return Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            color: OhSheetColors.mutedText.withValues(alpha: 0.5),
+            fontWeight: FontWeight.w500,
+          ),
+        );
+      },
     );
   }
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -200,6 +200,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   file_picker: ^8.0.0
   url_launcher: ^6.2.5
   flutter_svg: ^2.2.4
+  package_info_plus: ^8.1.2
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/frontend/test/widgets/version_footer_test.dart
+++ b/frontend/test/widgets/version_footer_test.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ohsheet_app/widgets/version_footer.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 void main() {
-  testWidgets('VersionFooter displays version text', (tester) async {
+  testWidgets('VersionFooter shows pubspec version when APP_VERSION unset', (tester) async {
+    PackageInfo.setMockInitialValues(
+      appName: 'Oh Sheet',
+      packageName: 'ohsheet_app',
+      version: '0.1.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -11,8 +20,8 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
-    // Default value when APP_VERSION is not defined at compile time
-    expect(find.text('vdev'), findsOneWidget);
+    expect(find.text('v0.1.0+1'), findsOneWidget);
   });
 }

--- a/tests/test_arrange_simplify.py
+++ b/tests/test_arrange_simplify.py
@@ -6,8 +6,6 @@ and returns a simplified copy suitable for sheet-music engraving.
 """
 from __future__ import annotations
 
-import pytest
-
 from shared.contracts import (
     PianoScore,
     ScoreMetadata,


### PR DESCRIPTION
* docs: add version tracking design spec



* docs: add testing plan to version tracking spec



* docs: add version tracking implementation plan



* build: configure python-semantic-release for unified versioning



* feat: add version to health endpoint



* feat: add version footer to all screens



* build: pass APP_VERSION to Flutter build via Docker arg

* build: add pubspec version sync script

* ci: add semantic-release workflow for auto-versioning

* ci: pass app version to Docker build and Slack notifications

* ci: add version-sync lint check and semantic-release dry-run

* Stop tracking coverage.xml and dedupe gitignore rules

Made-with: Cursor

* docs: align system design with as-built architecture

Rewrite the HLD to reflect the current monolith + Celery workers, local blob store, in-memory jobs, and Flutter client. Add contracts, API surface, deployment, and known limitations; move aspirational Miro-style architecture to a future-design section.

Made-with: Cursor

* fix(ci): use --print instead of --dry-run for semantic-release v10

* fix(ci): allow semantic-release exit code 1 (no release) on PR branches

* fix(ci): disable bash -e so semantic-release exit code 1 doesn't abort

* fix(frontend): show semver from pubspec in version footer

Use package_info_plus when APP_VERSION is not set so local runs show v0.1.0+1 instead of vdev. Optional dart-define override unchanged.

Made-with: Cursor

* fix(tests): satisfy ruff in test_arrange_simplify

Remove unused pytest import; resolves I001/F401 for CI backend-lint.

Made-with: Cursor

---------