### PR TITLE
fix(deploy): pin orchestrator to --workers 1 (GAU-100)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,8 +15,14 @@ services:
       retries: 5
 
   orchestrator:
+    # JobManager stores jobs in an in-process dict (see
+    # backend/jobs/manager.py — "Single-process v1"), so running more
+    # than one uvicorn worker splits job state across processes: POST
+    # /v1/jobs lands on one worker, the subsequent GET / WS lands on
+    # another and returns "Job not found" (GAU-100). Keep --workers 1
+    # until JobManager is backed by Redis / Postgres.
     image: ${IMAGE}
-    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 2
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 1
     restart: unless-stopped
     ports:
       - "8000:8000"


### PR DESCRIPTION
## Summary
- Drop `orchestrator` service from `--workers 2` to `--workers 1` in `docker-compose.prod.yml`.
- Root cause: `JobManager` (`backend/jobs/manager.py`) stores jobs in an in-process `dict`; its docstring literally says *"Single-process v1. ... Replace with Redis Streams / Postgres LISTEN-NOTIFY for multi-worker deploys."* Two uvicorn workers split that state across PIDs, so `POST /v1/jobs` lands on worker A while the subsequent `GET /v1/jobs/{id}` / WS round-robins to worker B and surfaces **"Bad state: job not found"** in the UI.
- Not reproducible locally because `docker-compose.yml` uses `--reload`, which forces a single worker.

## Repro (before fix, against https://oh-sheet-qa.duckdns.org on commit `69dcbe1`)
1. Open the app, switch to the **MIDI** tab, pick `test_files/Rat Dance.mid`, click **Let's go!**
2. Frontend sees `POST /v1/uploads/midi → 200`, `POST /v1/jobs → 202` with `job_id=7587d7d3…`, then UI shows **"Bad state: job not found: 7587d7d3ac8d"**.
3. `GET /v1/jobs/7587d7d3ac8d` returns `{"detail":"Job not found: 7587d7d3ac8d"}` — the record lives in the other worker's memory.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge into `qa`, deploy workflow publishes new image and restarts the orchestrator with `--workers 1`.
- [ ] Re-run the MIDI upload flow on QA — expect the progress screen to stream events and land on **Succeeded**.
- [ ] `curl https://oh-sheet-qa.duckdns.org/v1/jobs/<id>` returns the record across repeated polls (no round-robin 404s).

## Follow-up (not this PR)
Longer-term fix: back `JobManager` with Redis (already in the compose) or Postgres so we can safely scale out workers. Tracked separately.