### PR TITLE
Release: merge qa into main (engrave overhaul, environments, worker fix)

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,25 @@
+name: Branch Guard
+
+# Enforces the release flow: the only way to get code into main is via a PR
+# from the qa branch. This check must be set as a required status check on
+# main's branch protection rules for the guarantee to hold.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  enforce-qa-source:
+    name: PR to main must come from qa
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch is qa
+        run: |
+          if [[ "${{ github.event.pull_request.head.ref }}" != "qa" ]]; then
+            echo "::error::PRs to main must originate from the 'qa' branch."
+            echo "::error::This PR's source is '${{ github.event.pull_request.head.ref }}'."
+            echo "::error::Release flow: feature branch → qa → main."
+            exit 1
+          fi
+          echo "Source branch is qa — OK."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [qa, main]
   pull_request:
-    branches: [main]
+    branches: [qa, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,12 @@ name: Deploy to VM
 
 on:
   push:
-    branches: [main]
+    branches: [qa, main]
   workflow_dispatch:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
@@ -18,8 +18,13 @@ env:
 
 jobs:
   deploy:
-    name: Build & Deploy
+    name: Build & Deploy (${{ github.ref_name }})
     runs-on: ubuntu-latest
+    # Route qa pushes → qa environment, main pushes → prod environment.
+    # Environment-scoped vars/secrets (VM_HOST, PUBLIC_URL) determine the target.
+    environment:
+      name: ${{ github.ref_name == 'main' && 'prod' || 'qa' }}
+      url: ${{ vars.PUBLIC_URL }}
     permissions:
       contents: read
       id-token: write
@@ -74,11 +79,12 @@ jobs:
           SSH="ssh -i ~/.ssh/deploy_key ${VM_USER}@${VM_HOST}"
           SCP="scp -i ~/.ssh/deploy_key"
 
-          # Write .env with the image tag and commit SHA for docker compose
+          # Write .env with image tags, commit SHA, and domain for docker compose
           echo "IMAGE=${{ env.IMAGE }}:${{ github.sha }}" > /tmp/.env
           echo "IMAGE_DECOMPOSER=${{ env.IMAGE_DECOMPOSER }}:${{ github.sha }}" >> /tmp/.env
           echo "IMAGE_ASSEMBLER=${{ env.IMAGE_ASSEMBLER }}:${{ github.sha }}" >> /tmp/.env
           echo "COMMIT_SHA=${{ github.sha }}" >> /tmp/.env
+          echo "DOMAIN=${{ vars.DOMAIN }}" >> /tmp/.env
 
           # Copy compose files to VM (SCP .env to temp name, then atomic mv)
           $SCP docker-compose.prod.yml Caddyfile "${VM_USER}@${VM_HOST}:~/oh-sheet/"
@@ -90,20 +96,21 @@ jobs:
 
       - name: Verify deployment
         env:
-          VM_HOST: ${{ vars.VM_HOST }}
+          PUBLIC_URL: ${{ vars.PUBLIC_URL }}
         run: |
           sleep 15
-          curl -sf --retry 5 --retry-delay 5 "https://oh-sheet.duckdns.org/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
+          curl -sf --retry 5 --retry-delay 5 "${PUBLIC_URL}/v1/health" && echo "Health check passed" || echo "::warning::Health check did not pass yet"
 
       - name: Notify Slack on success
         if: success()
         run: |
           COMMIT_SHORT="${{ github.sha }}"
           COMMIT_SHORT="${COMMIT_SHORT:0:7}"
+          ENV_NAME="${{ github.ref_name == 'main' && 'PROD' || 'QA' }}"
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             -d "{
-              \"text\": \":white_check_mark: *oh-sheet deployed* v${{ steps.version.outputs.version }} (\`${COMMIT_SHORT}\`) to <https://oh-sheet.duckdns.org> — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+              \"text\": \":white_check_mark: *oh-sheet [${ENV_NAME}] deployed* v${{ steps.version.outputs.version }} (\`${COMMIT_SHORT}\`) to <${{ vars.PUBLIC_URL }}> — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }"
 
       - name: Notify Slack on failure
@@ -111,8 +118,9 @@ jobs:
         run: |
           COMMIT_SHORT="${{ github.sha }}"
           COMMIT_SHORT="${COMMIT_SHORT:0:7}"
+          ENV_NAME="${{ github.ref_name == 'main' && 'PROD' || 'QA' }}"
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H 'Content-type: application/json' \
             -d "{
-              \"text\": \":x: *oh-sheet deploy failed* \`${COMMIT_SHORT}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
+              \"text\": \":x: *oh-sheet [${ENV_NAME}] deploy failed* \`${COMMIT_SHORT}\` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"
             }"

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,3 @@
-oh-sheet.duckdns.org {
+{$DOMAIN:localhost} {
     reverse_proxy orchestrator:8000
 }
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,15 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# System deps for yt-dlp (ffmpeg) and general health
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg curl \
+# System deps:
+#   ffmpeg   — yt-dlp audio extraction
+#   lilypond — MusicXML → PDF via musicxml2ly + lilypond (the engrave
+#              service falls back to a 60-byte stub PDF without this)
+#   curl     — health checks / debug
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        lilypond \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install shared package first (changes less often)

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.api.deps import get_job_manager
+from backend.api.deps import get_blob_store, get_job_manager
 from backend.config import settings
 from backend.contracts import (
     SCHEMA_VERSION,
@@ -21,6 +21,7 @@ from backend.contracts import (
 )
 from backend.jobs.events import JobEvent
 from backend.jobs.manager import JobManager, JobRecord
+from backend.storage.local import LocalBlobStore
 
 router = APIRouter()
 
@@ -35,12 +36,22 @@ class JobCreateRequest(BaseModel):
 
     ``title`` and ``artist`` are metadata — they can be supplied alongside any
     source.
+
+    ``prefer_clean_source`` is the user's opt-in to the cover-search fast
+    path: when True, the ingest stage will try to find a clean piano
+    cover of the song and transcribe that instead of the user's original
+    YouTube URL. Only meaningful for title-lookup / YouTube inputs; the
+    audio_upload and midi_upload variants ignore it because the user is
+    providing the source directly. See ``backend.services.cover_search``
+    for the matching policy. Defaults to False so existing clients keep
+    working unchanged.
     """
 
     audio: RemoteAudioFile | None = None
     midi: RemoteMidiFile | None = None
     title: str | None = None
     artist: str | None = None
+    prefer_clean_source: bool = False
 
     skip_humanizer: bool = False
     difficulty: Difficulty = "intermediate"
@@ -72,6 +83,7 @@ def _record_to_summary(record: JobRecord) -> JobSummary:
 async def create_job(
     body: JobCreateRequest,
     manager: Annotated[JobManager, Depends(get_job_manager)],
+    blob: Annotated[LocalBlobStore, Depends(get_blob_store)],
 ) -> JobSummary:
     # Source signal: audio xor midi; if neither, fall back to title-lookup.
     if body.audio is not None and body.midi is not None:
@@ -85,12 +97,37 @@ async def create_job(
             detail="Provide one of: audio, midi, or title (for title-lookup).",
         )
 
+    # Integrity: the audio / midi URI must point to a real blob in
+    # storage. Without this check a client could forge a Remote*File
+    # with an arbitrary URI and the pipeline would "succeed" by
+    # running stub stages over nothing — a silent failure mode that
+    # masked real upload bugs during development.
+    if body.audio is not None and not blob.exists(body.audio.uri):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Audio URI does not resolve to a stored blob: {body.audio.uri!r}",
+        )
+    if body.midi is not None and not blob.exists(body.midi.uri):
+        raise HTTPException(
+            status_code=400,
+            detail=f"MIDI URI does not resolve to a stored blob: {body.midi.uri!r}",
+        )
+
+    # Build InputMetadata once — prefer_clean_source is threaded through
+    # every variant so uploads can theoretically opt in too (the ingest
+    # stage just ignores it when audio is already present).
+    metadata_kwargs = {
+        "title": body.title,
+        "artist": body.artist,
+        "prefer_clean_source": body.prefer_clean_source,
+    }
+
     if body.audio is not None:
         bundle = InputBundle(
             schema_version=SCHEMA_VERSION,
             audio=body.audio,
             midi=None,
-            metadata=InputMetadata(title=body.title, artist=body.artist, source="audio_upload"),
+            metadata=InputMetadata(source="audio_upload", **metadata_kwargs),
         )
         variant: PipelineVariant = "audio_upload"
     elif body.midi is not None:
@@ -98,7 +135,7 @@ async def create_job(
             schema_version=SCHEMA_VERSION,
             audio=None,
             midi=body.midi,
-            metadata=InputMetadata(title=body.title, artist=body.artist, source="midi_upload"),
+            metadata=InputMetadata(source="midi_upload", **metadata_kwargs),
         )
         variant = "midi_upload"
     else:
@@ -107,7 +144,7 @@ async def create_job(
             schema_version=SCHEMA_VERSION,
             audio=None,
             midi=None,
-            metadata=InputMetadata(title=body.title, artist=body.artist, source="title_lookup"),
+            metadata=InputMetadata(source="title_lookup", **metadata_kwargs),
         )
         variant = "full"
 

--- a/backend/api/routes/uploads.py
+++ b/backend/api/routes/uploads.py
@@ -22,6 +22,13 @@ router = APIRouter()
 AUDIO_FORMATS = {"mp3", "wav", "flac", "m4a"}
 MIDI_FORMATS = {"mid", "midi"}
 
+# Standard MIDI File magic header. Every SMF (regardless of format 0/1/2)
+# begins with the 4-byte "MThd" chunk type. Checking these four bytes
+# is a cheap content-integrity gate — it blocks the "rename anything
+# to .mid and upload" attack without pulling in a MIDI parser at the
+# HTTP layer. Deeper structural validation is ingest's job.
+_MIDI_MAGIC = b"MThd"
+
 
 def _ext(filename: str) -> str:
     return filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
@@ -67,6 +74,20 @@ async def upload_midi(
         )
 
     data = await file.read()
+
+    # Content-integrity check: the .mid/.midi extension is a hint, not
+    # a guarantee. Reject anything that doesn't begin with the Standard
+    # MIDI File magic header so garbage bytes can't land in blob
+    # storage and get passed to the ingest stage.
+    if not data.startswith(_MIDI_MAGIC):
+        raise HTTPException(
+            status_code=415,
+            detail=(
+                "Uploaded bytes are not a valid MIDI file "
+                "(missing 'MThd' header). Please upload a Standard MIDI File."
+            ),
+        )
+
     digest = hashlib.sha256(data).hexdigest()
     uri = blob.put_bytes(f"uploads/midi/{digest}.mid", data)
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -434,6 +434,31 @@ class Settings(BaseSettings):
     duration_refine_min_duration_sec: float = 0.03
     duration_refine_hop_length: int = 256
 
+    # ---- Piano cover search (ingest fast path) ----------------------------
+    # When a job arrives with ``prefer_clean_source=True``, the ingest
+    # stage probes the user's YouTube URL for (title, artist), searches
+    # for a clean piano cover via yt-dlp + scoring, and swaps the URL
+    # for the cover's URL before transcription. Basic Pitch is a
+    # polyphonic tracker that transcribes every audible pitch — drums,
+    # vocals, bass — as piano notes, so feeding it a monophonic piano
+    # cover produces a dramatically cleaner result than a full-band mix.
+    # See backend/services/cover_search.py for the matching logic.
+    #
+    # ``cover_search_enabled`` is the operator kill switch. Leave it
+    # on by default so the per-job ``prefer_clean_source`` flag decides
+    # whether to run; flip to False in production to disable the whole
+    # feature without needing a code change (e.g. if yt-dlp search
+    # breaks or the allowlist is producing bad matches on a new corpus).
+    #
+    # ``cover_search_min_score`` is the scoring threshold that a
+    # candidate must clear to trigger a URL swap. See the module
+    # docstring in cover_search.py for the scoring rules; the default
+    # of 60 was chosen from dry-run testing against real YouTube.
+    # Raise to 70 for "allowlist-only" strict matching, lower to 50 if
+    # you're happy to accept weaker title-only matches.
+    cover_search_enabled: bool = True
+    cover_search_min_score: int = 60
+
     @field_validator(
         "cleanup_energy_gate_floor_ratio",
         "cleanup_octave_amp_ratio",

--- a/backend/services/arrange.py
+++ b/backend/services/arrange.py
@@ -37,8 +37,15 @@ log = logging.getLogger(__name__)
 
 QUANT_GRID = 0.25            # 1/16th note (default / fallback)
 SPLIT_PITCH = 60             # middle C — pitches >= split go right hand
-MAX_VOICES_RH = 4
-MAX_VOICES_LH = 3
+# Piano notation is defined by at most two voices per staff (stems up =
+# melody, stems down = accompaniment). Capping here means engrave can
+# trust the voice assignment and emit ``<voice>1</voice>`` / ``<voice>2</voice>``
+# directly instead of collapsing everything back down. Going wider
+# (4/3 previously) produced voice-3 notes that OSMD's VexFlow backend
+# crashes on and that no pianist can actually read as four parallel
+# lines on one staff.
+MAX_VOICES_RH = 2
+MAX_VOICES_LH = 2
 MIN_TRACK_CONFIDENCE = 0.35
 NEAR_OVERLAP_TOL = 0.15      # beats
 
@@ -386,6 +393,7 @@ def _chord_to_score_chord(
         duration_beat=max(end - onset, QUANT_GRID),
         label=chord.label,
         root=chord.root,
+        confidence=chord.confidence,
     )
 
 
@@ -427,7 +435,7 @@ def _arrange_sync(
         grid = QUANT_GRID
     overlap_tol = 0.6 * grid
 
-    max_rh = MAX_VOICES_RH if difficulty != "beginner" else 2
+    max_rh = MAX_VOICES_RH if difficulty != "beginner" else 1
     max_lh = MAX_VOICES_LH if difficulty != "beginner" else 1
     rh_voiced = _resolve_overlaps(rh_raw, max_rh, grid=grid, overlap_tol=overlap_tol)
     lh_voiced = _resolve_overlaps(lh_raw, max_lh, grid=grid, overlap_tol=overlap_tol)

--- a/backend/services/condense.py
+++ b/backend/services/condense.py
@@ -56,6 +56,7 @@ def _chord_to_score_chord(
         duration_beat=max(end - onset, MIN_DURATION_BEAT),
         label=chord.label,
         root=chord.root,
+        confidence=chord.confidence,
     )
 
 

--- a/backend/services/cover_search.py
+++ b/backend/services/cover_search.py
@@ -1,0 +1,707 @@
+"""Clean-source search — the ingest stage's "fast path" data source router.
+
+When the user submits a YouTube URL with ``prefer_clean_source=True``,
+this module searches YouTube for a clean alternative version of the same
+song (piano cover, 8-bit/chiptune cover, …) and returns the best
+candidate across all variants. The ingest stage then swaps the user's
+original URL for the match's URL so Basic Pitch receives something it
+can actually transcribe well.
+
+Why this helps transcription quality:
+    Basic Pitch is a polyphonic pitch tracker, but it transcribes every
+    audible pitch — including drum fundamentals, vocal harmonics, and
+    bass subharmonics — as piano notes. On a pop-song mix this yields a
+    dense, unplayable result. A **piano cover** is already monophonic
+    (or polyphonic but piano-only). An **8-bit cover** is even cleaner
+    because chiptune channels are pure square/triangle waves with zero
+    reverb and no drums mixed into the pitched content. Either path is
+    dramatically easier to transcribe than a full-band mix.
+
+Multi-variant architecture:
+    ``find_clean_source`` runs the search once per ``_SourceVariant``
+    (piano + chiptune by default) and returns the single highest-scoring
+    result across ALL variants. Each variant has its own channel
+    allowlist and positive-keyword list so the scorer rewards the right
+    kind of signal for the right kind of source.
+
+Scoring policy (see ``score_candidate_for_variant``):
+    +50  channel is in the variant's channel allowlist
+    +30  title contains one of the variant's positive keywords
+    +20  wanted song title is a substring of the found video title
+    +10  artist name appears in the found title or the channel name
+    -20  title contains "karaoke" / "tutorial" / "how to play" / "lesson"
+
+The +50 and +30 weights come from the *variant's* lists, so a Rousseau
+result scores 50 against the piano variant and 0 against the chiptune
+variant — exactly the isolation we want.
+
+Default threshold: score >= 60 triggers a URL swap. Dry-run testing
+against real YouTube (see scripts/dryrun_cover_search.py) showed the
+original 70 was too strict — legitimate pop covers from non-allowlist
+channels cap at exactly 60 (+30 piano cover + +20 title + +10 artist),
+so 70 silently rejected them. At 60, junk content (karaoke/tutorial)
+still can't clear because the -20 penalty brings them to 40 or below.
+The threshold is passed as a parameter so callers (or config) can
+tune strictness without editing this module.
+
+Silent failure contract:
+    ``find_clean_source`` / ``find_piano_cover`` return ``None`` on any
+    failure (network error, yt-dlp exception, no candidates, all below
+    threshold). If ONE variant's search crashes but another succeeds,
+    the successful variant's best result is still returned. The caller
+    must interpret ``None`` as "fall back to direct transcription of the
+    original URL." No exceptions propagate out — this is a hint, not a
+    hard dependency.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Channel allowlist — tiered by playability
+# ---------------------------------------------------------------------------
+#
+# Piano covers on YouTube span a huge difficulty range. Rousseau's Bohemian
+# Rhapsody has 2000+ notes across full 10-finger chords — transcribes to
+# MIDI beautifully but the resulting sheet music is unreadable for anyone
+# short of a concert pianist. Pianote's beginner arrangements of the same
+# song have ~400 notes and fit comfortably on two staves.
+#
+# For the MVP we target **easy + moderate** only. Dropping the advanced
+# tier is a scope decision, not a quality issue: virtuoso covers still
+# exist and work fine for MIDI playback, but the sheet music output is
+# not a fit for the target user (casual / beginner / intermediate player
+# learning a song). When we add a difficulty selector to the upload
+# screen that meaningfully affects cover selection, the advanced tier
+# can be reactivated by adding PIANO_ADVANCED_CHANNELS to the active
+# allowlist below.
+#
+# Entries are lowercase and matched case-insensitively as substrings of
+# the candidate's channel field, so "Rousseau" matches "Rousseau - Official".
+
+# Tier 1 — easy / beginner arrangements. Explicitly branded as easy or
+# known for simplified versions. Gets a soft preference bonus in scoring
+# so when an easy-tier match and a moderate-tier match both exist, easy
+# wins the tie.
+PIANO_EASY_CHANNELS: tuple[str, ...] = (
+    "pianote",
+    "peter plutax",
+    "everynote",
+    "phianonize",           # frequent "easy version" releases
+    "onepianoheart",
+    "easy piano tutorials",
+    "simple piano",
+)
+
+# Tier 2 — moderate / intermediate arrangements. Playable for a
+# developing player without being watered down. Many of these channels
+# occasionally post advanced tracks too; scoring uses the channel tier,
+# not the individual video's complexity.
+PIANO_MODERATE_CHANNELS: tuple[str, ...] = (
+    "jacob's piano",
+    "jacobs piano",         # ASCII fallback
+    "akmigone",
+    "peter buka",
+    "pianella piano",
+    "dotted8th",
+    "francesco parrino",
+    "martin walsh",
+    "adam chen",
+    "aaronastro",
+    # Kesh Piano Music (@keshpianomusic) — see TRUSTED_TUTORIAL_CHANNELS
+    # below. yt-dlp returns ``channel='Kesh'`` which is too broad for
+    # substring matching (risks false positives against the pop artist
+    # Kesha), so we match on the unambiguous uploader_id handle.
+    "keshpianomusic",
+)
+
+# Tier 3 — virtuoso / concert-level arrangements. Defined here for
+# documentation and future re-enablement, but NOT part of the active
+# allowlist. These channels produce dense 10-finger arrangements that
+# are great to listen to but not readable as sheet music for the target
+# audience. To reactivate, include this tuple in COVER_CHANNEL_ALLOWLIST
+# below and add a difficulty selector to the UI.
+PIANO_ADVANCED_CHANNELS: tuple[str, ...] = (
+    "rousseau",
+    "patrik pietschmann",
+    "kyle landry",
+    "lord vinheteiro",
+    "david solís",
+    "david solis",          # ASCII fallback
+    "the piano guys",
+)
+
+# Active piano allowlist = easy + moderate. Advanced is defined above
+# but not included. This is the list the scorer checks for the +50
+# channel bonus. Easy channels get an additional +10 bias via
+# _EASY_TIER_BONUS below.
+COVER_CHANNEL_ALLOWLIST: tuple[str, ...] = (
+    PIANO_EASY_CHANNELS + PIANO_MODERATE_CHANNELS
+)
+
+
+# ---------------------------------------------------------------------------
+# Trusted tutorial channels — exempt from the "tutorial" keyword penalty
+# ---------------------------------------------------------------------------
+#
+# Some channels explicitly label their videos as "Piano Tutorial" but
+# produce clean transcription-quality audio — Synthesia-style rendered
+# piano with no voiceover or backing track. For those channels the
+# ``-20`` tutorial penalty in _BAD_KEYWORDS is the wrong signal: it
+# marks them down for what they CALL themselves, not what they actually
+# sound like. Basic Pitch can transcribe their audio fine.
+#
+# Channels listed here bypass the tutorial penalty. Matched against
+# yt-dlp's ``uploader_id`` (the ``@handle``, with the ``@`` stripped)
+# so the identifier is unambiguous even for channels whose display
+# name is a common word. "keshpianomusic" matches ``@keshpianomusic``
+# cleanly without colliding with the pop artist Kesha.
+#
+# Add new entries here as dry-runs identify other trustworthy
+# tutorial-labelled channels. Keep it narrow — the penalty exists for
+# a reason and most tutorials ARE noisy (voiceover, slowdowns, etc.).
+
+TRUSTED_TUTORIAL_CHANNELS: tuple[str, ...] = (
+    "keshpianomusic",
+)
+
+
+# 8-bit / chiptune covers. These channels publish pure square+triangle
+# arrangements of popular songs (and game themes). Chiptune audio is the
+# easiest possible input for Basic Pitch — monophonic channels, zero
+# reverb, no drums mixed into pitched content — so when one of these
+# channels has a cover of the user's song, it's usually a better source
+# than any piano cover. The list is intentionally shorter than the piano
+# allowlist because the chiptune ecosystem is narrower; tune as needed.
+#
+# Must be disjoint from COVER_CHANNEL_ALLOWLIST so a matching channel
+# only scores for ONE variant — enforced by a test.
+
+CHIPTUNE_CHANNEL_ALLOWLIST: tuple[str, ...] = (
+    "8-bit universe",
+    "8 bit universe",         # common spelling variant w/o hyphen
+    "button masher",
+    "press start",
+    "noize 8-bit",
+    "noize 8 bit",
+    "vgmpire",
+    "arcade player",
+    "pixelord",
+    "8-bit arcade",
+    "8 bit arcade",
+    "chipzel",
+    "inverse phase",
+)
+
+
+# ---------------------------------------------------------------------------
+# Title normalization
+# ---------------------------------------------------------------------------
+
+
+# Noise patterns to strip from titles before comparing. Order matters:
+# more-specific patterns first so they don't get accidentally matched by
+# a generic one.
+_NOISE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # "(Official Music Video)", "[Official Video]", " - Official Video"
+    re.compile(r"\s*[\[\(]\s*official\s+(music\s+)?video\s*[\]\)]", re.IGNORECASE),
+    re.compile(r"\s*-\s*official\s+(music\s+)?video", re.IGNORECASE),
+    # "(Lyrics)", "[Lyric Video]"
+    re.compile(r"\s*[\[\(]\s*lyrics?\s*(video)?\s*[\]\)]", re.IGNORECASE),
+    # "(HD)", "[4K Remaster]", "(Remastered 2020)"
+    re.compile(r"\s*[\[\(]\s*\d*k?\s*remaster(ed)?\s*\d*\s*[\]\)]", re.IGNORECASE),
+    re.compile(r"\s*[\[\(]\s*\d+k\s*[\]\)]", re.IGNORECASE),
+    re.compile(r"\s*[\[\(]\s*hd\s*[\]\)]", re.IGNORECASE),
+    # "(Live at Wembley 1988)"
+    re.compile(r"\s*[\[\(]\s*live[^\]\)]*[\]\)]", re.IGNORECASE),
+    # "feat. Jay-Z", "(feat. Jay-Z)", "ft. Jay-Z"
+    re.compile(r"\s*[\[\(]\s*(feat\.?|ft\.?)[^\]\)]*[\]\)]", re.IGNORECASE),
+    re.compile(r"\s+(feat\.?|ft\.?)\s+.*$", re.IGNORECASE),
+)
+
+
+def normalize_title(raw: str | None) -> str:
+    """Strip noise tokens from a song title and lowercase the result.
+
+    Returns ``""`` for ``None`` or empty input. The output is safe to use
+    as a substring-comparison key against other normalized titles.
+    """
+    if not raw:
+        return ""
+    cleaned = raw
+    for pattern in _NOISE_PATTERNS:
+        cleaned = pattern.sub("", cleaned)
+    # Collapse whitespace runs and strip leading/trailing space.
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned.lower()
+
+
+# ---------------------------------------------------------------------------
+# Scoring rules
+# ---------------------------------------------------------------------------
+
+
+# Positive-signal keywords that indicate "this really is a piano cover."
+_PIANO_COVER_KEYWORDS: tuple[str, ...] = (
+    "piano cover",
+    "piano arrangement",
+    "solo piano",
+)
+
+# Positive-signal keywords for chiptune/8-bit covers. "8 bit" is the most
+# common phrasing on YouTube; "8-bit" gets hit by the same substring check
+# because we match on normalized lowercase text.
+_CHIPTUNE_KEYWORDS: tuple[str, ...] = (
+    "8 bit",
+    "8-bit",
+    "chiptune",
+    "nes version",
+    "famicom",
+    "8bit",
+)
+
+# Negative-signal keywords that indicate "this is NOT what we want."
+# Shared across all variants — karaoke and tutorials are noise no matter
+# what source we're looking for.
+_BAD_KEYWORDS: tuple[str, ...] = (
+    "karaoke",
+    "tutorial",
+    "how to play",
+    "lesson",
+)
+
+# Additional bonus for piano channels in the "easy" tier on top of the
+# normal +50 allowlist bonus. When both an easy-tier and a moderate-tier
+# candidate score equally on title/artist, the easy-tier one wins by +10.
+# Not enough to let a weak easy candidate beat a strong moderate one;
+# just enough to break ties in the easy tier's favor.
+_EASY_TIER_BONUS: int = 10
+
+
+# ---------------------------------------------------------------------------
+# Source variants
+# ---------------------------------------------------------------------------
+#
+# A _SourceVariant describes one "kind of clean source" we search for.
+# Adding a new variant (e.g. "orchestral cover", "acoustic guitar cover")
+# is a data change: append a new _SourceVariant to DEFAULT_VARIANTS and
+# write its allowlist + keywords. No scoring logic change required.
+
+
+@dataclass(frozen=True)
+class _SourceVariant:
+    """One search strategy: a query suffix, a channel allowlist, and
+    a positive-keyword list. Scoring is variant-scoped, so a Rousseau
+    entry gets +50 against the piano variant and +0 against the chiptune
+    variant."""
+
+    name: str
+    query_suffix: str
+    channel_allowlist: tuple[str, ...]
+    keywords: tuple[str, ...]
+
+
+PIANO_VARIANT = _SourceVariant(
+    name="piano",
+    query_suffix="piano cover",
+    channel_allowlist=COVER_CHANNEL_ALLOWLIST,
+    keywords=_PIANO_COVER_KEYWORDS,
+)
+
+CHIPTUNE_VARIANT = _SourceVariant(
+    name="chiptune",
+    query_suffix="8 bit cover",
+    channel_allowlist=CHIPTUNE_CHANNEL_ALLOWLIST,
+    keywords=_CHIPTUNE_KEYWORDS,
+)
+
+# Default variant set used by ``find_clean_source``. Order matters only
+# for logging — the scorer always picks the globally highest across all
+# variants, regardless of list position.
+DEFAULT_VARIANTS: tuple[_SourceVariant, ...] = (PIANO_VARIANT, CHIPTUNE_VARIANT)
+
+
+def score_candidate_for_variant(
+    entry: dict[str, Any],
+    *,
+    wanted_title: str,
+    wanted_artist: str | None,
+    variant: _SourceVariant,
+) -> int:
+    """Score a yt-dlp entry against a SPECIFIC source variant.
+
+    This is the scorer the multi-variant orchestrator uses. See the
+    module docstring for the canonical rule list. The +50 allowlist
+    bonus and +30 keyword bonus come from the variant; everything else
+    (title match, artist match, bad-keyword penalty) is shared.
+    """
+    title_norm = normalize_title(entry.get("title", ""))
+    channel_norm = (entry.get("channel") or "").lower()
+    # uploader_id is yt-dlp's "@handle" form (e.g. "@keshpianomusic").
+    # Strip the leading "@" so allowlist entries can be plain strings.
+    uploader_id_norm = (entry.get("uploader_id") or "").lower().lstrip("@")
+    wanted_title_norm = normalize_title(wanted_title)
+    wanted_artist_norm = (wanted_artist or "").lower().strip()
+
+    # Helper: does any allowlist entry match either the channel name
+    # OR the uploader_id handle? Checking both fields lets us pin
+    # specific channels via their unambiguous handle when their
+    # display name is too broad (e.g. "Kesh" would collide with the
+    # pop artist "Kesha").
+    def _matches_any(allowlist: tuple[str, ...]) -> bool:
+        return any(
+            entry_key in channel_norm or entry_key in uploader_id_norm
+            for entry_key in allowlist
+        )
+
+    score = 0
+
+    # +50 if the channel is in this variant's allowlist (substring match
+    # against channel OR uploader_id so "Rousseau - Official" still
+    # matches "rousseau" and "@keshpianomusic" still matches
+    # "keshpianomusic").
+    if _matches_any(variant.channel_allowlist):
+        score += 50
+
+    # Piano-only extra: +10 if the channel is in the "easy" tier of the
+    # piano allowlist. Soft preference so easy arrangements win ties
+    # against moderate arrangements. Chiptune variant doesn't have
+    # difficulty sub-tiers so this check is a no-op there.
+    if variant.name == "piano" and _matches_any(PIANO_EASY_CHANNELS):
+        score += _EASY_TIER_BONUS
+
+    # +30 if any of this variant's positive keywords appear in the title.
+    if any(kw in title_norm for kw in variant.keywords):
+        score += 30
+
+    # +20 if the wanted song title appears in the found title. Shared
+    # across all variants.
+    if wanted_title_norm and wanted_title_norm in title_norm:
+        score += 20
+
+    # +10 if the artist name appears in the title or channel. Shared
+    # across all variants.
+    if wanted_artist_norm and (
+        wanted_artist_norm in title_norm or wanted_artist_norm in channel_norm
+    ):
+        score += 10
+
+    # -20 for any bad keyword — karaoke, tutorials, and lessons are not
+    # cover recordings and will confuse Basic Pitch worse than the mix.
+    # EXEMPTION: channels on TRUSTED_TUTORIAL_CHANNELS bypass the
+    # penalty because their "tutorial" videos are actually clean
+    # synthesized-piano audio suitable for transcription (e.g. Kesh).
+    is_trusted_tutorial = _matches_any(TRUSTED_TUTORIAL_CHANNELS)
+    if not is_trusted_tutorial and any(bad in title_norm for bad in _BAD_KEYWORDS):
+        score -= 20
+
+    return score
+
+
+def score_candidate(
+    entry: dict[str, Any],
+    wanted_title: str,
+    wanted_artist: str | None,
+) -> int:
+    """Score a yt-dlp search result entry for the piano variant.
+
+    Thin wrapper around ``score_candidate_for_variant`` with the piano
+    variant baked in. Kept for backward compatibility with older tests
+    and callers that still use the piano-specific rule list.
+    """
+    return score_candidate_for_variant(
+        entry,
+        wanted_title=wanted_title,
+        wanted_artist=wanted_artist,
+        variant=PIANO_VARIANT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CoverSearchResult:
+    """Successful cover match. The URL is ready to feed into yt-dlp for
+    download; the score is included so callers can log or display it."""
+
+    url: str
+    score: int
+    channel: str
+    title: str
+
+
+def _search_one_variant(
+    title: str,
+    artist: str | None,
+    *,
+    variant: _SourceVariant,
+    top_k: int,
+) -> tuple[int, dict[str, Any]] | None:
+    """Run the search for ONE variant and return its best (score, entry).
+
+    Returns ``None`` if the search failed, returned nothing, or crashed.
+    Does NOT apply the min_score threshold — the orchestrator compares
+    raw best scores across variants before applying the threshold.
+    """
+    if artist:
+        query = f"{title} {artist} {variant.query_suffix}"
+    else:
+        query = f"{title} {variant.query_suffix}"
+
+    try:
+        entries = _yt_dlp_search(query, top_k=top_k)
+    except Exception as exc:  # noqa: BLE001 — silent-failure boundary
+        log.warning(
+            "cover_search[%s]: yt-dlp search failed for %r: %s",
+            variant.name, query, exc,
+        )
+        return None
+
+    if not entries:
+        log.info("cover_search[%s]: no results for %r", variant.name, query)
+        return None
+
+    scored = [
+        (
+            score_candidate_for_variant(
+                e, wanted_title=title, wanted_artist=artist, variant=variant,
+            ),
+            e,
+        )
+        for e in entries
+    ]
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return scored[0]
+
+
+def find_clean_source(
+    title: str,
+    artist: str | None,
+    *,
+    min_score: int = 60,
+    top_k: int = 5,
+    variants: tuple[_SourceVariant, ...] = DEFAULT_VARIANTS,
+) -> CoverSearchResult | None:
+    """Search every variant for a clean alternative source of the song,
+    return the highest-scoring match across all variants.
+
+    Runs the query once per variant (so "piano cover" AND "8 bit cover"
+    both get searched), scores each variant's best candidate against
+    its OWN allowlist + keywords, and returns the single best result
+    across all of them. Silent-failure contract: any exception in one
+    variant is logged and the others still run; the function never
+    raises.
+
+    Returns ``None`` if no variant's best candidate clears ``min_score``,
+    so the caller can fall back to direct transcription of the original
+    URL. This is a hint, not a hard dependency.
+    """
+    best_overall: tuple[int, dict[str, Any], _SourceVariant] | None = None
+
+    for variant in variants:
+        result = _search_one_variant(
+            title, artist, variant=variant, top_k=top_k,
+        )
+        if result is None:
+            continue
+        score, entry = result
+        if best_overall is None or score > best_overall[0]:
+            best_overall = (score, entry, variant)
+
+    if best_overall is None:
+        return None
+
+    best_score, best_entry, best_variant = best_overall
+    if best_score < min_score:
+        log.info(
+            "cover_search: best candidate across %d variant(s) for %r "
+            "scored %d, below threshold %d",
+            len(variants), title, best_score, min_score,
+        )
+        return None
+
+    log.info(
+        "cover_search: winning variant=%s score=%d channel=%r",
+        best_variant.name, best_score, best_entry.get("channel", ""),
+    )
+    return CoverSearchResult(
+        url=best_entry.get("url", ""),
+        score=best_score,
+        channel=best_entry.get("channel", ""),
+        title=best_entry.get("title", ""),
+    )
+
+
+def find_piano_cover(
+    title: str,
+    artist: str | None,
+    *,
+    min_score: int = 60,
+    top_k: int = 5,
+) -> CoverSearchResult | None:
+    """Piano-only search — thin backward-compat wrapper around
+    ``find_clean_source``.
+
+    Runs only the piano variant, not the chiptune variant. Kept so
+    callers and tests that specifically want piano-only behavior don't
+    have to construct a one-element ``variants`` tuple. New code should
+    prefer ``find_clean_source`` to get the full multi-variant benefit.
+    """
+    return find_clean_source(
+        title,
+        artist,
+        min_score=min_score,
+        top_k=top_k,
+        variants=(PIANO_VARIANT,),
+    )
+
+
+def _normalize_entry_url(entry: dict[str, Any]) -> str:
+    """Resolve a yt-dlp entry into a canonical ``https://www.youtube.com/watch?v=...`` URL.
+
+    yt-dlp's ``extract_flat=True`` mode is inconsistent about where the
+    watch URL ends up. In practice we see three variants:
+
+      1. ``url`` field holds a full ``http(s)://...`` URL (most common)
+      2. ``url`` field holds the bare 11-char video ID (observed on
+         recent yt-dlp builds — "flat" is literal there)
+      3. ``url`` field is missing and ``webpage_url`` carries the URL
+
+    Variant #2 is the dangerous one: a bare ID flows unchecked through
+    CoverSearchResult → _maybe_swap_for_cover_sync → _download_youtube_sync,
+    where ``urlparse`` returns an empty hostname and _download_youtube_sync
+    raises ValueError — crashing the ingest job (PR #47 review, Critical).
+
+    Preference order, highest to lowest:
+      1. ``webpage_url`` if it's a valid ``http(s)://`` URL
+      2. ``url`` if it's a valid ``http(s)://`` URL
+      3. Constructed ``https://www.youtube.com/watch?v={id}`` from ``id``
+      4. ``""`` — caller must drop this entry
+
+    webpage_url wins over url because when yt-dlp populates it at all,
+    it's always the full canonical form; url may be bare.
+    """
+    webpage_url = (entry.get("webpage_url") or "").strip()
+    if webpage_url.startswith(("http://", "https://")):
+        return webpage_url
+
+    existing_url = (entry.get("url") or "").strip()
+    if existing_url.startswith(("http://", "https://")):
+        return existing_url
+
+    video_id = (entry.get("id") or "").strip()
+    if video_id:
+        return f"https://www.youtube.com/watch?v={video_id}"
+
+    return ""
+
+
+def _yt_dlp_search(query: str, *, top_k: int = 5) -> list[dict[str, Any]]:
+    """Run yt-dlp in search mode and return up to ``top_k`` entries.
+
+    Uses ytsearch{N}: prefix — no YouTube Data API key required.
+    Metadata only; does not download any video. This is the single
+    boundary where network I/O happens, so tests mock this function.
+    """
+    import yt_dlp  # local import so tests can patch _yt_dlp_search without
+                   # forcing yt-dlp into the test environment.
+
+    ydl_opts = {
+        "default_search": f"ytsearch{top_k}",
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "extract_flat": True,  # metadata only, don't resolve each result
+        "socket_timeout": 15,
+    }
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        result = ydl.extract_info(f"ytsearch{top_k}:{query}", download=False)
+
+    raw_entries = (result or {}).get("entries", []) or []
+    # Normalize each entry's URL through _normalize_entry_url, which
+    # handles the extract_flat quirks (bare IDs, webpage_url fallback,
+    # id-based reconstruction). Drop any entry we can't resolve at all;
+    # passing a bad URL downstream crashes _download_youtube_sync.
+    entries: list[dict[str, Any]] = []
+    for e in raw_entries:
+        normalized = _normalize_entry_url(e)
+        if not normalized:
+            continue
+        e["url"] = normalized
+        entries.append(e)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Metadata probe for a single URL
+# ---------------------------------------------------------------------------
+
+
+def probe_youtube_metadata(url: str) -> tuple[str, str | None] | None:
+    """Fetch (song_title, artist) for a YouTube URL without downloading audio.
+
+    Used by the ingest stage to resolve the user's submitted URL into a
+    searchable song identity before calling ``find_piano_cover``. The
+    returned title is lowercased and noise-stripped via ``normalize_title``
+    so it can feed straight into the search query.
+
+    Field precedence:
+      * title: ``track`` → ``title`` (noise-stripped)
+      * artist: ``artist`` → ``creator`` → ``uploader``
+
+    Returns ``None`` on any failure (network error, invalid URL,
+    metadata dict has no title-shaped field). Like ``find_piano_cover``,
+    this function follows the silent-failure contract.
+    """
+    try:
+        info = _yt_dlp_extract_info(url)
+    except Exception as exc:  # noqa: BLE001 — silent-failure boundary
+        log.warning("cover_search: metadata probe failed for %r: %s", url, exc)
+        return None
+
+    if not info:
+        return None
+
+    # Title: prefer 'track' (structured music metadata) over 'title'
+    # (human-readable video title, often has noise tags). Normalize
+    # whichever we pick so downstream callers get a clean search key.
+    raw_title = info.get("track") or info.get("title")
+    if not raw_title:
+        return None
+    title = normalize_title(raw_title)
+    if not title:
+        return None
+
+    # Artist: precedence artist > creator > uploader.
+    artist = info.get("artist") or info.get("creator") or info.get("uploader")
+
+    return title, artist
+
+
+def _yt_dlp_extract_info(url: str) -> dict[str, Any] | None:
+    """Fetch a single video's metadata via yt-dlp without downloading.
+
+    The thin I/O wrapper that tests mock. Uses the same suppress-noise
+    flags as ``_yt_dlp_search`` but targets a single URL instead of a
+    search query.
+    """
+    import yt_dlp  # local import — keeps yt-dlp out of the test import path
+
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "skip_download": True,
+        "socket_timeout": 15,
+    }
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        return ydl.extract_info(url, download=False)

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -1,22 +1,18 @@
 """Engraving stage — render MIDI / MusicXML / PDF artifacts.
 
-Tries the real renderers when their optional deps are present and falls
-back to small but valid stub bytes otherwise so the rest of the pipeline
-keeps working in environments without pretty_midi / music21 / LilyPond.
-
   * MIDI     — pretty_midi if installed, else a minimal MThd+MTrk file
-  * MusicXML — music21 if installed, else a minimal score-partwise body
-  * PDF      — MuseScore / LilyPond CLI if on $PATH, else a 1-line %PDF stub
+  * MusicXML — music21 (hard dependency; errors propagate to the caller)
+  * PDF      — LilyPond (preferred) or MuseScore CLI if on $PATH, else a 1-line %PDF stub
 """
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from xml.sax.saxutils import escape
 
 from backend.contracts import (
     SCHEMA_VERSION,
@@ -24,7 +20,6 @@ from backend.contracts import (
     EngravedScoreData,
     HumanizedPerformance,
     PianoScore,
-    ScoreNote,
     beat_to_sec,
 )
 from backend.storage.base import BlobStore
@@ -40,12 +35,6 @@ _STUB_PDF = b"%PDF-1.4\n% stub PDF emitted by ohsheet engrave service\n"
 _STUB_MIDI = (
     b"MThd\x00\x00\x00\x06\x00\x00\x00\x01\x01\xe0"   # header chunk: format 0, 1 track, 480 tpq
     b"MTrk\x00\x00\x00\x04\x00\xff\x2f\x00"            # one empty track ending in End-Of-Track
-)
-_STUB_MUSICXML = (
-    b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
-    b'<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" '
-    b'"http://www.musicxml.org/dtds/partwise.dtd">\n'
-    b'<score-partwise version="3.1"/>\n'
 )
 
 
@@ -84,8 +73,12 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
             offset = beat_to_sec(en.onset_beat + en.duration_beat, tempo_map) - midi_time_offset
         except ValueError:
             continue
+        # timing_offset_ms is an *onset-only* nudge — the release boundary
+        # stays on the metronomic grid, so a late-struck note plays shorter
+        # and an early-struck note plays longer. Mirrors humanize._humanize_timing,
+        # which models downbeat anticipation / backbeat push as attack-time
+        # gestures with no release component.
         onset += en.timing_offset_ms / 1000.0
-        offset += en.timing_offset_ms / 1000.0
         onset = max(0.0, onset)
         offset = max(onset + 0.01, offset)
         raw_notes.append((en.pitch, onset, offset, max(1, min(127, en.velocity))))
@@ -108,8 +101,13 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
             continue
         piano.notes.append(pretty_midi.Note(velocity=vel, pitch=pitch, start=start, end=end))
 
+    # Pedal events → GM control changes. Sustain = CC64, sostenuto = CC66,
+    # una corda = CC67. All three use the standard on=127 / off=0 encoding
+    # (below 64 disengages on most synths, but 0 is the unambiguous convention).
+    _PEDAL_CC = {"sustain": 64, "sostenuto": 66, "una_corda": 67}
     for pedal in perf.expression.pedal_events:
-        if pedal.type != "sustain":
+        cc_num = _PEDAL_CC.get(pedal.type)
+        if cc_num is None:
             continue
         try:
             on_sec = beat_to_sec(pedal.onset_beat, tempo_map) - midi_time_offset
@@ -117,10 +115,10 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
         except ValueError:
             continue
         piano.control_changes.append(
-            pretty_midi.ControlChange(number=64, value=127, time=max(0.0, on_sec))
+            pretty_midi.ControlChange(number=cc_num, value=127, time=max(0.0, on_sec))
         )
         piano.control_changes.append(
-            pretty_midi.ControlChange(number=64, value=0, time=max(0.0, off_sec))
+            pretty_midi.ControlChange(number=cc_num, value=0, time=max(0.0, off_sec))
         )
 
     midi.instruments.append(piano)
@@ -141,234 +139,437 @@ def _render_midi_bytes(perf: HumanizedPerformance) -> bytes:
 # MusicXML rendering
 # ---------------------------------------------------------------------------
 
+# Human-readable labels for non-sustain pedals. Sustain uses the standard
+# "Ped." / "*" pair; MusicXML doesn't reserve glyphs for sostenuto / una
+# corda, so text directions are the portable choice across renderers.
+_PEDAL_TEXT = {
+    "sustain":    ("Ped.", "*"),
+    "sostenuto":  ("Sost. Ped.", "*"),
+    "una_corda":  ("una corda", "tre corde"),
+}
+
+
+# Chord symbols below this transcriber confidence are dropped — the
+# audio-harmony pipeline routinely emits low-confidence labels that look
+# like pitch-octave pairs ("G5", "E5") rather than chord qualities, and
+# they clutter the notation more than they help.
+_CHORD_MIN_CONFIDENCE = 0.5
+
+# Anything that lexically looks like a pitch-and-octave (e.g. "G5",
+# "C#4", "Db3") is an artifact of the transcription pipeline treating
+# a single pitch as a chord. Filter these out before handing to music21
+# so ``ChordSymbol`` doesn't build a one-note "chord".
+_PITCH_OCTAVE_RE = re.compile(r"^[A-G][#b]?\d+$")
+
+
+# Minimum Krumhansl-Schmuckler correlation coefficient for an override
+# to fire. Empirically the KS analyzer reports ~0.90+ on clean tonal
+# material (e.g. two_hand_chordal at 0.965), ~0.78 on a bare diatonic
+# scale, and drops below 0.4 on highly chromatic content (jazz_voicings
+# at 0.35). 0.80 is the floor for a clearly-tonal excerpt — above this,
+# disagreements with the declared key almost always indicate upstream
+# mis-labeling rather than a confused analyzer. Below this we trust
+# the declared key and skip the override.
+_KEY_OVERRIDE_MIN_CORRELATION = 0.80
+
+
+def _resolve_key_signature(score: PianoScore, music21) -> tuple[str, str, bool]:  # noqa: ANN001
+    """Resolve the effective key signature using Krumhansl-Schmuckler.
+
+    Audio transcription / arrange can label a piece with the wrong key
+    — e.g. tagging an F# minor piece as "C:major" — and every accidental
+    downstream explodes because music21 emits sharps/flats for every
+    non-diatonic note. KS is the canonical pitch-histogram tonic finder
+    and ships with music21; five lines of analyzer gate + one override
+    fix the bug before makeNotation ever sees it.
+
+    Returns ``(root_name, mode, overridden)``. The override fires only
+    when **both** conditions hold:
+
+    1. Analyzer correlation ≥ ``_KEY_OVERRIDE_MIN_CORRELATION``. Low
+       correlations mean the pitch histogram is ambiguous (short
+       excerpts, highly chromatic jazz) — trust the upstream label.
+    2. The analyzer's (tonic, mode) disagrees with the declared key.
+       If KS agrees, the declared key is already correct and we skip
+       the override to keep logs quiet.
+
+    Any exception from the analyzer (empty stream, pitch-less notes,
+    library internals) falls back to the declared key so this never
+    blocks engrave.
+    """
+    declared = score.metadata.key or "C:major"
+    declared_root = declared.split(":")[0] if ":" in declared else "C"
+    declared_mode = "minor" if "minor" in declared else "major"
+
+    # Build a throwaway Stream from every note so the pitch histogram
+    # is the whole piece, not one hand or one measure. Velocity /
+    # duration / voice are irrelevant for KS — it only reads pitch
+    # classes.
+    all_notes = list(score.right_hand) + list(score.left_hand)
+    if not all_notes:
+        return declared_root, declared_mode, False
+
+    try:
+        # Pin every note to quarterLength=1 so the KS pitch-class histogram
+        # is duration-independent. Raw score durations can over-weight
+        # sustained LH pedal tones (a 4-beat F#2 gets 8× the histogram
+        # mass of a 0.5-beat RH note), which looks to KS like a single-
+        # pitch stream rather than a real key. Note-count weighting is
+        # what we actually want — the question is "what scale are these
+        # notes drawn from", not "which note is longest".
+        analysis_stream = music21.stream.Stream()
+        for sn in all_notes:
+            n = music21.note.Note(sn.pitch)
+            n.quarterLength = 1.0
+            analysis_stream.append(n)
+        analyzer = music21.analysis.discrete.KrumhanslSchmuckler()
+        result = analyzer.process(analysis_stream)
+    except Exception as exc:  # noqa: BLE001 — analyzer errors must not crash engrave
+        log.debug("key-signature analyzer failed; trusting declared %r: %s", declared, exc)
+        return declared_root, declared_mode, False
+
+    try:
+        tonic_pitch, analyzer_mode, correlation = result[0]
+    except (TypeError, IndexError, ValueError) as exc:
+        log.debug("unexpected KS result shape %r: %s", result, exc)
+        return declared_root, declared_mode, False
+
+    analyzer_root = tonic_pitch.name
+    if correlation < _KEY_OVERRIDE_MIN_CORRELATION:
+        return declared_root, declared_mode, False
+    if analyzer_root == declared_root and analyzer_mode == declared_mode:
+        return declared_root, declared_mode, False
+
+    log.info(
+        "engrave: KS key override — declared=%s:%s analyzer=%s:%s correlation=%.3f",
+        declared_root, declared_mode, analyzer_root, analyzer_mode, correlation,
+    )
+    return analyzer_root, analyzer_mode, True
+
+
+def _attach_chord_symbols(part, chord_symbols, music21) -> int:  # noqa: ANN001
+    """Insert chord symbols onto a music21 part, returning the count rendered.
+
+    Chord symbols from audio transcription are noisy — single-pitch
+    false positives, low-confidence guesses, and Harte labels music21
+    can't parse all end up here. Applies three filters before committing:
+
+    1. **Confidence gate.** Drop anything below
+       ``_CHORD_MIN_CONFIDENCE``. The transcriber already reports its
+       own uncertainty; trust it.
+    2. **Shape gate.** Reject labels that match ``[A-G][#b]?\\d+`` —
+       those are pitch-octave pairs (e.g. "G5"), not chord qualities.
+    3. **Parse gate.** ``music21.harmony.ChordSymbol`` must parse the
+       label cleanly AND the resulting chord must carry ≥ 3 distinct
+       pitches. Everything else is a one-note or two-note artifact
+       that clutters the staff.
+
+    music21's ChordSymbol parser uses a custom pitch-name grammar that
+    doesn't accept Harte's colon separator ("C:maj7"), so we strip the
+    colon before parsing. Any parser error lands in a broad except —
+    ChordSymbol raises a grab-bag of exception types and the cost of a
+    missed symbol is much lower than the cost of an exploding engrave.
+    """
+    rendered = 0
+    for cs in chord_symbols:
+        if cs.confidence < _CHORD_MIN_CONFIDENCE:
+            continue
+        label = cs.label.strip()
+        if not label or _PITCH_OCTAVE_RE.match(label):
+            continue
+        # music21 doesn't accept Harte's "root:quality" colon form.
+        parse_label = label.replace(":", "")
+        try:
+            h = music21.harmony.ChordSymbol(parse_label)
+        except Exception:  # noqa: BLE001 — ChordSymbol raises many types
+            continue
+        try:
+            pitches = h.pitches
+        except Exception:  # noqa: BLE001 — defensive, some labels parse but can't resolve
+            continue
+        if len({p.midi % 12 for p in pitches}) < 3:
+            continue
+        try:
+            part.insert(max(0.0, float(cs.beat)), h)
+        except Exception:  # noqa: BLE001 — insertion shouldn't fail, but don't crash engrave
+            continue
+        rendered += 1
+    return rendered
+
+
+def _attach_dynamics(part, dynamics, music21) -> None:  # noqa: ANN001 — music21 is untyped
+    """Insert ``DynamicMarking`` events into a music21 part.
+
+    Static marks (pp..ff) become ``music21.dynamics.Dynamic`` objects at
+    ``dyn.beat``. Hairpins (crescendo/decrescendo) become italic text
+    directions — ``music21.dynamics.Crescendo`` spanners need referenced
+    note endpoints that may have been quantized away, so text is the
+    more portable choice across OSMD / LilyPond / MuseScore.
+    """
+    for dyn in dynamics:
+        beat = max(0.0, float(dyn.beat))
+        if dyn.type in ("pp", "p", "mp", "mf", "f", "ff"):
+            part.insert(beat, music21.dynamics.Dynamic(dyn.type))
+        elif dyn.type == "crescendo":
+            part.insert(beat, music21.expressions.TextExpression("cresc."))
+        elif dyn.type == "decrescendo":
+            part.insert(beat, music21.expressions.TextExpression("dim."))
+
+
+def _attach_pedal_marks(part, pedal_events, music21) -> None:  # noqa: ANN001
+    """Insert pedal text directions into a music21 part.
+
+    Uses ``TextExpression`` rather than ``music21.expressions.PedalMark``
+    because the latter has inconsistent MusicXML export across music21
+    versions. Sustain emits the standard ``Ped.`` / ``*`` pair; sostenuto
+    and una corda use descriptive labels.
+    """
+    for pedal in pedal_events:
+        labels = _PEDAL_TEXT.get(pedal.type)
+        if labels is None:
+            continue
+        on_label, off_label = labels
+        on_beat = max(0.0, float(pedal.onset_beat))
+        off_beat = max(on_beat, float(pedal.offset_beat))
+        part.insert(on_beat, music21.expressions.TextExpression(on_label))
+        part.insert(off_beat, music21.expressions.TextExpression(off_label))
+
+
 def _render_musicxml_bytes(
     score: PianoScore,
     perf: HumanizedPerformance | None,
     title: str,
     composer: str,
-) -> bytes:
-    """Render a PianoScore to MusicXML.
+) -> tuple[bytes, int]:
+    """Render a PianoScore to MusicXML via music21.
 
-    Tries music21 first; on failure (or if music21 isn't installed) falls
-    back to a hand-rolled minimal score-partwise body that at least lists
-    the notes for each hand.
+    Returns a ``(bytes, chord_symbols_rendered)`` tuple so the caller
+    can report how many chord symbols actually survived the filter gate
+    in ``_attach_chord_symbols`` (see plan phase 3.2). The bare length
+    of ``score.metadata.chord_symbols`` lies about rendered content —
+    low-confidence, unparseable, or pitch-octave-shaped labels are
+    dropped before they ever reach the staff.
+
+    music21 is a hard dependency (see ``pyproject.toml``); if it raises
+    during export we let the exception propagate so the job manager can
+    surface the failure instead of silently emitting a stub.
     """
+    import music21  # noqa: PLC0415 — heavy import, kept lazy for test speed
+
+    chord_symbols_rendered = 0
+
+    s = music21.stream.Score()
+    s.metadata = music21.metadata.Metadata()
+    s.metadata.title = title or "Untitled"
+    s.metadata.composer = composer or ""
+
+    ts = music21.meter.TimeSignature(
+        f"{score.metadata.time_signature[0]}/{score.metadata.time_signature[1]}"
+    )
+    # Verify the declared key against a KS pitch-histogram analysis
+    # before trusting it. Audio transcription can mis-label a piece and
+    # every accidental downstream turns into a sharp/flat explosion.
+    # ``_resolve_key_signature`` only overrides when the analyzer is
+    # confident (correlation ≥ 0.85) AND disagrees with the upstream
+    # label — otherwise the declared key wins.
+    key_root, mode, _key_overridden = _resolve_key_signature(score, music21)
+    ks = music21.key.Key(key_root, mode)
+    # Round BPM to a whole number so the metronome mark reads cleanly
+    # (e.g., ♩ = 99 instead of ♩ = 99.38401442307693). The tempo map
+    # itself stays float for beat→sec conversions elsewhere.
+    bpm_float = score.metadata.tempo_map[0].bpm if score.metadata.tempo_map else 120.0
+    bpm = round(bpm_float)
+    tempo_mark = music21.tempo.MetronomeMark(number=bpm)
+
+    articulations_at: dict[str, str] = {}
+    if perf is not None:
+        for a in perf.expression.articulations:
+            articulations_at[a.score_note_id] = a.type
+
+    # Render as a real piano grand staff: two ``PartStaff`` objects bound
+    # by a braced ``StaffGroup``. music21 emits this as a single
+    # ``<part>`` with ``<staves>2</staves>`` and staff-tagged notes —
+    # exactly what OSMD / LilyPond / MuseScore expect for piano. Previous
+    # behavior emitted two separate ``<part>``s ("Right Hand", "Left
+    # Hand") which renderers drew as two stacked instruments without a
+    # connecting brace. Both PartStaffs share ``partName="Piano"`` so the
+    # merged ``<score-part>`` gets the correct "Piano" label.
+    piano_parts: list = []
+    for hand_name, notes, clef in (
+        ("Right Hand", score.right_hand, music21.clef.TrebleClef()),
+        ("Left Hand", score.left_hand, music21.clef.BassClef()),
+    ):
+        part = music21.stream.PartStaff()
+        part.partName = "Piano"
+        part.partAbbreviation = "Pno."
+        part.append(ts)
+        part.append(ks)
+        if hand_name == "Right Hand":
+            part.append(tempo_mark)
+        part.append(clef)
+
+        # Group notes by voice so music21 emits <voice>1</voice> /
+        # <voice>2</voice> instead of collapsing everything to a single
+        # stream. Arrange now caps at 2 voices per hand (PR-10 / plan
+        # phase 3.1), but the older condense pipeline can still produce
+        # voice numbers up to 16 — for that high-voice path we fall back
+        # to a single stream on the staff, matching the pre-PR-10
+        # collapse-to-voice-1 behavior. Piano notation is *defined* by
+        # ≤2 voices per staff, so clamping here matches the physical
+        # reality of stems-up melody + stems-down accompaniment.
+        max_voice_in_hand = max((sn.voice for sn in notes), default=1)
+        use_explicit_voices = 1 < max_voice_in_hand <= 2
+
+        notes_by_voice: dict[int, list] = {}
+        for sn in sorted(notes, key=lambda n: n.onset_beat):
+            n = music21.note.Note(sn.pitch)
+            n.quarterLength = sn.duration_beat
+            n.volume.velocity = sn.velocity
+            art_type = articulations_at.get(sn.id)
+            if art_type == "staccato":
+                n.articulations.append(music21.articulations.Staccato())
+            elif art_type == "accent":
+                n.articulations.append(music21.articulations.Accent())
+            elif art_type == "tenuto":
+                n.articulations.append(music21.articulations.Tenuto())
+            elif art_type == "fermata":
+                # Fermata lives on n.expressions in music21, not
+                # n.articulations — MusicXML emits it as a <fermata/>
+                # inside <notations> either way, but only the
+                # expressions placement round-trips through makeNotation.
+                n.expressions.append(music21.expressions.Fermata())
+            voice_num = sn.voice if use_explicit_voices else 1
+            notes_by_voice.setdefault(voice_num, []).append((sn.onset_beat, n))
+
+        if use_explicit_voices:
+            # Insert voice 1 before voice 2 so music21's internal
+            # enumeration (0-indexed, in insertion order) maps
+            # deterministically back to 1/2 after makeNotation. The
+            # string ``id`` we set here is discarded by ``makeMeasures``
+            # — it re-creates per-measure Voice streams with fresh
+            # integer ids — so the 1..N rename after ``makeNotation``
+            # is the authoritative step.
+            for voice_num in sorted(notes_by_voice.keys()):
+                v = music21.stream.Voice(id=str(voice_num))
+                for onset, n in notes_by_voice[voice_num]:
+                    v.insert(onset, n)
+                part.insert(0, v)
+        else:
+            for _, nlist in notes_by_voice.items():
+                for onset, n in nlist:
+                    part.insert(onset, n)
+
+        # Dynamics + pedal marks are attached to the RH and LH parts
+        # respectively so the markings sit between the staves where
+        # pianists expect them. Skipped on the engrave-from-score path
+        # (perf is never None there, but the expression map is empty).
+        if hand_name == "Right Hand" and perf is not None:
+            _attach_dynamics(part, perf.expression.dynamics, music21)
+        if hand_name == "Left Hand" and perf is not None:
+            _attach_pedal_marks(part, perf.expression.pedal_events, music21)
+
+        # Chord symbols ride above the RH staff where pianists read them.
+        # ``_attach_chord_symbols`` handles confidence / shape / parse
+        # filtering so noisy transcriber output doesn't reach the score.
+        if hand_name == "Right Hand":
+            chord_symbols_rendered += _attach_chord_symbols(
+                part, score.metadata.chord_symbols, music21,
+            )
+
+        # Trust arrange's grid. arrange already quantizes every onset
+        # and duration via ``_estimate_best_grid`` (see
+        # ``backend/services/arrange.py``), picking the best of
+        # {triplet-16th, 16th, triplet-8th, 8th} for the incoming
+        # material. Re-quantizing here to a coarser ``(4, 3)`` divisor
+        # tuple would throw away whatever triplet-16th content arrange
+        # preserved. ``makeNotation`` auto-detects tuplet brackets from
+        # the raw quarterLength without an explicit hint, so the safety
+        # net no longer buys anything. PR-9 forces
+        # ``defaults.divisionsPerQuarter=12`` at the export boundary,
+        # which is LCM(2, 3, 4) — every grid value arrange can emit
+        # lands on an integer ``<duration>``.
+        part.makeNotation(inPlace=True)
+
+        # makeMeasures rebuilds per-measure Voice sub-streams with fresh
+        # integer ids (music21 treats large ints as memory locations and
+        # re-numbers them starting from 0), so the original "1"/"2"
+        # string ids we set before makeNotation are gone. Rename them
+        # back to the MusicXML-valid 1..N range. Enumeration order
+        # matches our insertion order on the part, so voice 0 → "1" and
+        # voice 1 → "2" — consistent across every measure.
+        for meas in part.getElementsByClass(music21.stream.Measure):
+            for idx, v in enumerate(meas.voices):
+                v.id = str(idx + 1)
+
+        s.insert(0, part)
+        piano_parts.append(part)
+
+    # Bind the two PartStaffs into a braced grand staff. music21 detects
+    # the StaffGroup and collapses them into one ``<part>`` with
+    # ``<staves>2</staves>`` in the MusicXML output, with each note
+    # carrying a ``<staff>`` tag so renderers place it on the correct
+    # stave.
+    s.insert(
+        0,
+        music21.layout.StaffGroup(
+            piano_parts,
+            name="Piano",
+            abbreviation="Pno.",
+            symbol="brace",
+            barTogether=True,
+        ),
+    )
+
+    # Force divisions=12 at the exporter boundary. music21's MeasureExporter
+    # reads ``defaults.divisionsPerQuarter`` verbatim when stamping the
+    # ``<divisions>`` tag (m21ToXml.setMxAttributesObjectForStartOfMeasure)
+    # and the shipped default is 10080 — producing MusicXML that OSMD
+    # chokes on. 12 = LCM(4, 3) which is the finest grid we need to
+    # represent the (4, 3) quarterLengthDivisors quantization: 16th = 3
+    # divisions, 8th = 6, triplet-8th = 4, quarter = 12. Done here
+    # (process-global, restored after write) rather than at module import
+    # so non-engrave music21 callers keep the upstream default.
+    with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    prior_divisions = music21.defaults.divisionsPerQuarter
     try:
-        import music21  # noqa: PLC0415 — optional heavy dep
-    except ImportError:
-        log.warning("music21 not installed — MusicXML output will be a minimal stub. Install with: pip install music21")
-        return _minimal_musicxml(score, title, composer)
-
-    try:
-        s = music21.stream.Score()
-        s.metadata = music21.metadata.Metadata()
-        s.metadata.title = title or "Untitled"
-        s.metadata.composer = composer or ""
-
-        ts = music21.meter.TimeSignature(
-            f"{score.metadata.time_signature[0]}/{score.metadata.time_signature[1]}"
-        )
-        key_root = score.metadata.key.split(":")[0] if ":" in score.metadata.key else "C"
-        mode = "major" if "minor" not in score.metadata.key else "minor"
-        ks = music21.key.Key(key_root, mode)
-        # Round BPM to a whole number so the metronome mark reads cleanly
-        # (e.g., ♩ = 99 instead of ♩ = 99.38401442307693). The tempo map
-        # itself stays float for beat→sec conversions elsewhere.
-        bpm_float = score.metadata.tempo_map[0].bpm if score.metadata.tempo_map else 120.0
-        bpm = round(bpm_float)
-        tempo_mark = music21.tempo.MetronomeMark(number=bpm)
-
-        articulations_at: dict[str, str] = {}
-        if perf is not None:
-            for a in perf.expression.articulations:
-                articulations_at[a.score_note_id] = a.type
-
-        for hand_name, notes, clef in (
-            ("Right Hand", score.right_hand, music21.clef.TrebleClef()),
-            ("Left Hand", score.left_hand, music21.clef.BassClef()),
-        ):
-            part = music21.stream.Part()
-            part.partName = hand_name
-            part.append(ts)
-            part.append(ks)
-            if hand_name == "Right Hand":
-                part.append(tempo_mark)
-            part.append(clef)
-
-            for sn in sorted(notes, key=lambda n: n.onset_beat):
-                n = music21.note.Note(sn.pitch)
-                n.quarterLength = sn.duration_beat
-                n.volume.velocity = sn.velocity
-                art_type = articulations_at.get(sn.id)
-                if art_type == "staccato":
-                    n.articulations.append(music21.articulations.Staccato())
-                elif art_type == "accent":
-                    n.articulations.append(music21.articulations.Accent())
-                elif art_type == "tenuto":
-                    n.articulations.append(music21.articulations.Tenuto())
-                part.insert(sn.onset_beat, n)
-
-            # Chord symbols disabled for now — the harmonic analysis from
-            # audio transcription produces noisy labels (G5, E5, etc.) that
-            # clutter the notation. Re-enable when chord recognition quality
-            # improves or when source is a clean MIDI upload.
-            # for cs in score.metadata.chord_symbols:
-            #     try:
-            #         h = music21.harmony.ChordSymbol(cs.label.replace(":", ""))
-            #         part.insert(cs.beat, h)
-            #     except Exception:
-            #         pass
-
-            # Quantize to a 16th-note + triplet grid so OSMD can render it.
-            # Without explicit divisors, music21 defaults to divisions=10080
-            # which produces MusicXML that OSMD chokes on.
-            part.quantize(quarterLengthDivisors=(4, 3), inPlace=True)
-            part.makeNotation(inPlace=True)
-            s.append(part)
-
-        with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
-            tmp_path = Path(tmp.name)
-        try:
-            s.write("musicxml", fp=str(tmp_path))
-            raw = tmp_path.read_bytes()
-            return _sanitize_musicxml_for_osmd(raw)
-        finally:
-            tmp_path.unlink(missing_ok=True)
-    except Exception as exc:  # noqa: BLE001 — music21 has many failure modes
-        log.warning("music21 MusicXML render failed (%s); falling back to minimal", exc)
-        return _minimal_musicxml(score, title, composer)
+        music21.defaults.divisionsPerQuarter = 12
+        s.write("musicxml", fp=str(tmp_path))
+        raw = tmp_path.read_bytes()
+        return _sanitize_musicxml_for_osmd(raw), chord_symbols_rendered
+    finally:
+        music21.defaults.divisionsPerQuarter = prior_divisions
+        tmp_path.unlink(missing_ok=True)
 
 
 def _sanitize_musicxml_for_osmd(raw: bytes) -> bytes:
     """Post-process music21 MusicXML to fix OSMD compatibility issues.
 
-    OSMD's VexFlow backend crashes (parentVoiceEntry) when:
-    1. <divisions> is very high (10080) — we reduce to 4 (16th-note grid)
-    2. Voice numbers exceed 2 per part — we collapse to voice 1
-    3. Voice 0 exists — OSMD expects 1-indexed voices
+    Two mechanical fixups remain after PR-9 (source-level ``divisions=12``)
+    and PR-10 (Voice sub-streams for 2-voice preservation):
 
-    We also scale all <duration> values proportionally when changing divisions.
+    1. ``<voice>0</voice>`` → ``<voice>1</voice>`` — music21 emits 0 when
+       a note isn't wrapped in a ``Voice`` sub-stream and the part has
+       multiple voices elsewhere. MusicXML requires voice numbers ≥ 1,
+       and OSMD rejects zero outright.
+    2. ``<voice>N</voice>`` with N ≥ 3 → ``<voice>2</voice>`` — defense-in-
+       depth for any upstream stage (e.g. the condense path) that
+       produces more than two voices per hand. OSMD's VexFlow backend
+       crashes (``parentVoiceEntry undefined``) on 3+ voices per part;
+       clamping to 2 is the minimum-damage fallback.
     """
-    import re
-
     text = raw.decode("utf-8")
 
-    # Find the current divisions value
-    div_match = re.search(r"<divisions>(\d+)</divisions>", text)
-    if div_match:
-        old_div = int(div_match.group(1))
-        new_div = 4  # 4 divisions per quarter = 16th-note grid
+    def _clamp(match: re.Match[str]) -> str:
+        n = int(match.group(1))
+        if n == 0:
+            return "<voice>1</voice>"
+        if n > 2:
+            return "<voice>2</voice>"
+        return match.group(0)
 
-        if old_div != new_div and old_div > 0:
-            ratio = new_div / old_div
-
-            # Replace all <divisions> tags
-            text = re.sub(
-                r"<divisions>\d+</divisions>",
-                f"<divisions>{new_div}</divisions>",
-                text,
-            )
-
-            # Scale all <duration> values
-            def scale_duration(m: re.Match) -> str:
-                old_dur = int(m.group(1))
-                new_dur = max(1, round(old_dur * ratio))
-                return f"<duration>{new_dur}</duration>"
-
-            text = re.sub(r"<duration>(\d+)</duration>", scale_duration, text)
-
-            # Scale <forward> and <backup> durations too
-            def scale_forward(m: re.Match) -> str:
-                tag = m.group(1)
-                old_dur = int(m.group(2))
-                new_dur = max(1, round(old_dur * ratio))
-                return f"<{tag}>\n        <duration>{new_dur}</duration>"
-
-            text = re.sub(
-                r"<(forward|backup)>\s*<duration>(\d+)</duration>",
-                scale_forward,
-                text,
-            )
-
-    # Collapse all voices to voice 1 (OSMD chokes on 3+ voices per part)
-    text = re.sub(r"<voice>\d+</voice>", "<voice>1</voice>", text)
-
+    text = re.sub(r"<voice>(\d+)</voice>", _clamp, text)
     return text.encode("utf-8")
-
-
-def _minimal_musicxml(score: PianoScore, title: str, composer: str) -> bytes:
-    """Hand-rolled minimal score-partwise body.
-
-    Not bar-aware — emits each note as a single ``<note>`` element with
-    its pitch step, octave, and duration in tenths of a beat. Good enough
-    for round-trip tests; the music21 path is what real consumers want.
-    """
-    bpm = score.metadata.tempo_map[0].bpm if score.metadata.tempo_map else 120.0
-    divisions = 4  # 4 divisions per quarter note → 16th-note grid
-
-    def note_xml(sn: ScoreNote, hand: int) -> str:
-        step, alter, octave = _midi_to_step_alter_octave(sn.pitch)
-        duration = max(1, int(round(sn.duration_beat * divisions)))
-        alter_xml = f"<alter>{alter}</alter>" if alter else ""
-        return (
-            "<note>"
-            f"<pitch><step>{step}</step>{alter_xml}<octave>{octave}</octave></pitch>"
-            f"<duration>{duration}</duration>"
-            f"<voice>{sn.voice}</voice>"
-            f"<staff>{hand}</staff>"
-            "</note>"
-        )
-
-    rh_notes = "".join(note_xml(n, 1) for n in sorted(score.right_hand, key=lambda n: n.onset_beat))
-    lh_notes = "".join(note_xml(n, 2) for n in sorted(score.left_hand, key=lambda n: n.onset_beat))
-
-    ts = score.metadata.time_signature
-    body = (
-        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
-        '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" '
-        '"http://www.musicxml.org/dtds/partwise.dtd">\n'
-        '<score-partwise version="3.1">'
-        '<work>'
-        f'<work-title>{escape(title or "Untitled")}</work-title>'
-        '</work>'
-        '<identification>'
-        f'<creator type="composer">{escape(composer or "Unknown")}</creator>'
-        '</identification>'
-        '<part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>'
-        '<part id="P1">'
-        '<measure number="1">'
-        '<attributes>'
-        f'<divisions>{divisions}</divisions>'
-        f'<key><fifths>0</fifths></key>'
-        f'<time><beats>{ts[0]}</beats><beat-type>{ts[1]}</beat-type></time>'
-        '<staves>2</staves>'
-        '<clef number="1"><sign>G</sign><line>2</line></clef>'
-        '<clef number="2"><sign>F</sign><line>4</line></clef>'
-        '</attributes>'
-        f'<sound tempo="{bpm:.2f}"/>'
-        f'{rh_notes}'
-        '<backup>'
-        f'<duration>{max(1, int(round(sum(n.duration_beat for n in score.right_hand) * divisions)))}</duration>'
-        '</backup>'
-        f'{lh_notes}'
-        '</measure>'
-        '</part>'
-        '</score-partwise>\n'
-    )
-    return body.encode("utf-8")
-
-
-_PITCH_NAMES: list[tuple[str, int]] = [
-    ("C", 0), ("C", 1), ("D", 0), ("D", 1), ("E", 0), ("F", 0),
-    ("F", 1), ("G", 0), ("G", 1), ("A", 0), ("A", 1), ("B", 0),
-]
-
-
-def _midi_to_step_alter_octave(midi: int) -> tuple[str, int, int]:
-    midi = max(0, min(127, midi))
-    octave = (midi // 12) - 1
-    step, alter = _PITCH_NAMES[midi % 12]
-    return step, alter, octave
 
 
 # ---------------------------------------------------------------------------
@@ -376,35 +577,36 @@ def _midi_to_step_alter_octave(midi: int) -> tuple[str, int, int]:
 # ---------------------------------------------------------------------------
 
 def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
-    """Try MuseScore CLI then LilyPond. Returns the stub PDF on failure."""
-    if not (shutil.which("musescore4") or shutil.which("musescore3")
-            or shutil.which("mscore") or shutil.which("MuseScore4")
-            or (shutil.which("musicxml2ly") and shutil.which("lilypond"))):
-        log.warning("No PDF renderer found — install LilyPond or MuseScore for real PDF output")
+    """Render MusicXML to PDF bytes.
+
+    Tries LilyPond first (this is what production ships — ~250 MB apt
+    package, musicxml2ly + lilypond binaries) and MuseScore as a
+    higher-fidelity fallback for local dev machines that have it
+    installed. Returns the 60-byte stub PDF only when no renderer is
+    available or all renderers fail.
+    """
+    has_lilypond = bool(shutil.which("musicxml2ly") and shutil.which("lilypond"))
+    mscore_bin = next(
+        (b for b in ("musescore4", "musescore3", "mscore", "MuseScore4") if shutil.which(b)),
+        None,
+    )
+
+    if not has_lilypond and mscore_bin is None:
+        log.warning(
+            "No PDF renderer found — install lilypond (preferred) or MuseScore "
+            "for real PDF output; emitting stub",
+        )
         return _STUB_PDF
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         xml_path = tmp / "score.musicxml"
-        pdf_path = tmp / "sheet.pdf"
         xml_path.write_bytes(musicxml_bytes)
 
-        for mscore in ("musescore4", "musescore3", "mscore", "MuseScore4"):
-            if not shutil.which(mscore):
-                continue
+        if has_lilypond:
+            ly_path = tmp / "score.ly"
+            pdf_path = tmp / "sheet.pdf"
             try:
-                subprocess.run(
-                    [mscore, "-o", str(pdf_path), str(xml_path)],
-                    check=True, capture_output=True, timeout=120,
-                )
-                if pdf_path.is_file():
-                    return pdf_path.read_bytes()
-            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
-                continue
-
-        if shutil.which("musicxml2ly") and shutil.which("lilypond"):
-            try:
-                ly_path = tmp / "score.ly"
                 subprocess.run(
                     ["musicxml2ly", "-o", str(ly_path), str(xml_path)],
                     check=True, capture_output=True, timeout=60,
@@ -414,9 +616,39 @@ def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
                     check=True, capture_output=True, timeout=120,
                 )
                 if pdf_path.is_file():
+                    log.info("PDF rendered via LilyPond (%d bytes)", pdf_path.stat().st_size)
                     return pdf_path.read_bytes()
-            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
-                pass
+                log.warning("LilyPond ran but produced no PDF at %s", pdf_path)
+            except subprocess.CalledProcessError as exc:
+                log.warning(
+                    "LilyPond PDF render failed (%s): %s",
+                    exc.cmd[0] if exc.cmd else "?",
+                    (exc.stderr or b"").decode("utf-8", "replace")[:500],
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                log.warning("LilyPond PDF render failed: %s", exc)
+
+        if mscore_bin is not None:
+            pdf_path = tmp / "sheet.pdf"
+            try:
+                subprocess.run(
+                    [mscore_bin, "-o", str(pdf_path), str(xml_path)],
+                    check=True, capture_output=True, timeout=120,
+                )
+                if pdf_path.is_file():
+                    log.info(
+                        "PDF rendered via %s (%d bytes)", mscore_bin, pdf_path.stat().st_size,
+                    )
+                    return pdf_path.read_bytes()
+                log.warning("%s ran but produced no PDF at %s", mscore_bin, pdf_path)
+            except subprocess.CalledProcessError as exc:
+                log.warning(
+                    "%s PDF render failed: %s",
+                    mscore_bin,
+                    (exc.stderr or b"").decode("utf-8", "replace")[:500],
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                log.warning("%s PDF render failed: %s", mscore_bin, exc)
 
     return _STUB_PDF
 
@@ -429,11 +661,20 @@ def _engrave_sync(
     payload: HumanizedPerformance | PianoScore,
     title: str,
     composer: str,
-) -> tuple[bytes, bytes, bytes, bool]:
-    """Render all three artifacts. Returns (pdf, musicxml, midi, is_humanized)."""
-    is_humanized = isinstance(payload, HumanizedPerformance)
-    score = payload.score if is_humanized else payload  # type: ignore[union-attr]
-    perf = payload if is_humanized else None  # type: ignore[assignment]
+) -> tuple[bytes, bytes, bytes, int]:
+    """Render all three artifacts.
+
+    Returns ``(pdf, musicxml, midi, chord_symbols_rendered)``. The trailing
+    count reflects chord symbols that *actually made it to the staff* after
+    ``_attach_chord_symbols`` filtering — not the raw input count — so
+    ``EngravedScoreData.includes_chord_symbols`` can tell the truth.
+    """
+    if isinstance(payload, HumanizedPerformance):
+        score = payload.score
+        perf: HumanizedPerformance | None = payload
+    else:
+        score = payload
+        perf = None
 
     if perf is None:
         # Engrave-from-score: synthesize a zero-deviation performance shell so
@@ -463,9 +704,11 @@ def _engrave_sync(
         )
 
     midi_bytes = _render_midi_bytes(perf)
-    musicxml_bytes = _render_musicxml_bytes(score, perf, title, composer)
+    musicxml_bytes, chord_symbols_rendered = _render_musicxml_bytes(
+        score, perf, title, composer,
+    )
     pdf_bytes = _render_pdf_bytes(musicxml_bytes)
-    return pdf_bytes, musicxml_bytes, midi_bytes, is_humanized
+    return pdf_bytes, musicxml_bytes, midi_bytes, chord_symbols_rendered
 
 
 class EngraveService:
@@ -488,8 +731,8 @@ class EngraveService:
             title,
             isinstance(payload, HumanizedPerformance),
         )
-        pdf_bytes, musicxml_bytes, midi_bytes, is_humanized = await asyncio.to_thread(
-            _engrave_sync, payload, title, composer,
+        pdf_bytes, musicxml_bytes, midi_bytes, chord_symbols_rendered = (
+            await asyncio.to_thread(_engrave_sync, payload, title, composer)
         )
 
         prefix = f"jobs/{job_id}/output"
@@ -498,24 +741,34 @@ class EngraveService:
         midi_uri = self.blob_store.put_bytes(f"{prefix}/humanized.mid", midi_bytes)
 
         score = payload.score if isinstance(payload, HumanizedPerformance) else payload
-        chord_count = len(score.metadata.chord_symbols)
+        chord_input_count = len(score.metadata.chord_symbols)
 
         log.info(
-            "engrave: done job_id=%s bytes pdf=%d musicxml=%d midi=%d chord_symbols=%d",
+            "engrave: done job_id=%s bytes pdf=%d musicxml=%d midi=%d "
+            "chord_symbols=%d/%d rendered",
             job_id,
             len(pdf_bytes),
             len(musicxml_bytes),
             len(midi_bytes),
-            chord_count,
+            chord_symbols_rendered,
+            chord_input_count,
         )
 
+        # These flags describe what was *actually rendered*. As of PR-5
+        # (plan phase 1.3–1.6) engrave renders dynamics and pedal marks
+        # when the humanized input populates them, so we surface that
+        # state directly from the expression map instead of hardcoding.
+        # PR-11 (plan phase 3.2) extends the same truth-telling to chord
+        # symbols: the input count can lie (low-confidence / unparseable
+        # labels are dropped), so gate on the filtered-rendered count.
+        perf_for_flags = payload if isinstance(payload, HumanizedPerformance) else None
         return EngravedOutput(
             schema_version=SCHEMA_VERSION,
             metadata=EngravedScoreData(
-                includes_dynamics=is_humanized,
-                includes_pedal_marks=is_humanized,
+                includes_dynamics=bool(perf_for_flags and perf_for_flags.expression.dynamics),
+                includes_pedal_marks=bool(perf_for_flags and perf_for_flags.expression.pedal_events),
                 includes_fingering=False,
-                includes_chord_symbols=chord_count > 0,
+                includes_chord_symbols=chord_symbols_rendered > 0,
                 title=title,
                 composer=composer,
             ),

--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -17,6 +17,7 @@ import logging
 from pathlib import Path
 from urllib.parse import urlparse
 
+from backend.config import settings
 from backend.contracts import (
     SCHEMA_VERSION,
     InputBundle,
@@ -24,6 +25,7 @@ from backend.contracts import (
     RemoteAudioFile,
     RemoteMidiFile,
 )
+from backend.services.cover_search import find_clean_source, probe_youtube_metadata
 
 log = logging.getLogger(__name__)
 
@@ -136,6 +138,78 @@ def _download_youtube_sync(url: str, blob_store) -> tuple[RemoteAudioFile, str |
         ), info.get("title"), info.get("uploader") or info.get("channel")
 
 
+def _maybe_swap_for_cover_sync(url: str) -> str:
+    """If a high-scoring clean source for ``url`` exists, return its URL;
+    otherwise return ``url`` unchanged.
+
+    This is the ingest stage's "fast path" router (see
+    ``backend/services/cover_search.py``). The rationale: Basic Pitch
+    transcribes every audible pitch as a piano note, so feeding it a
+    polyphonic pop mix produces dense, unplayable sheet music. A clean
+    piano cover (easy / moderate tier) is already piano-shaped, which
+    is exactly what Basic Pitch is good at. An 8-bit / chiptune cover
+    is even cleaner — monophonic channels, no reverb, no drums mixed
+    into pitched content — so when one exists it often outscores any
+    piano cover in the same search.
+
+    ``find_clean_source`` runs both variants and returns the single
+    highest-scoring result across piano+chiptune. This function is the
+    thin async wrapper that enforces the silent-failure contract: ANY
+    exception or non-match falls back to the original URL. Job
+    continues, user gets the direct transcription they implicitly
+    asked for. Called via ``asyncio.to_thread`` because both probe and
+    search are blocking network I/O.
+    """
+    try:
+        probed = probe_youtube_metadata(url)
+    except Exception as exc:  # noqa: BLE001 — silent-failure boundary
+        log.warning("ingest: cover_search probe crashed for %r: %s", url, exc)
+        return url
+
+    if probed is None:
+        log.info("ingest: cover_search could not probe metadata for %r", url)
+        return url
+
+    title, artist = probed
+    try:
+        match = find_clean_source(
+            title,
+            artist,
+            min_score=settings.cover_search_min_score,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive depth; find_clean_source
+                              # is documented silent-failure but we must never
+                              # crash the job on a cover-search bug.
+        log.warning("ingest: cover_search find crashed for %r: %s", title, exc)
+        return url
+
+    if match is None:
+        log.info(
+            "ingest: cover_search no match for title=%r artist=%r — using original URL",
+            title, artist,
+        )
+        return url
+
+    # Defense-in-depth (PR #47 review, Critical): even with the
+    # _normalize_entry_url fix upstream in _yt_dlp_search, we refuse
+    # to propagate any cover_search result whose URL we can't parse as
+    # YouTube. A bad URL here would reach _download_youtube_sync and
+    # crash the job with ValueError, violating the silent-failure
+    # contract. Falling back to the original URL is always safe.
+    if not is_youtube_url(match.url):
+        log.warning(
+            "ingest: cover_search returned non-YouTube URL %r — falling back to original",
+            match.url,
+        )
+        return url
+
+    log.info(
+        "ingest: cover_search SWAP url=%r → %r (channel=%r score=%d)",
+        url, match.url, match.channel, match.score,
+    )
+    return match.url
+
+
 def _file_path(uri: str) -> Path | None:
     """Return a local Path for ``file://`` URIs, or None for anything else."""
     parsed = urlparse(uri)
@@ -217,8 +291,25 @@ class IngestService:
             and payload.metadata.title is not None
             and is_youtube_url(payload.metadata.title)
         ):
+            download_url = payload.metadata.title
+
+            # Cover-search fast path: before downloading, try to swap the
+            # user's URL for a clean piano cover. Gated by BOTH the
+            # per-job flag (prefer_clean_source) and the global kill
+            # switch (settings.cover_search_enabled), so operators can
+            # disable the feature globally without any per-request change.
+            # The helper enforces the silent-failure contract — any
+            # failure returns ``download_url`` unchanged.
+            if (
+                payload.metadata.prefer_clean_source
+                and settings.cover_search_enabled
+            ):
+                download_url = await asyncio.to_thread(
+                    _maybe_swap_for_cover_sync, download_url,
+                )
+
             dl_result = await asyncio.to_thread(
-                _download_youtube_sync, payload.metadata.title, self._blob_store,
+                _download_youtube_sync, download_url, self._blob_store,
             )
             audio, yt_title, yt_artist = dl_result
             if yt_title:
@@ -284,10 +375,25 @@ class IngestService:
         )
 
     @staticmethod
-    def from_title_lookup(title: str, artist: str | None = None) -> InputBundle:
+    def from_title_lookup(
+        title: str,
+        artist: str | None = None,
+        *,
+        prefer_clean_source: bool = False,
+    ) -> InputBundle:
+        # prefer_clean_source is keyword-only so callers can't shadow
+        # artist positionally. Tests, scripts, and any non-API caller
+        # that wants to exercise the cover_search fast path must pass
+        # this flag through; the live API route constructs InputBundle
+        # directly, so production is unaffected. PR #47 review #3.
         return InputBundle(
             schema_version=SCHEMA_VERSION,
             audio=None,
             midi=None,
-            metadata=InputMetadata(title=title, artist=artist, source="title_lookup"),
+            metadata=InputMetadata(
+                title=title,
+                artist=artist,
+                source="title_lookup",
+                prefer_clean_source=prefer_clean_source,
+            ),
         )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,8 +15,14 @@ services:
       retries: 5
 
   orchestrator:
+    # JobManager stores jobs in an in-process dict (see
+    # backend/jobs/manager.py — "Single-process v1"), so running more
+    # than one uvicorn worker splits job state across processes: POST
+    # /v1/jobs lands on one worker, the subsequent GET / WS lands on
+    # another and returns "Job not found" (GAU-100). Keep --workers 1
+    # until JobManager is backed by Redis / Postgres.
     image: ${IMAGE}
-    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 2
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 1
     restart: unless-stopped
     ports:
       - "8000:8000"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -131,6 +131,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN:-localhost}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,100 @@
+# Deployment & Release Flow
+
+Oh Sheet uses a two-environment release flow with strict branch protection.
+
+## Branches & environments
+
+| Branch | Environment | URL | Approvals |
+|--------|-------------|-----|-----------|
+| `qa`   | **QA**   | https://oh-sheet-qa.duckdns.org | 1 |
+| `main` | **prod** | https://oh-sheet.duckdns.org | 2 |
+
+## Release flow
+
+```
+feature/foo ──► qa ──► main
+              (1 approval)  (2 approvals, only from qa)
+                 │              │
+                 ▼              ▼
+              QA deploy     Prod deploy
+```
+
+1. **Develop on a feature branch** off `qa`.
+2. **Open a PR into `qa`**. CI runs (lint, typecheck, tests). Requires **1 approval** from the team. No direct pushes.
+3. **Merge into `qa`** → the deploy workflow builds images and deploys to the **QA VM** automatically.
+4. **Open a PR from `qa` into `main`** to release. The `Branch Guard` workflow enforces that the source branch is exactly `qa` — no feature branch can bypass QA. Requires **2 approvals**.
+5. **Merge into `main`** → the same deploy workflow builds images and deploys to the **prod VM** automatically.
+
+## How it works
+
+- One `.github/workflows/deploy.yml` runs for both branches. It reads the target environment from `github.ref_name` (`main` → `prod`, anything else → `qa`).
+- GitHub Environments (`qa`, `prod`) provide **environment-scoped secrets and variables**, so `VM_HOST`, `PUBLIC_URL`, and `DOMAIN` automatically point at the right VM and domain.
+- `Caddyfile` uses the Caddy placeholder `{$DOMAIN}` so a single file serves both environments. The deploy workflow writes `DOMAIN` into `.env` on the VM and `docker-compose.prod.yml` passes it to the caddy container, which Caddy expands at startup. Caddy auto-provisions a Let's Encrypt cert for whichever hostname the env var resolves to.
+- `.github/workflows/branch-guard.yml` runs on every PR targeting `main` and **fails the check unless the PR's source branch is `qa`**. Branch protection on `main` requires this check to pass, so feature branches physically cannot merge directly to `main`.
+- Slack notifications are prefixed with `[QA]` or `[PROD]` so the shared `#oh-sheet-notifications` channel clearly indicates which environment was deployed.
+
+## Admin setup (one-time — requires repo admin)
+
+The code changes in this repo enable the flow, but branch protection and GitHub Environments require admin rights to configure.
+
+### 1. Create GitHub Environments
+
+In **Settings → Environments**:
+
+**`qa` environment**:
+- No required reviewers
+- Environment variables:
+  - `VM_HOST = 34.169.16.93`
+  - `VM_USER = deploy`
+  - `PUBLIC_URL = https://oh-sheet-qa.duckdns.org`
+  - `DOMAIN = oh-sheet-qa.duckdns.org`
+- Environment secrets (copy from repo secrets): `VM_SSH_PRIVATE_KEY`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `SLACK_WEBHOOK_URL`
+
+**`prod` environment**:
+- **Required reviewers**: at least 2 team members (optional — the 2-approval rule is also enforced at PR level, but this adds a runtime gate)
+- Environment variables:
+  - `VM_HOST = 104.196.254.221`
+  - `VM_USER = deploy`
+  - `PUBLIC_URL = https://oh-sheet.duckdns.org`
+  - `DOMAIN = oh-sheet.duckdns.org`
+- Environment secrets: same as qa
+
+Once environment-scoped vars/secrets exist, the repo-level `VM_HOST`/`VM_USER` variables can be removed to avoid confusion.
+
+### 2. Branch protection
+
+**`qa` branch**:
+- Require a pull request before merging
+- Require approvals: **1**
+- Dismiss stale pull request approvals when new commits are pushed
+- Require status checks to pass: `Backend Lint`, `Backend Typecheck`, `Backend Tests`, `Frontend Lint`
+- Require branches to be up to date before merging
+- Do not allow bypassing (include admins)
+
+**`main` branch**:
+- Require a pull request before merging
+- Require approvals: **2**
+- Dismiss stale pull request approvals when new commits are pushed
+- Require status checks to pass: `Backend Lint`, `Backend Typecheck`, `Backend Tests`, `Frontend Lint`, **`PR to main must come from qa`** (from `branch-guard.yml`)
+- Require branches to be up to date before merging
+- Do not allow bypassing (include admins)
+
+## Infrastructure
+
+Both VMs live in GCP project `oh-she3t`:
+
+| VM | Zone | Machine | Static IP |
+|----|------|---------|-----------|
+| `oh-sheet-vm` (prod) | `us-west1-b` | `e2-small` | `104.196.254.221` |
+| `oh-sheet-qa-vm` (qa) | `us-west1-b` | `e2-small` | `34.169.16.93` |
+
+Both VMs share the same firewall tag (`oh-sheet-vm`) so the existing rules on ports 22/80/443 apply to both.
+
+## Domains
+
+| Environment | Domain | DNS |
+|-------------|--------|-----|
+| QA          | `oh-sheet-qa.duckdns.org` | DuckDNS A record → `34.169.16.93` |
+| Prod        | `oh-sheet.duckdns.org`    | DuckDNS A record → `104.196.254.221` |
+
+Caddy auto-provisions Let's Encrypt certificates on first deploy for whichever hostname the `DOMAIN` env var resolves to. If you later add a new environment or rename a domain, just update the env-scoped `DOMAIN` variable — no Caddyfile change required.

--- a/docs/engrave-improvement-plan.md
+++ b/docs/engrave-improvement-plan.md
@@ -1,0 +1,433 @@
+# Engrave Stage — Improvement Plan
+
+Synthesis of three parallel research passes on `backend/services/engrave.py`:
+renderer infrastructure & output fidelity, musical notation quality, and
+evaluation strategy. Scoped to measurable, incremental improvements that can
+each land as a single PR.
+
+## TL;DR
+
+The engrave stage today is functional but leaks value on every axis:
+
+- **Two latent correctness issues** — `timing_offset_ms` is applied to both
+  onset and offset at `engrave.py:87-88` (duration-preserving shift — probably
+  not what humanize intends), and `EngravedScoreData.includes_dynamics/pedal`
+  at `engrave.py:515` claim features that are never actually rendered.
+- **Data is being dropped on the floor.** `humanize.py:101-114` generates
+  dynamics; engrave never reads `perf.expression.dynamics`. Pedal events
+  reach MIDI but not MusicXML. Chord symbols are disabled entirely.
+- **The OSMD sanitizer regex (`engrave.py:242-296`) is a workaround masquerading
+  as infrastructure.** It collapses voices 1+2 (destroying piano stems-up/
+  stems-down) and rescales divisions after the fact. Both problems are better
+  fixed at the music21 export boundary.
+- **Test coverage for engrave is ~zero.** No fixture-based golden tests,
+  no schema validation, no MIDI round-trip. Every change is a shot in the
+  dark.
+- **Production emits stub PDFs.** The Cloud Run image has no MuseScore or
+  LilyPond, so every job returns the 60-byte `%PDF-1.4` stub.
+
+The right order is **build the evaluation harness first**, then fix the bugs
+it surfaces, then ship the incremental notation/renderer improvements with
+regression coverage on every PR.
+
+---
+
+## Phase 0 — Evaluation harness (land before any behavior changes)
+
+Rationale: almost every improvement below is risky without a way to A/B old
+vs. new output. Building the harness first means subsequent PRs are
+diffable and reviewable.
+
+### 0.1 Score fixtures — `tests/fixtures/scores/`
+Commit ten small hand-authored `PianoScore` / `HumanizedPerformance` fixtures
+as Pydantic-built JSON so they survive contract changes via re-validation:
+
+1. `single_note.json` — RH C4 only (trivial baseline)
+2. `c_major_scale.json` — RH scale + LH whole notes (beaming, single voice)
+3. `two_hand_chordal.json` — RH triads + LH octaves (`<staff>` separation)
+4. `bach_invention_excerpt.json` — 8 bars of two-voice counterpoint, RH
+   only — **the voice-handling fixture**
+5. `jazz_voicings.json` — chromatic bass + 7th-chord shells (accidentals)
+6. `seven_eight.json` — 7/8 irregular grouping (time-sig propagation,
+   `quarterLengthDivisors=(4,3)` edge cases)
+7. `tempo_change.json` — multi-segment `tempo_map`
+8. `humanized_with_offsets.json` — c_major_scale with
+   `timing_offset_ms ∈ [-30,30]` and a sustain pedal event — **the timing-bug
+   fixture**
+9. `empty_left_hand.json` — RH only (catches no-note backup logic)
+10. `overlapping_same_pitch.json` — two RH C4 notes that overlap (exercises
+    `engrave.py:94-103` overlap resolver)
+
+Promote the `_piano_score()` / `_humanized_performance()` builders from
+`tests/test_stages.py` into a shared `tests/fixtures/_builders.py` +
+`load_score_fixture(name)` helper.
+
+### 0.2 Test layers, in priority order
+
+| Layer | Catches | Runs |
+|---|---|---|
+| **L1 — MIDI round-trip** | `timing_offset_ms` bug, dropped notes, wrong pitches | Every PR |
+| **L2 — Notation quality lints** (lxml xpath) | `<voice>` out of range, divisions > 480, out-of-piano-range pitches, note-count mismatch | Every PR |
+| **L3 — MusicXML 4.0 XSD validation** | Structural schema violations | Every PR |
+| **L4 — MusicXML golden diffs** | Regressions in music21 output after normalization | Every PR |
+| **L5 — Verovio render check** | MusicXML that validates but won't render; missing measure attributes | Every PR |
+| **L6 — OSMD/Playwright headless** | `parentVoiceEntry` class crashes in actual consumer | **Nightly only** |
+| **L7 — MuseScore/LilyPond PDF** | Real engraver feedback | **Manual / nightly**, not PR-blocking |
+
+Layers L1–L5 are all cheap (sub-second each) and add <10s to CI. Dev deps
+to add to `pyproject.toml`: `lxml` (already transitive), `verovio` (~10 MB
+pure-Python wheel, no system deps). Vendor `musicxml-4.0.xsd` into
+`tests/fixtures/`.
+
+**Skip** MuseScore/LilyPond in PR CI (500 MB+ images, nondeterministic
+output, X-server hassles). Reserve for optional nightly on a beefier runner.
+
+### 0.3 Golden-file normalization
+Before diffing MusicXML goldens, strip time-varying tags: `<encoding-date>`,
+`<software>`, `<encoder>`, `<creator type="software">`, `<supports>`. Use
+`lxml.etree.canonicalize`. Ship a `pytest --update-goldens` flag from day
+one so music21 version bumps are a reviewable diff, not a mystery churn.
+Pin music21 exactly in `pyproject.toml`.
+
+### 0.4 A/B regression harness — `scripts/engrave_diff.py`
+Takes two git refs, runs all fixtures through both, prints a table of
+MusicXML normalized-byte-diff sizes and Verovio note counts per fixture.
+Not a test — an investigative CLI for PR authors.
+
+**Expected first finding:** the failing `humanized_with_offsets` MIDI
+round-trip test surfaces the `timing_offset_ms` behavior so we can make an
+informed decision (is it a bug, or is it the intended "whole-note shift"
+model?).
+
+---
+
+## Phase 1 — Bug fixes and truth-telling (small PRs, low risk)
+
+### 1.1 Truthful `EngravedScoreData` flags
+`engrave.py:512-526` currently sets `includes_dynamics=is_humanized` and
+`includes_pedal_marks=is_humanized` unconditionally. Change to reflect
+actual rendered content:
+
+```python
+includes_dynamics=bool(perf and perf.expression.dynamics),
+includes_pedal_marks=bool(perf and perf.expression.pedal_events),
+```
+
+**Effort: S. Risk: none.** Land independently before 1.3/1.4 because those
+will flip these flags to actually-True.
+
+### 1.2 `timing_offset_ms` semantics decision — `engrave.py:87-88`
+The shift is applied to *both* onset and offset, so duration is preserved
+(it's a pure translation, not a stretch). Whether that's correct depends on
+humanize's intent — does `timing_offset_ms` mean "nudge the whole note" or
+"nudge the onset only"? Check `backend/services/humanize.py` and the schema
+docstring on `ExpressiveNote`. Two possible fixes:
+
+- **If onset-only:** apply the offset only to `onset` and let `offset`
+  absorb a duration change, OR introduce a separate release-offset field.
+- **If whole-note shift:** current code is correct; document it and close
+  the issue.
+
+The L1 MIDI round-trip test (fixture 8) will fail either way; resolving it
+forces the decision to be made explicit.
+
+**Effort: S (after decision). Risk: low — test will pin behavior.**
+
+### 1.3 Render dynamics from `perf.expression.dynamics`
+Currently zero lines reference `perf.expression.dynamics` in engrave, even
+though humanize populates them at `humanize.py:101-114`. In the RH part
+loop (`engrave.py:186-227`), after `part.append(clef)`, walk
+`perf.expression.dynamics`:
+
+- `pp/p/mp/mf/f/ff` → `music21.dynamics.Dynamic(type)` inserted at `dyn.beat`
+- `crescendo/decrescendo` → `music21.dynamics.Crescendo()` / `Diminuendo()`
+  spanners using `span_beats` for the end anchor
+
+Attach to RH only so markings sit between staves.
+
+**Effort: S. Risk: low.** Flip flag from 1.1 after this lands.
+
+### 1.4 Render pedal markings in MusicXML
+`engrave.py:111-124` writes CC64 to MIDI only. Add pedal marks to the LH
+part via `music21.expressions.TextExpression("Ped.")` at
+`pedal.onset_beat` and `"*"` at `pedal.offset_beat` (falling back from
+`music21.expressions.PedalMark`, whose support varies across music21
+versions).
+
+**Effort: S. Risk: low — text directions always work.**
+
+### 1.5 Emit sostenuto (CC66) and una_corda (CC67)
+`engrave.py:111-124` hard-codes `pedal.type == "sustain"`. The
+`PedalEvent.type` literal in `shared/shared/contracts.py` already supports
+`sostenuto` and `una_corda`. Add two more branches mapping to CC66/CC67.
+
+**Effort: S. Risk: none.**
+
+### 1.6 Handle fermata articulation
+`engrave.py:203-208` handles staccato/accent/tenuto but drops `fermata`
+from the `Articulation.type` literal. Add:
+`music21.expressions.Fermata()` appended to the note.
+
+Skip `legato` for now — slurs need spanner endpoints that humanize doesn't
+yet emit.
+
+**Effort: S. Risk: none.**
+
+---
+
+## Phase 2 — Renderer infrastructure (medium PRs)
+
+### 2.1 Install LilyPond in the production image — **biggest user-visible win**
+`Dockerfile` currently installs only ffmpeg on `python:3.12-slim`, so
+`_render_pdf_bytes` always returns the 60-byte stub in production. Options
+ranked:
+
+| Option | Size add | Quality | Complexity |
+|---|---|---|---|
+| **LilyPond via apt** | ~250 MB | Excellent engraving, but `musicxml2ly` is lossy (loses chord symbols, some articulations) | S — 3 lines in Dockerfile |
+| MuseScore 4 headless | ~600–900 MB | Highest fidelity | M — Xvfb + Qt deps, 2–5s cold start |
+| Verovio → SVG → cairosvg → PDF | ~10 MB | Modern engraving, MusicXML 4.0 native | M — new code, page-break logic |
+| Server-side OSMD via Playwright | ~300 MB | Visual parity with web viewer | L — Chromium, 1–3s/page, fragile |
+
+**Recommendation: LilyPond first.** Smallest delta from current state,
+ships real PDFs tomorrow. Verovio is the more attractive long-term play
+(smallest image, modern output) but is M-sized new code; schedule as a
+follow-up if LilyPond's `musicxml2ly` loses notation we care about.
+
+**Effort: S. Risk: image size budget review.**
+
+### 2.2 Hard-require music21; delete `_minimal_musicxml`
+The `_minimal_musicxml` fallback at `engrave.py:299-358` is "not bar-aware"
+per its own docstring and would produce unrenderable MusicXML if it ever
+ran in prod. The bare `except Exception` at `engrave.py:237` masks music21
+errors and would silently fall through to this path. Music21 is already
+required in practice — promote it in `pyproject.toml`, delete lines
+299–358 and the import-error branches at 156–160, and let exceptions
+propagate to the job manager so failures are visible.
+
+**Effort: S. Risk: verify no dev environment actually runs without
+music21. Install size is ~30 MB.**
+
+### 2.3 PianoStaff grouping — one part with `<staves>2</staves>`
+Currently each hand is a separate `<part>` named "Right Hand" / "Left
+Hand". Correct piano notation is one `<part>` with two staves and a brace.
+In music21: two `PartStaff` objects wrapped in
+`music21.layout.StaffGroup(..., symbol='brace', barTogether=True)`. See
+how `_minimal_musicxml` already structures this at `engrave.py:344-346`.
+
+**Effort: S (~10 lines around `engrave.py:186-227`). Impact: visible
+improvement — real grand staff instead of two stacked instruments.**
+
+### 2.4 Set `divisionsPerQuarter` upfront; retire the regex sanitizer's
+divisions branch
+The regex sanitizer (`engrave.py:242-296`) exists because music21 picks
+`divisions=10080` and OSMD chokes. Fix it at the source by calling
+`music21.musicxml.m21ToXml.ScoreExporter(score).parse()` with an explicit
+`divisionsPerQuarter=4`, or by invoking `makeNotation(inPlace=True)` at
+the score level with `quarterLengthDivisors` set. This makes durations
+correct *by construction* instead of by integer-rounded ratios (which
+silently truncates anything finer than a 16th).
+
+Keep the voice-collapse regex for now; remove it in 3.1.
+
+**Effort: M. Risk: scoring quirks for tuplets. Mitigation: gate behind a
+feature flag and A/B against fixtures 2, 4, 6 using the harness from
+0.4.**
+
+### 2.5 Multi-tempo MIDI export
+`engrave.py:69` reads only `tempo_map[0].bpm`. The schema supports
+multi-segment tempo maps. `pretty_midi` doesn't expose mid-piece tempo
+writes cleanly; drop to `mido.MidiFile` with `MetaMessage('set_tempo', ...)`
+events. This currently has no user-visible impact because upstream only
+emits constant tempo — ship only after arrange/humanize start producing
+real tempo maps.
+
+**Effort: S–M. Risk: low. Defer until upstream actually varies tempo.**
+
+---
+
+## Phase 3 — Notation quality (medium-to-large PRs)
+
+### 3.1 Preserve voices 1 and 2 per staff
+The biggest visual-readability improvement in this plan. Piano notation is
+*defined* by two voices per staff (stems up = melody, stems down =
+accompaniment). The regex at `engrave.py:294` collapses everything to
+voice 1, destroying music21's voice output.
+
+Two-PR sequence:
+1. Cap `MAX_VOICES_RH` / `MAX_VOICES_LH` at 2 in `arrange.py:40-41`
+   (arrange currently allows 4/3 via greedy first-fit in
+   `arrange.py:194-210`).
+2. Change the OSMD sanitizer to clamp voices ≥3 to 2 instead of
+   collapsing everything to 1; set `n.voice = sn.voice` before insertion
+   in `engrave.py:209` so music21 honors the assignment.
+
+OSMD reliably handles 2 voices per staff — only 3+ are buggy. Validate
+with fixture 4 (`bach_invention_excerpt`) before merging.
+
+**Effort: M. Risk: M — if there really are 2-voice OSMD bugs, nightly
+Playwright test (L6) will catch them before release.**
+
+### 3.2 Chord-symbol cleanup + gated re-enable
+Currently disabled at `engrave.py:211-220` because transcription produces
+noisy labels like "G5", "E5" (pitch names, not chord qualities). Filter
+design:
+
+- Reject any label matching `^[A-G][#b]?\d+$` (those are pitch-and-octave,
+  not chord qualities)
+- Require `music21.harmony.ChordSymbol(label)` parses cleanly AND
+  `len(chord.pitches) >= 3`
+- Gate by `RealtimeChordEvent.confidence` — but note
+  `arrange.py:378-389` drops confidence when converting to
+  `ScoreChordEvent`. **One-line contract change:** add
+  `confidence: float` to `ScoreChordEvent` in
+  `shared/shared/contracts.py:205-209` and propagate.
+
+Wrap each `ChordSymbol` construction in try/except; the parser is
+finicky.
+
+**Effort: M. Risk: M — contract change affects serialization.**
+
+### 3.3 Key signature verification via Krumhansl-Schmuckler
+`engrave.py:171-172` trusts `score.metadata.key` blindly. If transcription
+says `"C:major"` for a piece that's actually F# minor, every accidental
+explodes. music21 ships `analysis.discrete.KrumhanslSchmuckler` — a
+~5-line check. If analyzer confidence is high and disagrees with metadata,
+override and log.
+
+**Effort: M. Risk: low (override is gated on high confidence).**
+
+### 3.4 Quantization grid improvements
+`engrave.py:225` uses `quarterLengthDivisors=(4, 3)` (16ths + triplets).
+Two mutually-exclusive directions:
+
+- **Expand divisor tuple tempo-adaptively:** add 8 (32nds) and 6
+  (sextuplets) at `bpm < 80`; drop to `(4, 3)` only above ~140. Simple
+  but noisy transcriptions fragment into 32nds.
+- **Better:** remove the re-quantize entirely. arrange already quantizes
+  via `_estimate_best_grid` (`arrange.py:67-97`); engrave only
+  re-quantizes because the OSMD sanitizer collapses divisions to 4. Once
+  2.4 lands, engrave can trust arrange's grid.
+
+**Effort: S–M depending on direction. Blocked on 2.4.**
+
+### 3.5 System breaks at section boundaries
+Insert `music21.layout.SystemLayout(isNew=True)` at `ScoreSection`
+boundaries so each verse/chorus starts on a new system. Polish item —
+ship only if users request it.
+
+**Effort: S. Impact: low. Skip until requested.**
+
+---
+
+## Phase 4 — Long-horizon / spikes
+
+### 4.1 Verovio frontend swap (OSMD → Verovio)
+The entire `_sanitize_musicxml_for_osmd` function (`engrave.py:242-296`)
+exists because OSMD's VexFlow backend is limited. Verovio supports
+MusicXML 4.0, unlimited voices, and complex tuplets. Bundle size is ~3–5
+MB (vs OSMD's ~1.5 MB), but the sanitizer disappears and phase 3 becomes
+trivial. **Scope:** Flutter web viewer rewrite in
+`frontend/lib/widgets/sheet_music_viewer_web.dart`.
+
+**Effort: L. Do this as a dedicated spike after phases 0–2 land.**
+
+### 4.2 Fingering via `pianoplayer`
+`pianoplayer` (pip) consumes MusicXML, runs hand-physics search, writes
+fingerings back. Integration point: after `s.write("musicxml", ...)` at
+`engrave.py:232`, shell out and re-read. Adds numpy + scipy dependencies
+(~50 MB) and a few-second runtime hit. Worth it only if users want
+practice-grade scores; `EngravedScoreData.includes_fingering` is
+currently hardcoded `False`.
+
+**Effort: ML–L. Schedule after user demand.**
+
+### 4.3 Voice separation with pitch-continuity bias
+arrange's voice allocator (`arrange.py:194-210`) is overlap-avoidance,
+not musical voice separation. Phase 1: bias voice choice toward the voice
+whose last note is closest in pitch. Phase 2: investigate Temperley's
+Streamer or music21's `makeVoices`. **Belongs in arrange, not engrave.**
+
+---
+
+## Recommended PR sequence
+
+1. **PR-1 (Phase 0.1–0.2):** Score fixtures + L1 MIDI round-trip + L2
+   notation lints. Lands with one known-failing test (`humanized_with_offsets`).
+2. **PR-2 (Phase 0.3–0.4):** L3 XSD + L4 goldens + L5 Verovio + A/B CLI.
+3. **PR-3 (Phase 1.1):** Truthful `EngravedScoreData` flags.
+4. **PR-4 (Phase 1.2):** Resolve `timing_offset_ms` semantics; turn the
+   failing test green.
+5. **PR-5 (Phase 1.3–1.6):** Dynamics + pedal marks + CC66/CC67 + fermata.
+   One combined "stop dropping data" PR.
+6. **PR-6 (Phase 2.1):** LilyPond in Dockerfile. Real PDFs in prod.
+7. **PR-7 (Phase 2.2):** Delete `_minimal_musicxml`; hard-require music21.
+8. **PR-8 (Phase 2.3):** PianoStaff grouping / grand staff.
+9. **PR-9 (Phase 2.4):** `divisionsPerQuarter` upfront; retire divisions
+   regex branch.
+10. **PR-10 (Phase 3.1):** Cap arrange voices at 2 + preserve 2 voices in
+    engrave.
+11. **PR-11 (Phase 3.2):** Chord symbol cleanup + contract tweak + re-enable.
+12. **PR-12 (Phase 3.3):** Key-signature verification.
+13. **PR-13 (Phase 3.4):** Quantization grid rework (only after PR-9).
+
+PRs 1–2 unlock everything else. PRs 3–6 are all S-sized and land in the
+first week. PRs 7–13 are each reviewable against the harness.
+
+---
+
+## Key file:line references
+
+- `backend/services/engrave.py:87-88` — `timing_offset_ms` applied to both
+  onset and offset
+- `backend/services/engrave.py:111-124` — sustain-only pedal filter,
+  MIDI-only output
+- `backend/services/engrave.py:162-227` — music21 score build (no dynamics,
+  no pedal marks)
+- `backend/services/engrave.py:211-220` — disabled chord symbols
+- `backend/services/engrave.py:225` — `quarterLengthDivisors=(4, 3)`
+- `backend/services/engrave.py:237` — bare `except Exception`, masks
+  music21 errors
+- `backend/services/engrave.py:242-296` — OSMD regex sanitizer
+- `backend/services/engrave.py:294` — voice-collapse-to-1
+- `backend/services/engrave.py:299-358` — `_minimal_musicxml` (not
+  bar-aware, latent footgun)
+- `backend/services/engrave.py:378-421` — PDF rendering (stubs in prod)
+- `backend/services/engrave.py:512-526` — `EngravedScoreData` flags that
+  lie
+- `backend/services/humanize.py:101-114` — dynamics generated then dropped
+- `backend/services/arrange.py:40-41` — `MAX_VOICES_RH=4`,
+  `MAX_VOICES_LH=3`
+- `backend/services/arrange.py:194-210` — greedy voice allocator
+- `backend/services/arrange.py:378-389` — chord confidence dropped on
+  conversion
+- `shared/shared/contracts.py` — `ScoreChordEvent` lacks `confidence`;
+  `PedalEvent.type` already supports sostenuto/una_corda;
+  `ExpressionMap.dynamics` already supports crescendo/decrescendo
+- `Dockerfile` — no MuseScore/LilyPond in production image
+- `tests/test_stages.py` — existing `_piano_score()` /
+  `_humanized_performance()` builders, promote to fixture loader
+- `tests/conftest.py` — reuse `isolated_blob_root` fixture
+
+---
+
+## What this plan does *not* do
+
+- No speculative refactors of the engrave service structure. The file is
+  ~500 lines and single-purpose; it doesn't need to be split.
+- No runtime performance work. engrave is not on any hot path.
+- No new file format outputs (ABC, MEI, etc.) — users want PDF + MIDI.
+- No upstream pipeline changes except the minimal ones called out
+  (voice caps in arrange, `confidence` on `ScoreChordEvent`).
+
+## Open questions for follow-up
+
+1. Does `timing_offset_ms` mean "nudge the whole note" or "nudge the
+   onset only"? Requires a read of `humanize.py` and a product-intent
+   call.
+2. Is music21 actually an optional dep or already required? Check
+   `pyproject.toml` before PR-7.
+3. What's the image size budget for Cloud Run? LilyPond adds ~250 MB —
+   need a deploy-side yes/no before PR-6.
+4. Is the frontend team open to a Verovio spike, or is OSMD a hard
+   constraint? Determines whether Phase 4.1 is even worth scoping.

--- a/frontend/lib/api/client.dart
+++ b/frontend/lib/api/client.dart
@@ -58,12 +58,22 @@ class OhSheetApi {
   // ---- jobs ------------------------------------------------------------
 
   /// Submit a job. Provide exactly one of ``audio``, ``midi``, or ``title``.
+  ///
+  /// ``preferCleanSource`` opts the user into the backend's clean-source
+  /// search fast path: when true, the ingest stage looks for a piano or
+  /// 8-bit cover of the song and transcribes that instead of the
+  /// original YouTube URL. Pass ``null`` (the default) to omit the
+  /// field entirely from the request body. Caller code for audio / MIDI
+  /// / plain-title modes should not pass this parameter at all — it is
+  /// meaningful only for YouTube URL submissions, and shipping it
+  /// anyway is semantic noise in request logs (PR #47 review #4).
   Future<JobSummary> createJob({
     RemoteAudioFile? audio,
     RemoteMidiFile? midi,
     String? title,
     String? artist,
     bool skipHumanizer = false,
+    bool? preferCleanSource,
   }) async {
     final body = <String, dynamic>{
       if (audio != null) 'audio': audio.toJson(),
@@ -71,6 +81,7 @@ class OhSheetApi {
       if (title != null && title.isNotEmpty) 'title': title,
       if (artist != null && artist.isNotEmpty) 'artist': artist,
       'skip_humanizer': skipHumanizer,
+      if (preferCleanSource != null) 'prefer_clean_source': preferCleanSource,
     };
     final response = await _client.post(
       _u('/v1/jobs'),

--- a/frontend/lib/screens/upload_screen.dart
+++ b/frontend/lib/screens/upload_screen.dart
@@ -34,6 +34,13 @@ class _UploadScreenState extends State<UploadScreen> {
   bool _submitting = false;
   String? _error;
 
+  // Opt-in for the backend cover_search fast path. Only surfaced in
+  // YouTube mode because it's meaningless for audio uploads (user
+  // already picked the source) and plain title lookups (no URL to swap).
+  // Defaults off so the user's first experience matches what they
+  // pasted; they can flip it on once they see the option.
+  bool _preferCleanSource = false;
+
   static final _youtubeRegex = RegExp(
     r'^https?://(www\.|music\.|m\.)?youtu(\.be/|be\.com/watch\?v=)([\w-]{11})',
   );
@@ -135,6 +142,7 @@ class _UploadScreenState extends State<UploadScreen> {
             artist: _artistController.text.trim().isEmpty
                 ? null
                 : _artistController.text.trim(),
+            preferCleanSource: _preferCleanSource,
           );
           break;
       }
@@ -238,6 +246,15 @@ class _UploadScreenState extends State<UploadScreen> {
                             _mode = s.first;
                             _pickedFile = null;
                             _error = null;
+                            // Reset clean-source opt-in on every mode
+                            // change. The toggle is YouTube-only; letting
+                            // its state persist across a mode switch
+                            // means the user could flip it ON, switch
+                            // to Audio, switch back to YouTube, and
+                            // submit with the flag still set silently —
+                            // the invisible-state footgun PR #47 review
+                            // flagged as (Important).
+                            _preferCleanSource = false;
                           }),
                         ),
                       ),
@@ -302,6 +319,39 @@ class _UploadScreenState extends State<UploadScreen> {
                           controller: _artistController,
                           decoration: const InputDecoration(
                             labelText: 'Artist (optional)',
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        // Clean-source opt-in. When on, the backend searches
+                        // for the best alternative source (easy/moderate piano
+                        // cover OR 8-bit chiptune cover) and transcribes that
+                        // instead of the full-band original. Dramatically
+                        // cleaner output on pop mixes because Basic Pitch is
+                        // much happier with piano-shaped or chiptune-shaped
+                        // audio than with a full band.
+                        SwitchListTile(
+                          key: const ValueKey('ohsheet_prefer_clean_source_toggle'),
+                          contentPadding: EdgeInsets.zero,
+                          dense: true,
+                          value: _preferCleanSource,
+                          onChanged: (v) => setState(() => _preferCleanSource = v),
+                          activeThumbColor: OhSheetColors.teal,
+                          title: const Text(
+                            'Find a clean source',
+                            style: TextStyle(
+                              fontWeight: FontWeight.w700,
+                              fontSize: 14,
+                              color: OhSheetColors.darkText,
+                            ),
+                          ),
+                          subtitle: const Text(
+                            'Search for a piano cover or 8-bit version of '
+                            'this song and transcribe that instead — much '
+                            'cleaner results for full-band pop tracks.',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: OhSheetColors.mutedText,
+                            ),
                           ),
                         ),
                       ] else ...[

--- a/frontend/lib/widgets/version_footer.dart
+++ b/frontend/lib/widgets/version_footer.dart
@@ -1,21 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../theme.dart';
 
-const appVersion = String.fromEnvironment('APP_VERSION', defaultValue: 'dev');
+/// Optional compile-time override (e.g. Docker `--dart-define=APP_VERSION=…`).
+/// When empty, the label comes from [PackageInfo] (semver + build from `pubspec.yaml`).
+const _envVersion = String.fromEnvironment('APP_VERSION', defaultValue: '');
 
 class VersionFooter extends StatelessWidget {
   const VersionFooter({super.key});
 
+  static String _displayFromEnv() {
+    final raw = _envVersion.trim();
+    if (raw.isEmpty) return '';
+    final normalized = raw.startsWith('v') ? raw.substring(1) : raw;
+    return 'v$normalized';
+  }
+
+  static String _displayFromPackageInfo(PackageInfo info) {
+    final build = info.buildNumber.trim();
+    final hasBuild = build.isNotEmpty && build != '0';
+    return hasBuild ? 'v${info.version}+$build' : 'v${info.version}';
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Text(
-      'v$appVersion',
-      style: TextStyle(
-        fontSize: 11,
-        color: OhSheetColors.mutedText.withValues(alpha: 0.5),
-        fontWeight: FontWeight.w500,
-      ),
+    final fromEnv = _displayFromEnv();
+    if (fromEnv.isNotEmpty) {
+      return Text(
+        fromEnv,
+        style: TextStyle(
+          fontSize: 11,
+          color: OhSheetColors.mutedText.withValues(alpha: 0.5),
+          fontWeight: FontWeight.w500,
+        ),
+      );
+    }
+
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox(height: 14);
+        }
+        final label = _displayFromPackageInfo(snapshot.data!);
+        return Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            color: OhSheetColors.mutedText.withValues(alpha: 0.5),
+            fontWeight: FontWeight.w500,
+          ),
+        );
+      },
     );
   }
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -200,6 +200,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   file_picker: ^8.0.0
   url_launcher: ^6.2.5
   flutter_svg: ^2.2.4
+  package_info_plus: ^8.1.2
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/frontend/test/upload_screen_cover_search_test.dart
+++ b/frontend/test/upload_screen_cover_search_test.dart
@@ -1,0 +1,196 @@
+// TDD: Tests for the "Find a clean piano cover" toggle on UploadScreen.
+//
+// This toggle is the frontend half of the cover_search feature. When on,
+// the UploadScreen passes prefer_clean_source=true in the POST /v1/jobs
+// body. The backend (IngestService) then probes the YouTube URL for
+// metadata and searches for a clean piano cover to transcribe instead.
+//
+// The toggle only appears in YouTube mode — it's meaningless for audio
+// uploads (user already picked their source) and title-only lookups
+// (no YouTube URL to swap).
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+
+import 'package:ohsheet_app/api/client.dart';
+import 'package:ohsheet_app/screens/upload_screen.dart';
+
+const _youtubeKey = ValueKey('ohsheet_prefer_clean_source_toggle');
+
+OhSheetApi _mockApi(void Function(Map<String, dynamic> body)? onCreateJob) {
+  final mockClient = http_testing.MockClient((request) async {
+    if (request.url.path == '/v1/jobs') {
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+      onCreateJob?.call(body);
+      return http.Response(
+        jsonEncode({
+          'job_id': 'cs-test',
+          'status': 'queued',
+          'variant': 'full',
+          'title': body['title'],
+        }),
+        202,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    return http.Response('Not found', 404);
+  });
+  return OhSheetApi(client: mockClient);
+}
+
+Widget _app(OhSheetApi api) => MaterialApp(home: UploadScreen(api: api));
+
+Future<void> _selectYoutubeMode(WidgetTester tester) async {
+  await tester.tap(find.text('YouTube'));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _enterYoutubeUrl(WidgetTester tester, String url) async {
+  await tester.enterText(find.widgetWithText(TextField, 'YouTube URL'), url);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _submit(WidgetTester tester) async {
+  await tester.ensureVisible(find.byKey(const ValueKey('ohsheet_primary_submit')));
+  await tester.tap(find.byKey(const ValueKey('ohsheet_primary_submit')));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('Clean-source toggle visibility', () {
+    testWidgets('toggle is visible in YouTube mode', (tester) async {
+      await tester.pumpWidget(_app(_mockApi(null)));
+      await _selectYoutubeMode(tester);
+      expect(find.byKey(_youtubeKey), findsOneWidget);
+    });
+
+    testWidgets('toggle is NOT visible in audio mode', (tester) async {
+      await tester.pumpWidget(_app(_mockApi(null)));
+      // Default mode is audio — confirm toggle doesn't appear.
+      expect(find.byKey(_youtubeKey), findsNothing);
+    });
+
+    testWidgets('toggle is NOT visible in MIDI mode', (tester) async {
+      await tester.pumpWidget(_app(_mockApi(null)));
+      await tester.tap(find.text('MIDI'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(_youtubeKey), findsNothing);
+    });
+
+    testWidgets('toggle is NOT visible in title mode', (tester) async {
+      await tester.pumpWidget(_app(_mockApi(null)));
+      await tester.tap(find.text('Title'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(_youtubeKey), findsNothing);
+    });
+  });
+
+  group('Clean-source toggle submission', () {
+    testWidgets('toggle defaults to OFF and submits prefer_clean_source=false',
+        (tester) async {
+      Map<String, dynamic>? captured;
+      await tester.pumpWidget(_app(_mockApi((body) => captured = body)));
+      await _selectYoutubeMode(tester);
+      await _enterYoutubeUrl(tester, 'https://youtu.be/dQw4w9WgXcQ');
+      await _submit(tester);
+
+      expect(captured, isNotNull);
+      // Default off — explicit false in body so backend sees the opt-in clearly.
+      expect(captured!['prefer_clean_source'], false);
+    });
+
+    testWidgets('flipping toggle ON submits prefer_clean_source=true',
+        (tester) async {
+      Map<String, dynamic>? captured;
+      await tester.pumpWidget(_app(_mockApi((body) => captured = body)));
+      await _selectYoutubeMode(tester);
+      await _enterYoutubeUrl(tester, 'https://youtu.be/dQw4w9WgXcQ');
+
+      // Flip the toggle on. The SwitchListTile is identified by key.
+      // Scroll into view first — the toggle sits below the artist field
+      // and the test viewport may not show it by default.
+      await tester.ensureVisible(find.byKey(_youtubeKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(_youtubeKey));
+      await tester.pumpAndSettle();
+
+      await _submit(tester);
+
+      expect(captured, isNotNull);
+      expect(captured!['prefer_clean_source'], true);
+    });
+
+    testWidgets(
+        'switching to YouTube shows an explainer mentioning piano cover',
+        (tester) async {
+      await tester.pumpWidget(_app(_mockApi(null)));
+      await _selectYoutubeMode(tester);
+      // Any prose describing what the toggle does — the exact copy is
+      // allowed to change but "piano cover" should anchor the explanation.
+      expect(find.textContaining('piano cover'), findsAtLeastNWidgets(1));
+    });
+  });
+
+  // PR #47 review, (Important) #2: toggle state must reset when the
+  // user switches away from YouTube mode. Otherwise the flag survives
+  // invisibly — toggle ON → switch to Audio → switch back to YouTube →
+  // the toggle control shows off but the underlying state is still on,
+  // so the submitted request carries prefer_clean_source=true without
+  // the user intending it.
+  group('Clean-source toggle state lifecycle', () {
+    testWidgets(
+        'toggle resets to OFF after switching modes away and back',
+        (tester) async {
+      Map<String, dynamic>? captured;
+      await tester.pumpWidget(_app(_mockApi((body) => captured = body)));
+
+      // 1. Enter YouTube mode and flip the toggle ON.
+      await _selectYoutubeMode(tester);
+      await tester.ensureVisible(find.byKey(_youtubeKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(_youtubeKey));
+      await tester.pumpAndSettle();
+
+      // 2. Switch away to Audio, then back to YouTube.
+      await tester.tap(find.text('Audio'));
+      await tester.pumpAndSettle();
+      await _selectYoutubeMode(tester);
+
+      // 3. The toggle should now be visually OFF and submit false.
+      await _enterYoutubeUrl(tester, 'https://youtu.be/dQw4w9WgXcQ');
+      await _submit(tester);
+
+      expect(captured, isNotNull);
+      expect(
+        captured!['prefer_clean_source'],
+        false,
+        reason: 'Toggle must reset to off when switching modes away and back',
+      );
+    });
+
+    // PR #47 review, (Minor) #4: title-lookup / audio / MIDI submissions
+    // should NOT serialize prefer_clean_source at all. It's meaningless
+    // for those modes — the backend ignores it — but shipping it anyway
+    // is semantic noise in request logs.
+    testWidgets(
+        'title-mode submission does not include prefer_clean_source',
+        (tester) async {
+      Map<String, dynamic>? captured;
+      await tester.pumpWidget(_app(_mockApi((body) => captured = body)));
+      await tester.tap(find.text('Title'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Song title (required)'),
+        'Yesterday',
+      );
+      await tester.pumpAndSettle();
+      await _submit(tester);
+
+      expect(captured, isNotNull);
+      expect(captured!.containsKey('prefer_clean_source'), false);
+    });
+  });
+}

--- a/frontend/test/widgets/version_footer_test.dart
+++ b/frontend/test/widgets/version_footer_test.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ohsheet_app/widgets/version_footer.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 void main() {
-  testWidgets('VersionFooter displays version text', (tester) async {
+  testWidgets('VersionFooter shows pubspec version when APP_VERSION unset', (tester) async {
+    PackageInfo.setMockInitialValues(
+      appName: 'Oh Sheet',
+      packageName: 'ohsheet_app',
+      version: '0.1.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -11,8 +20,8 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
-    // Default value when APP_VERSION is not defined at compile time
-    expect(find.text('vdev'), findsOneWidget);
+    expect(find.text('v0.1.0+1'), findsOneWidget);
   });
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dev = [
     "httpx>=0.26",
     "ruff>=0.4",
     "mypy>=1.10",
+    # Engrave-evaluation harness: lxml drives the xpath lints that check
+    # the MusicXML music21 emits (see tests/test_engrave_quality.py and
+    # docs/engrave-improvement-plan.md Phase 0.2 Layer L2).
+    "lxml>=5.0",
 ]
 youtube = [
     "yt-dlp>=2024.1",

--- a/shared/shared/contracts.py
+++ b/shared/shared/contracts.py
@@ -129,6 +129,12 @@ class InputMetadata(BaseModel):
     title: str | None = None
     artist: str | None = None
     source: Literal["title_lookup", "audio_upload", "midi_upload"]
+    # When True, the ingest stage will attempt to find a clean piano
+    # cover of the song (via yt-dlp search + scoring) and swap the
+    # user's URL for the cover's URL before transcription. See
+    # backend/services/cover_search.py for the matching logic.
+    # Defaults to False so existing callers and fixtures keep working.
+    prefer_clean_source: bool = False
 
 
 class InputBundle(BaseModel):

--- a/shared/shared/contracts.py
+++ b/shared/shared/contracts.py
@@ -207,6 +207,10 @@ class ScoreChordEvent(BaseModel):
     duration_beat: float
     label: str                                 # Harte notation
     root: int
+    # Propagated from the upstream ``RealtimeChordEvent`` so engrave can
+    # gate chord-symbol rendering on transcriber confidence. Defaults to
+    # 1.0 for legacy/test inputs that don't carry a confidence score.
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class ScoreSection(BaseModel):
@@ -244,6 +248,9 @@ class ExpressiveNote(BaseModel):
     velocity: int = Field(..., ge=0, le=127)
     hand: Literal["rh", "lh"]
     voice: int
+    # Onset-only nudge: engrave applies this to the attack time and leaves the
+    # release on the metronomic grid, so a positive value shortens the note
+    # and a negative value lengthens it. Do not interpret as a whole-note shift.
     timing_offset_ms: float = Field(..., ge=-50.0, le=50.0)
     velocity_offset: int = Field(..., ge=-30, le=30)
 

--- a/shared/shared/storage/local.py
+++ b/shared/shared/storage/local.py
@@ -46,6 +46,24 @@ class LocalBlobStore:
     def get_bytes(self, uri: str) -> bytes:
         return self._path_from_uri(uri).read_bytes()
 
+    def exists(self, uri: str) -> bool:
+        """Return True iff ``uri`` points to a readable blob in this store.
+
+        Safely handles:
+          * Non-``file://`` schemes (returns False)
+          * URIs whose resolved path escapes the blob root (returns False)
+          * Paths that simply don't exist (returns False)
+
+        Any ``ValueError`` from ``_path_from_uri`` is treated as "not in
+        this store" rather than re-raised, so callers can use this as a
+        simple truthy existence check without catching exceptions.
+        """
+        try:
+            path = self._path_from_uri(uri)
+        except ValueError:
+            return False
+        return path.is_file()
+
     # ---- json convenience ------------------------------------------------
 
     def put_json(self, key: str, payload: dict[str, Any]) -> str:

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,11 @@
+"""Shared score fixtures for engrave quality tests.
+
+Re-exports :func:`load_score_fixture` for convenience::
+
+    from tests.fixtures import load_score_fixture
+
+    score = load_score_fixture("c_major_scale")
+"""
+from tests.fixtures._builders import FIXTURE_NAMES, load_score_fixture
+
+__all__ = ["FIXTURE_NAMES", "load_score_fixture"]

--- a/tests/fixtures/_builders.py
+++ b/tests/fixtures/_builders.py
@@ -1,0 +1,613 @@
+"""Hand-authored score fixtures for the engrave evaluation harness.
+
+The ten fixtures below cover the cases that matter for engrave quality:
+trivial baselines, voice/staff separation, accidentals, irregular meter,
+multi-segment tempo, timing offsets, edge cases (empty LH, same-pitch
+overlap). They are the foundation for the L1–L5 test layers described in
+``docs/engrave-improvement-plan.md``.
+
+Each fixture is built as a Pydantic model (``PianoScore`` or
+``HumanizedPerformance``) and serialized to JSON under
+``tests/fixtures/scores/``. The loader re-parses via Pydantic so schema
+drift is caught as a validation error at test-collection time.
+
+To regenerate all fixture JSON files after a contract change::
+
+    python -m tests.fixtures._builders
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from backend.contracts import (
+    SCHEMA_VERSION,
+    Articulation,
+    DynamicMarking,
+    ExpressionMap,
+    ExpressiveNote,
+    HumanizedPerformance,
+    PedalEvent,
+    PianoScore,
+    QualitySignal,
+    ScoreChordEvent,
+    ScoreMetadata,
+    ScoreNote,
+    TempoMapEntry,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "scores"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers to keep the builders below readable
+# ---------------------------------------------------------------------------
+
+def _tempo(bpm: float = 120.0) -> list[TempoMapEntry]:
+    return [TempoMapEntry(time_sec=0.0, beat=0.0, bpm=bpm)]
+
+
+def _meta(
+    *,
+    key: str = "C:major",
+    time_signature: tuple[int, int] = (4, 4),
+    tempo_map: list[TempoMapEntry] | None = None,
+    chord_symbols: list[ScoreChordEvent] | None = None,
+) -> ScoreMetadata:
+    return ScoreMetadata(
+        key=key,
+        time_signature=time_signature,
+        tempo_map=tempo_map or _tempo(),
+        difficulty="intermediate",
+        sections=[],
+        chord_symbols=chord_symbols or [],
+    )
+
+
+def _rh(idx: int, pitch: int, onset: float, duration: float,
+        *, velocity: int = 80, voice: int = 1) -> ScoreNote:
+    return ScoreNote(
+        id=f"rh-{idx:04d}",
+        pitch=pitch,
+        onset_beat=onset,
+        duration_beat=duration,
+        velocity=velocity,
+        voice=voice,
+    )
+
+
+def _lh(idx: int, pitch: int, onset: float, duration: float,
+        *, velocity: int = 70, voice: int = 1) -> ScoreNote:
+    return ScoreNote(
+        id=f"lh-{idx:04d}",
+        pitch=pitch,
+        onset_beat=onset,
+        duration_beat=duration,
+        velocity=velocity,
+        voice=voice,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+def build_single_note() -> PianoScore:
+    """Trivial baseline — one RH C4 whole note."""
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=[_rh(0, pitch=60, onset=0.0, duration=4.0)],
+        left_hand=[],
+        metadata=_meta(),
+    )
+
+
+def build_c_major_scale() -> PianoScore:
+    """RH one-octave C major scale in quarters; LH two whole-note C3 pedal tones."""
+    pitches = [60, 62, 64, 65, 67, 69, 71, 72]  # C4..C5
+    rh = [_rh(i, pitch=p, onset=float(i), duration=1.0) for i, p in enumerate(pitches)]
+    lh = [
+        _lh(0, pitch=48, onset=0.0, duration=4.0),
+        _lh(1, pitch=48, onset=4.0, duration=4.0),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_two_hand_chordal() -> PianoScore:
+    """Four quarter-note triads over octave bass — exercises <staff> separation."""
+    # RH: C-E-G, F-A-C, G-B-D, C-E-G (I – IV – V – I)
+    triads = [
+        (60, 64, 67),  # C major
+        (65, 69, 72),  # F major
+        (67, 71, 74),  # G major
+        (60, 64, 67),  # C major
+    ]
+    rh: list[ScoreNote] = []
+    idx = 0
+    for beat, triad in enumerate(triads):
+        for p in triad:
+            rh.append(_rh(idx, pitch=p, onset=float(beat), duration=1.0))
+            idx += 1
+
+    # LH: octaves on the root of each chord (e.g. C2 + C3)
+    roots = [36, 41, 43, 36]
+    lh: list[ScoreNote] = []
+    idx = 0
+    for beat, root in enumerate(roots):
+        lh.append(_lh(idx, pitch=root, onset=float(beat), duration=1.0))
+        idx += 1
+        lh.append(_lh(idx, pitch=root + 12, onset=float(beat), duration=1.0))
+        idx += 1
+
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_bach_invention_excerpt() -> PianoScore:
+    """Eight quarters of two-voice counterpoint in the RH — the voice-handling fixture.
+
+    Not a real Bach quote; just two independent lines in the same staff
+    with different rhythms and pitches so the voice=1/voice=2 assignment
+    is unambiguous and any collapse to a single voice is visible.
+    """
+    # Voice 1 — upper line, quarter notes ascending
+    v1_pitches = [72, 74, 76, 77, 79, 77, 76, 74]  # C5..
+    voice1 = [
+        _rh(i, pitch=p, onset=float(i), duration=1.0, voice=1)
+        for i, p in enumerate(v1_pitches)
+    ]
+    # Voice 2 — lower line, half-note pulses
+    v2_pitches = [60, 64, 65, 64]
+    voice2 = [
+        _rh(100 + i, pitch=p, onset=float(i * 2), duration=2.0, voice=2)
+        for i, p in enumerate(v2_pitches)
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=voice1 + voice2,
+        left_hand=[],
+        metadata=_meta(time_signature=(4, 4)),
+    )
+
+
+def build_jazz_voicings() -> PianoScore:
+    """Chromatic walking bass + 7th-chord shells above — exercises accidentals."""
+    # LH walking bass: C2, C#2, D2, D#2, E2, F2, F#2, G2
+    lh = [
+        _lh(i, pitch=36 + i, onset=float(i), duration=1.0)
+        for i in range(8)
+    ]
+    # RH shells — 3rd and 7th of each chord. Cmaj7, C#7, Dm7, D#dim7,
+    # Emaj7, F7, F#m7b5, G7. Just two voices per hit.
+    shells = [
+        (64, 71),  # Cmaj7: E + B
+        (61, 70),  # C#7: C#(Db) + B(Bb as 7)
+        (65, 72),  # Dm7: F + C
+        (66, 72),  # D#dim7: F#(Gb) + C
+        (68, 75),  # Emaj7: G#(Ab) + D#(Eb)
+        (69, 75),  # F7: A + Eb
+        (69, 76),  # F#m7b5: A + E
+        (71, 77),  # G7: B + F
+    ]
+    rh: list[ScoreNote] = []
+    idx = 0
+    for beat, (low, high) in enumerate(shells):
+        rh.append(_rh(idx, pitch=low, onset=float(beat), duration=1.0))
+        idx += 1
+        rh.append(_rh(idx, pitch=high, onset=float(beat), duration=1.0))
+        idx += 1
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_seven_eight() -> PianoScore:
+    """7/8 irregular-meter fixture — tests time-sig propagation & grouping."""
+    # Seven eighth-note pulses in the RH (2+2+3 grouping).
+    durations = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    pitches = [60, 62, 64, 65, 67, 69, 71]
+    rh: list[ScoreNote] = []
+    onset = 0.0
+    for i, (p, d) in enumerate(zip(pitches, durations)):
+        rh.append(_rh(i, pitch=p, onset=onset, duration=d))
+        onset += d
+
+    # LH: one dotted-half per 7/8 bar, pinned to the downbeat
+    lh = [_lh(0, pitch=48, onset=0.0, duration=3.5)]
+
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(time_signature=(7, 8)),
+    )
+
+
+def build_tempo_change() -> PianoScore:
+    """Multi-segment tempo map (120 → 90 halfway through)."""
+    tempo_map = [
+        TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0),
+        TempoMapEntry(time_sec=2.0, beat=4.0, bpm=90.0),
+    ]
+    rh = [
+        _rh(i, pitch=60 + (i * 2), onset=float(i), duration=1.0)
+        for i in range(8)
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(tempo_map=tempo_map),
+    )
+
+
+def build_empty_left_hand() -> PianoScore:
+    """RH-only — catches the no-note backup / empty-staff logic in engrave."""
+    rh = [
+        _rh(0, pitch=67, onset=0.0, duration=1.0),
+        _rh(1, pitch=69, onset=1.0, duration=1.0),
+        _rh(2, pitch=71, onset=2.0, duration=1.0),
+        _rh(3, pitch=72, onset=3.0, duration=1.0),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(),
+    )
+
+
+def build_overlapping_same_pitch() -> PianoScore:
+    """Two overlapping C4s — exercises the same-pitch overlap resolver in engrave."""
+    rh = [
+        _rh(0, pitch=60, onset=0.0, duration=2.0),
+        _rh(1, pitch=60, onset=1.0, duration=2.0),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(),
+    )
+
+
+def build_triplet_eighths() -> PianoScore:
+    """Triplet-8ths grid — the PR-13 tuplet-survival fixture.
+
+    A bar of straight quarter-note LH root on C2, under an RH line of
+    four 8th-note triplets (12 notes total over 4 beats). Each triplet
+    subdivision lands on a 1/3-beat onset — clean arrange-grid output
+    that requires music21's ``makeNotation`` to auto-detect the tuplet
+    bracket without an explicit ``quantize(quarterLengthDivisors=...)``
+    hint.
+
+    After PR-13 engrave no longer re-quantizes inside ``_render_musicxml_bytes``
+    (arrange's grid is trusted directly), so this fixture is the
+    canary for the tuplet path. Expected output: each triplet 8th
+    carries ``<time-modification>`` with ``<actual-notes>3</actual-notes>``
+    + ``<normal-notes>2</normal-notes>`` in the MusicXML.
+    """
+    # Four beats of triplet-8ths: 12 notes, each at quarter/3 duration.
+    rh: list[ScoreNote] = []
+    for i in range(12):
+        onset = i * (1.0 / 3.0)
+        pitch = 60 + (i % 8)  # ascending C major scale under the triplet grid
+        rh.append(_rh(i, pitch=pitch, onset=onset, duration=1.0 / 3.0))
+
+    lh = [
+        _lh(i, pitch=36, onset=float(i), duration=1.0)
+        for i in range(4)
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(),
+    )
+
+
+def build_mislabeled_key() -> PianoScore:
+    """F# minor piece mislabeled as C major — the PR-12 KS override fixture.
+
+    Every RH note is drawn from the F# natural minor scale
+    (F#, G#, A, B, C#, D, E) with F# as the tonal center. The LH
+    reinforces F# as bass. The metadata key lies: it claims
+    ``C:major``. The Krumhansl-Schmuckler analyzer in
+    ``_resolve_key_signature`` should detect the real F# minor tonic,
+    report correlation ≥0.85, and override to F# minor before the key
+    signature reaches ``<key><fifths>`` in MusicXML.
+
+    Expected MusicXML ``<fifths>`` value after override: ``3``
+    (F# minor has three sharps). Without the override it would be ``0``
+    (C major, no sharps or flats), and every F#/G#/C# in the piece
+    would come out as an explicit accidental.
+    """
+    # F# minor scale + tonic arpeggios, thick enough that KS returns
+    # a solid correlation well above the 0.80 override floor. Tonic
+    # F#4 = pitch 66; scale is F#, G#, A, B, C#, D, E (natural minor).
+    scale = [66, 68, 69, 71, 73, 74, 76]  # F#4..E5
+    tonic_arp = [66, 69, 73, 78]          # F# A C# F# (i triad, emphasize tonic)
+    # Repeat scale up+down twice, separated by i-chord arpeggios, so
+    # the pitch histogram is emphatically weighted toward the F# minor
+    # scale degrees. Also rules out the "relative major" (A:major)
+    # trap — plain scale notes alone can correlate just as well with
+    # the parallel major.
+    pattern = (
+        scale + list(reversed(scale))
+        + tonic_arp + tonic_arp
+        + scale + list(reversed(scale))
+        + tonic_arp + [66, 66, 66, 66]     # hammer the tonic home
+    )
+    rh = [
+        _rh(i, pitch=p, onset=float(i) * 0.5, duration=0.5)
+        for i, p in enumerate(pattern)
+    ]
+    # LH reinforces F# as bass — F#2 pedal tones under every phrase so
+    # the analyzer sees the real tonic loud and clear.
+    lh_beats = 4
+    lh = [
+        _lh(i, pitch=42, onset=float(i * lh_beats), duration=float(lh_beats))
+        for i in range(len(rh) // (lh_beats * 2))
+    ] or [_lh(0, pitch=42, onset=0.0, duration=float(lh_beats))]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=lh,
+        metadata=_meta(key="C:major"),  # the lie
+    )
+
+
+def build_chord_symbols() -> PianoScore:
+    """Mixed-quality chord symbols — the PR-11 filter-gate fixture.
+
+    Seven input chord symbols that exercise every branch of
+    ``_attach_chord_symbols``:
+
+    1. ``C:maj7`` @ beat 0, conf 0.95 — clean, parses, ≥3 pitches → **rendered**.
+    2. ``Dm7``    @ beat 1, conf 0.90 — no colon, parses, ≥3 pitches → **rendered**.
+    3. ``F:maj7`` @ beat 2, conf 0.85 — colon form, ≥3 pitches → **rendered**.
+    4. ``G5``     @ beat 3, conf 0.80 — pitch-octave shape
+       (``^[A-G][#b]?\\d+$``) → **dropped (shape gate)**.
+    5. ``C:maj``  @ beat 4, conf 0.30 — would parse, but below the
+       0.5 confidence threshold → **dropped (confidence gate)**.
+    6. ``???``    @ beat 5, conf 0.90 — unparseable garbage → **dropped (parse gate)**.
+    7. ``C5``     @ beat 6, conf 0.95 — pitch-octave shape → **dropped (shape gate)**.
+
+    Expected rendered count: **3**. Note the deliberate choice not to
+    test ``G7`` / ``C7`` / ``C9`` — plan phase 3.2 accepts that the
+    ``^[A-G][#b]?\\d+$`` shape gate is aggressive enough to kill
+    dominant-sevenths written as bare ``G7``, because the audio
+    transcriber's false positives dominate the legitimate uses. Callers
+    that want dominant sevenths through this gate should emit Harte
+    colon form (``G:7``) — which the filter strips to ``G7`` for
+    parsing but which still *lexically* fails the shape check.
+
+    Paired with a simple C major melody so the test can focus on
+    harmony output, not note plumbing.
+    """
+    # Two-bar single-line RH so there's something to hang the symbols on.
+    rh = [
+        _rh(i, pitch=p, onset=float(i), duration=1.0)
+        for i, p in enumerate([60, 62, 64, 65, 67, 69, 71, 72])
+    ]
+    chord_symbols = [
+        ScoreChordEvent(beat=0.0, duration_beat=1.0, label="C:maj7", root=60, confidence=0.95),
+        ScoreChordEvent(beat=1.0, duration_beat=1.0, label="Dm7",    root=62, confidence=0.90),
+        ScoreChordEvent(beat=2.0, duration_beat=1.0, label="F:maj7", root=65, confidence=0.85),
+        ScoreChordEvent(beat=3.0, duration_beat=1.0, label="G5",     root=67, confidence=0.80),
+        ScoreChordEvent(beat=4.0, duration_beat=1.0, label="C:maj",  root=60, confidence=0.30),
+        ScoreChordEvent(beat=5.0, duration_beat=1.0, label="???",    root=60, confidence=0.90),
+        ScoreChordEvent(beat=6.0, duration_beat=1.0, label="C5",     root=60, confidence=0.95),
+    ]
+    return PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=rh,
+        left_hand=[],
+        metadata=_meta(chord_symbols=chord_symbols),
+    )
+
+
+def build_humanized_with_offsets() -> HumanizedPerformance:
+    """C major scale wrapped as a HumanizedPerformance with timing offsets + a pedal event.
+
+    This is **the timing-bug fixture** — ``timing_offset_ms`` values are
+    non-zero and alternate in sign so the round-trip test can verify
+    whether the shift is onset-only or a whole-note translation (see
+    ``engrave.py:87-88``). Also includes one sustain-pedal event so L1
+    can verify pedal events reach the MIDI output.
+    """
+    base = build_c_major_scale()
+
+    # Alternating ±20ms offsets across the RH scale notes; LH whole notes
+    # stay at 0 so any timing drift in the LH clearly comes from engrave,
+    # not the fixture.
+    timing = [20.0, -20.0, 15.0, -15.0, 10.0, -10.0, 5.0, -5.0]
+    expressive_notes = [
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="rh",
+            voice=n.voice,
+            timing_offset_ms=t,
+            velocity_offset=0,
+        )
+        for n, t in zip(base.right_hand, timing)
+    ]
+    expressive_notes.extend(
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="lh",
+            voice=n.voice,
+            timing_offset_ms=0.0,
+            velocity_offset=0,
+        )
+        for n in base.left_hand
+    )
+
+    expression = ExpressionMap(
+        dynamics=[],
+        articulations=[],
+        pedal_events=[
+            PedalEvent(onset_beat=0.0, offset_beat=8.0, type="sustain"),
+        ],
+        tempo_changes=[],
+    )
+
+    return HumanizedPerformance(
+        schema_version=SCHEMA_VERSION,
+        expressive_notes=expressive_notes,
+        expression=expression,
+        score=base,
+        quality=QualitySignal(overall_confidence=0.9, warnings=[]),
+    )
+
+
+def build_humanized_with_expression() -> HumanizedPerformance:
+    """The "stop dropping data" fixture — dynamics, pedal variants, fermata.
+
+    Exercises every branch of plan PR-5 (phase 1.3–1.6): a static
+    dynamic (``p``) at bar 1 and a hairpin (``crescendo``) spanning bar
+    2, sustain + sostenuto + una_corda pedal events on the LH, and a
+    fermata articulation on the last RH note.
+    """
+    base = build_c_major_scale()
+
+    expressive_notes = [
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="rh",
+            voice=n.voice,
+            timing_offset_ms=0.0,
+            velocity_offset=0,
+        )
+        for n in base.right_hand
+    ]
+    expressive_notes.extend(
+        ExpressiveNote(
+            score_note_id=n.id,
+            pitch=n.pitch,
+            onset_beat=n.onset_beat,
+            duration_beat=n.duration_beat,
+            velocity=n.velocity,
+            hand="lh",
+            voice=n.voice,
+            timing_offset_ms=0.0,
+            velocity_offset=0,
+        )
+        for n in base.left_hand
+    )
+
+    # Pedal offsets are pulled just inside the final beat. music21 drops
+    # direction elements inserted at the exact barline past the last note,
+    # so "Ped. / *" lifts at the very end of the piece never reach MusicXML.
+    # A ~16th-note release is still audible in the MIDI output.
+    last_rh_id = base.right_hand[-1].id
+    expression = ExpressionMap(
+        dynamics=[
+            DynamicMarking(beat=0.0, type="p"),
+            DynamicMarking(beat=4.0, type="crescendo", span_beats=3.5),
+        ],
+        articulations=[
+            Articulation(beat=7.0, hand="rh", score_note_id=last_rh_id, type="fermata"),
+        ],
+        pedal_events=[
+            PedalEvent(onset_beat=0.0, offset_beat=3.5, type="sustain"),
+            PedalEvent(onset_beat=4.0, offset_beat=7.5, type="sostenuto"),
+            PedalEvent(onset_beat=0.0, offset_beat=7.5, type="una_corda"),
+        ],
+        tempo_changes=[],
+    )
+
+    return HumanizedPerformance(
+        schema_version=SCHEMA_VERSION,
+        expressive_notes=expressive_notes,
+        expression=expression,
+        score=base,
+        quality=QualitySignal(overall_confidence=0.9, warnings=[]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry + load + regenerate
+# ---------------------------------------------------------------------------
+
+_BUILDERS: dict[str, Callable[[], PianoScore | HumanizedPerformance]] = {
+    "single_note": build_single_note,
+    "c_major_scale": build_c_major_scale,
+    "two_hand_chordal": build_two_hand_chordal,
+    "bach_invention_excerpt": build_bach_invention_excerpt,
+    "jazz_voicings": build_jazz_voicings,
+    "seven_eight": build_seven_eight,
+    "tempo_change": build_tempo_change,
+    "humanized_with_offsets": build_humanized_with_offsets,
+    "humanized_with_expression": build_humanized_with_expression,
+    "empty_left_hand": build_empty_left_hand,
+    "overlapping_same_pitch": build_overlapping_same_pitch,
+    "chord_symbols": build_chord_symbols,
+    "mislabeled_key": build_mislabeled_key,
+    "triplet_eighths": build_triplet_eighths,
+}
+
+FIXTURE_NAMES: tuple[str, ...] = tuple(_BUILDERS.keys())
+
+# Fixtures that build a HumanizedPerformance rather than a raw PianoScore.
+_HUMANIZED_FIXTURES: frozenset[str] = frozenset({
+    "humanized_with_offsets",
+    "humanized_with_expression",
+})
+
+
+def load_score_fixture(name: str) -> PianoScore | HumanizedPerformance:
+    """Load a committed fixture JSON and re-validate via Pydantic.
+
+    Parsing through the model catches contract drift at test-collection
+    time — if a field is renamed or removed, the fixture is flagged
+    immediately instead of silently producing garbage MusicXML.
+    """
+    path = FIXTURES_DIR / f"{name}.json"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Score fixture {name!r} not found at {path}. "
+            "Run `python -m tests.fixtures._builders` to regenerate.",
+        )
+    raw = json.loads(path.read_text())
+    model = HumanizedPerformance if name in _HUMANIZED_FIXTURES else PianoScore
+    return model.model_validate(raw)
+
+
+def regenerate_all() -> None:
+    """Write every builder's output to ``tests/fixtures/scores/<name>.json``."""
+    FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    for name, builder in _BUILDERS.items():
+        model = builder()
+        path = FIXTURES_DIR / f"{name}.json"
+        path.write_text(model.model_dump_json(indent=2) + "\n")
+        print(f"wrote {path.relative_to(FIXTURES_DIR.parent.parent)}")
+
+
+if __name__ == "__main__":
+    regenerate_all()

--- a/tests/fixtures/scores/bach_invention_excerpt.json
+++ b/tests/fixtures/scores/bach_invention_excerpt.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 72,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 74,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 76,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 77,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 79,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 77,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 76,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 74,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0100",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    },
+    {
+      "id": "rh-0101",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    },
+    {
+      "id": "rh-0102",
+      "pitch": 65,
+      "onset_beat": 4.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    },
+    {
+      "id": "rh-0103",
+      "pitch": 64,
+      "onset_beat": 6.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 2
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/c_major_scale.json
+++ b/tests/fixtures/scores/c_major_scale.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/chord_symbols.json
+++ b/tests/fixtures/scores/chord_symbols.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": [
+      {
+        "beat": 0.0,
+        "duration_beat": 1.0,
+        "label": "C:maj7",
+        "root": 60,
+        "confidence": 0.95
+      },
+      {
+        "beat": 1.0,
+        "duration_beat": 1.0,
+        "label": "Dm7",
+        "root": 62,
+        "confidence": 0.9
+      },
+      {
+        "beat": 2.0,
+        "duration_beat": 1.0,
+        "label": "F:maj7",
+        "root": 65,
+        "confidence": 0.85
+      },
+      {
+        "beat": 3.0,
+        "duration_beat": 1.0,
+        "label": "G5",
+        "root": 67,
+        "confidence": 0.8
+      },
+      {
+        "beat": 4.0,
+        "duration_beat": 1.0,
+        "label": "C:maj",
+        "root": 60,
+        "confidence": 0.3
+      },
+      {
+        "beat": 5.0,
+        "duration_beat": 1.0,
+        "label": "???",
+        "root": 60,
+        "confidence": 0.9
+      },
+      {
+        "beat": 6.0,
+        "duration_beat": 1.0,
+        "label": "C5",
+        "root": 60,
+        "confidence": 0.95
+      }
+    ]
+  }
+}

--- a/tests/fixtures/scores/empty_left_hand.json
+++ b/tests/fixtures/scores/empty_left_hand.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 67,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 69,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 71,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 72,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/humanized_with_expression.json
+++ b/tests/fixtures/scores/humanized_with_expression.json
@@ -1,0 +1,265 @@
+{
+  "schema_version": "3.0.0",
+  "expressive_notes": [
+    {
+      "score_note_id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    }
+  ],
+  "expression": {
+    "dynamics": [
+      {
+        "beat": 0.0,
+        "type": "p",
+        "span_beats": null,
+        "target": null
+      },
+      {
+        "beat": 4.0,
+        "type": "crescendo",
+        "span_beats": 3.5,
+        "target": null
+      }
+    ],
+    "articulations": [
+      {
+        "beat": 7.0,
+        "hand": "rh",
+        "score_note_id": "rh-0007",
+        "type": "fermata"
+      }
+    ],
+    "pedal_events": [
+      {
+        "onset_beat": 0.0,
+        "offset_beat": 3.5,
+        "type": "sustain"
+      },
+      {
+        "onset_beat": 4.0,
+        "offset_beat": 7.5,
+        "type": "sostenuto"
+      },
+      {
+        "onset_beat": 0.0,
+        "offset_beat": 7.5,
+        "type": "una_corda"
+      }
+    ],
+    "tempo_changes": []
+  },
+  "score": {
+    "schema_version": "3.0.0",
+    "right_hand": [
+      {
+        "id": "rh-0000",
+        "pitch": 60,
+        "onset_beat": 0.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0001",
+        "pitch": 62,
+        "onset_beat": 1.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0002",
+        "pitch": 64,
+        "onset_beat": 2.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0003",
+        "pitch": 65,
+        "onset_beat": 3.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0004",
+        "pitch": 67,
+        "onset_beat": 4.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0005",
+        "pitch": 69,
+        "onset_beat": 5.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0006",
+        "pitch": 71,
+        "onset_beat": 6.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0007",
+        "pitch": 72,
+        "onset_beat": 7.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      }
+    ],
+    "left_hand": [
+      {
+        "id": "lh-0000",
+        "pitch": 48,
+        "onset_beat": 0.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      },
+      {
+        "id": "lh-0001",
+        "pitch": 48,
+        "onset_beat": 4.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      }
+    ],
+    "metadata": {
+      "key": "C:major",
+      "time_signature": [
+        4,
+        4
+      ],
+      "tempo_map": [
+        {
+          "time_sec": 0.0,
+          "beat": 0.0,
+          "bpm": 120.0
+        }
+      ],
+      "difficulty": "intermediate",
+      "sections": [],
+      "chord_symbols": []
+    }
+  },
+  "quality": {
+    "overall_confidence": 0.9,
+    "warnings": []
+  }
+}

--- a/tests/fixtures/scores/humanized_with_offsets.json
+++ b/tests/fixtures/scores/humanized_with_offsets.json
@@ -1,0 +1,235 @@
+{
+  "schema_version": "3.0.0",
+  "expressive_notes": [
+    {
+      "score_note_id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 20.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -20.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 15.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -15.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 10.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -10.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": 5.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "hand": "rh",
+      "voice": 1,
+      "timing_offset_ms": -5.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    },
+    {
+      "score_note_id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "hand": "lh",
+      "voice": 1,
+      "timing_offset_ms": 0.0,
+      "velocity_offset": 0
+    }
+  ],
+  "expression": {
+    "dynamics": [],
+    "articulations": [],
+    "pedal_events": [
+      {
+        "onset_beat": 0.0,
+        "offset_beat": 8.0,
+        "type": "sustain"
+      }
+    ],
+    "tempo_changes": []
+  },
+  "score": {
+    "schema_version": "3.0.0",
+    "right_hand": [
+      {
+        "id": "rh-0000",
+        "pitch": 60,
+        "onset_beat": 0.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0001",
+        "pitch": 62,
+        "onset_beat": 1.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0002",
+        "pitch": 64,
+        "onset_beat": 2.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0003",
+        "pitch": 65,
+        "onset_beat": 3.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0004",
+        "pitch": 67,
+        "onset_beat": 4.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0005",
+        "pitch": 69,
+        "onset_beat": 5.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0006",
+        "pitch": 71,
+        "onset_beat": 6.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      },
+      {
+        "id": "rh-0007",
+        "pitch": 72,
+        "onset_beat": 7.0,
+        "duration_beat": 1.0,
+        "velocity": 80,
+        "voice": 1
+      }
+    ],
+    "left_hand": [
+      {
+        "id": "lh-0000",
+        "pitch": 48,
+        "onset_beat": 0.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      },
+      {
+        "id": "lh-0001",
+        "pitch": 48,
+        "onset_beat": 4.0,
+        "duration_beat": 4.0,
+        "velocity": 70,
+        "voice": 1
+      }
+    ],
+    "metadata": {
+      "key": "C:major",
+      "time_signature": [
+        4,
+        4
+      ],
+      "tempo_map": [
+        {
+          "time_sec": 0.0,
+          "beat": 0.0,
+          "bpm": 120.0
+        }
+      ],
+      "difficulty": "intermediate",
+      "sections": [],
+      "chord_symbols": []
+    }
+  },
+  "quality": {
+    "overall_confidence": 0.9,
+    "warnings": []
+  }
+}

--- a/tests/fixtures/scores/jazz_voicings.json
+++ b/tests/fixtures/scores/jazz_voicings.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 64,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 71,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 61,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 70,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 65,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 72,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 66,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 72,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 68,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 75,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 69,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 75,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0012",
+      "pitch": 69,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0013",
+      "pitch": 76,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0014",
+      "pitch": 71,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0015",
+      "pitch": 77,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 36,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 37,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 38,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 39,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0004",
+      "pitch": 40,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0005",
+      "pitch": 41,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0006",
+      "pitch": 42,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0007",
+      "pitch": 43,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/mislabeled_key.json
+++ b/tests/fixtures/scores/mislabeled_key.json
@@ -1,0 +1,416 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 66,
+      "onset_beat": 0.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 68,
+      "onset_beat": 0.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 69,
+      "onset_beat": 1.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 71,
+      "onset_beat": 1.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 73,
+      "onset_beat": 2.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 74,
+      "onset_beat": 2.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 76,
+      "onset_beat": 3.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 76,
+      "onset_beat": 3.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 74,
+      "onset_beat": 4.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 73,
+      "onset_beat": 4.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 71,
+      "onset_beat": 5.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 69,
+      "onset_beat": 5.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0012",
+      "pitch": 68,
+      "onset_beat": 6.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0013",
+      "pitch": 66,
+      "onset_beat": 6.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0014",
+      "pitch": 66,
+      "onset_beat": 7.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0015",
+      "pitch": 69,
+      "onset_beat": 7.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0016",
+      "pitch": 73,
+      "onset_beat": 8.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0017",
+      "pitch": 78,
+      "onset_beat": 8.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0018",
+      "pitch": 66,
+      "onset_beat": 9.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0019",
+      "pitch": 69,
+      "onset_beat": 9.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0020",
+      "pitch": 73,
+      "onset_beat": 10.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0021",
+      "pitch": 78,
+      "onset_beat": 10.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0022",
+      "pitch": 66,
+      "onset_beat": 11.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0023",
+      "pitch": 68,
+      "onset_beat": 11.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0024",
+      "pitch": 69,
+      "onset_beat": 12.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0025",
+      "pitch": 71,
+      "onset_beat": 12.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0026",
+      "pitch": 73,
+      "onset_beat": 13.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0027",
+      "pitch": 74,
+      "onset_beat": 13.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0028",
+      "pitch": 76,
+      "onset_beat": 14.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0029",
+      "pitch": 76,
+      "onset_beat": 14.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0030",
+      "pitch": 74,
+      "onset_beat": 15.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0031",
+      "pitch": 73,
+      "onset_beat": 15.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0032",
+      "pitch": 71,
+      "onset_beat": 16.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0033",
+      "pitch": 69,
+      "onset_beat": 16.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0034",
+      "pitch": 68,
+      "onset_beat": 17.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0035",
+      "pitch": 66,
+      "onset_beat": 17.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0036",
+      "pitch": 66,
+      "onset_beat": 18.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0037",
+      "pitch": 69,
+      "onset_beat": 18.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0038",
+      "pitch": 73,
+      "onset_beat": 19.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0039",
+      "pitch": 78,
+      "onset_beat": 19.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0040",
+      "pitch": 66,
+      "onset_beat": 20.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0041",
+      "pitch": 66,
+      "onset_beat": 20.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0042",
+      "pitch": 66,
+      "onset_beat": 21.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0043",
+      "pitch": 66,
+      "onset_beat": 21.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 42,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 42,
+      "onset_beat": 4.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 42,
+      "onset_beat": 8.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 42,
+      "onset_beat": 12.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0004",
+      "pitch": 42,
+      "onset_beat": 16.0,
+      "duration_beat": 4.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/overlapping_same_pitch.json
+++ b/tests/fixtures/scores/overlapping_same_pitch.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 60,
+      "onset_beat": 1.0,
+      "duration_beat": 2.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/seven_eight.json
+++ b/tests/fixtures/scores/seven_eight.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 0.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 1.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 1.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 67,
+      "onset_beat": 2.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 69,
+      "onset_beat": 2.5,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 71,
+      "onset_beat": 3.0,
+      "duration_beat": 0.5,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 3.5,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      7,
+      8
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/single_note.json
+++ b/tests/fixtures/scores/single_note.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 4.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/tempo_change.json
+++ b/tests/fixtures/scores/tempo_change.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 62,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 64,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 66,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 68,
+      "onset_beat": 4.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 70,
+      "onset_beat": 5.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 72,
+      "onset_beat": 6.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 74,
+      "onset_beat": 7.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      },
+      {
+        "time_sec": 2.0,
+        "beat": 4.0,
+        "bpm": 90.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/triplet_eighths.json
+++ b/tests/fixtures/scores/triplet_eighths.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 61,
+      "onset_beat": 0.3333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 62,
+      "onset_beat": 0.6666666666666666,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 63,
+      "onset_beat": 1.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 64,
+      "onset_beat": 1.3333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 65,
+      "onset_beat": 1.6666666666666665,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 66,
+      "onset_beat": 2.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 67,
+      "onset_beat": 2.333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 60,
+      "onset_beat": 2.6666666666666665,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 61,
+      "onset_beat": 3.0,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 62,
+      "onset_beat": 3.333333333333333,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 63,
+      "onset_beat": 3.6666666666666665,
+      "duration_beat": 0.3333333333333333,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 36,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 36,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 36,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 36,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/fixtures/scores/two_hand_chordal.json
+++ b/tests/fixtures/scores/two_hand_chordal.json
@@ -1,0 +1,184 @@
+{
+  "schema_version": "3.0.0",
+  "right_hand": [
+    {
+      "id": "rh-0000",
+      "pitch": 60,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0001",
+      "pitch": 64,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0002",
+      "pitch": 67,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0003",
+      "pitch": 65,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0004",
+      "pitch": 69,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0005",
+      "pitch": 72,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0006",
+      "pitch": 67,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0007",
+      "pitch": 71,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0008",
+      "pitch": 74,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0009",
+      "pitch": 60,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0010",
+      "pitch": 64,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    },
+    {
+      "id": "rh-0011",
+      "pitch": 67,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 80,
+      "voice": 1
+    }
+  ],
+  "left_hand": [
+    {
+      "id": "lh-0000",
+      "pitch": 36,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0001",
+      "pitch": 48,
+      "onset_beat": 0.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0002",
+      "pitch": 41,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0003",
+      "pitch": 53,
+      "onset_beat": 1.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0004",
+      "pitch": 43,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0005",
+      "pitch": 55,
+      "onset_beat": 2.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0006",
+      "pitch": 36,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    },
+    {
+      "id": "lh-0007",
+      "pitch": 48,
+      "onset_beat": 3.0,
+      "duration_beat": 1.0,
+      "velocity": 70,
+      "voice": 1
+    }
+  ],
+  "metadata": {
+    "key": "C:major",
+    "time_signature": [
+      4,
+      4
+    ],
+    "tempo_map": [
+      {
+        "time_sec": 0.0,
+        "beat": 0.0,
+        "bpm": 120.0
+      }
+    ],
+    "difficulty": "intermediate",
+    "sections": [],
+    "chord_symbols": []
+  }
+}

--- a/tests/test_arrange.py
+++ b/tests/test_arrange.py
@@ -118,6 +118,13 @@ def test_arrange_dedups_same_pitch_across_tracks_keep_loudest() -> None:
 
 
 def test_arrange_beginner_reduces_max_polyphony() -> None:
+    """Voice caps: intermediate=2 RH voices, beginner=1. PR-10 / plan 3.1.
+
+    Three overlapping notes at beat 0 force the voice allocator up to
+    three concurrent voices. Intermediate keeps voices 1 and 2 (the
+    piano cap) and drops the third; beginner keeps only voice 1 and
+    drops both extras.
+    """
     payload = _payload(
         tracks=[
             MidiTrack(
@@ -136,9 +143,10 @@ def test_arrange_beginner_reduces_max_polyphony() -> None:
     beginner = _arrange_sync(payload, "beginner")
     intermediate = _arrange_sync(payload, "intermediate")
 
-    assert len(beginner.right_hand) == 2
-    assert len(intermediate.right_hand) == 3
-    assert max(n.voice for n in beginner.right_hand) <= 2
+    assert len(beginner.right_hand) == 1
+    assert len(intermediate.right_hand) == 2
+    assert max(n.voice for n in intermediate.right_hand) <= 2
+    assert max(n.voice for n in beginner.right_hand) == 1
 
 
 def test_arrange_falls_back_to_all_tracks_when_all_are_other() -> None:

--- a/tests/test_arrange_simplify.py
+++ b/tests/test_arrange_simplify.py
@@ -6,8 +6,6 @@ and returns a simplified copy suitable for sheet-music engraving.
 """
 from __future__ import annotations
 
-import pytest
-
 from shared.contracts import (
     PianoScore,
     ScoreMetadata,

--- a/tests/test_cover_search.py
+++ b/tests/test_cover_search.py
@@ -1,0 +1,1134 @@
+"""TDD tests for the piano cover search fast path.
+
+Module under test: ``backend.services.cover_search`` (doesn't exist yet —
+these tests drive the design).
+
+The feature takes a song title + optional artist and searches YouTube
+for a clean piano cover of that song. If it finds a high-quality match,
+the ingest stage swaps the user's original URL for the cover's URL so
+Basic Pitch gets a monophonic piano recording to transcribe instead of
+a full-band mix.
+
+Tested in three layers:
+
+1. ``normalize_title`` — strips "[Official Video]", "(Lyrics)", etc.
+2. ``score_candidate`` — the scoring rules and threshold policy.
+3. ``find_piano_cover`` — the orchestrator, with yt-dlp mocked.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Layer 1a: title normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTitle:
+    """Strip noise tokens that obscure title comparison."""
+
+    def test_plain_title_unchanged(self):
+        from backend.services.cover_search import normalize_title
+        assert normalize_title("Bohemian Rhapsody") == "bohemian rhapsody"
+
+    def test_lowercase_output(self):
+        from backend.services.cover_search import normalize_title
+        # Normalization must lowercase so case-insensitive substring match works.
+        assert normalize_title("Hotel California") == "hotel california"
+
+    def test_strips_official_video_tag(self):
+        from backend.services.cover_search import normalize_title
+        assert normalize_title("Hotel California [Official Video]") == "hotel california"
+        assert normalize_title("Hotel California (Official Music Video)") == "hotel california"
+        assert normalize_title("Hotel California - Official Video") == "hotel california"
+
+    def test_strips_lyrics_tag(self):
+        from backend.services.cover_search import normalize_title
+        assert normalize_title("Someone Like You (Lyrics)") == "someone like you"
+        assert normalize_title("Someone Like You [Lyric Video]") == "someone like you"
+
+    def test_strips_quality_tags(self):
+        from backend.services.cover_search import normalize_title
+        assert normalize_title("Imagine (HD)") == "imagine"
+        assert normalize_title("Imagine [4K Remaster]") == "imagine"
+        assert normalize_title("Imagine (Remastered 2020)") == "imagine"
+
+    def test_strips_live_tag(self):
+        from backend.services.cover_search import normalize_title
+        assert normalize_title("Hey Jude (Live at Wembley 1988)") == "hey jude"
+
+    def test_collapses_whitespace(self):
+        from backend.services.cover_search import normalize_title
+        # After stripping a tag, leftover whitespace should be normalized.
+        assert normalize_title("Yesterday  [HD]   ") == "yesterday"
+
+    def test_removes_featured_artists(self):
+        from backend.services.cover_search import normalize_title
+        # "feat." is noise for title matching (the artist is a separate field).
+        assert normalize_title("Umbrella feat. Jay-Z") == "umbrella"
+        assert normalize_title("Umbrella (feat. Jay-Z)") == "umbrella"
+        assert normalize_title("Umbrella ft. Jay-Z") == "umbrella"
+
+    def test_empty_or_none_safe(self):
+        from backend.services.cover_search import normalize_title
+        assert normalize_title("") == ""
+        assert normalize_title(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# Layer 1b: channel allowlist presence check
+# ---------------------------------------------------------------------------
+
+
+class TestChannelAllowlist:
+    """The seeded list of known-good piano cover channels."""
+
+    def test_allowlist_exists_and_nonempty(self):
+        from backend.services.cover_search import COVER_CHANNEL_ALLOWLIST
+        assert isinstance(COVER_CHANNEL_ALLOWLIST, (list, tuple, frozenset, set))
+        assert len(COVER_CHANNEL_ALLOWLIST) >= 5  # Seeded with at least a handful
+
+    def test_allowlist_entries_are_lowercase(self):
+        # Match is case-insensitive so the list stores lowercased names.
+        from backend.services.cover_search import COVER_CHANNEL_ALLOWLIST
+        for channel in COVER_CHANNEL_ALLOWLIST:
+            assert channel == channel.lower(), f"{channel!r} should be lowercase"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: scoring rules
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    title: str,
+    channel: str = "Random Channel",
+    duration: int = 240,
+    view_count: int = 10_000,
+    uploader_id: str | None = None,
+) -> dict:
+    """Build a yt-dlp search result entry for testing.
+
+    ``uploader_id`` is the ``@handle`` string yt-dlp returns for the
+    channel (e.g. ``@keshpianomusic``). Optional — most tests don't
+    care about it, but the trusted-tutorial exemption path reads it
+    for unambiguous channel identification.
+    """
+    entry = {
+        "id": "abc123",
+        "title": title,
+        "channel": channel,
+        "duration": duration,
+        "view_count": view_count,
+        "url": "https://www.youtube.com/watch?v=abc123",
+    }
+    if uploader_id is not None:
+        entry["uploader_id"] = uploader_id
+    return entry
+
+
+class TestScoreCandidate:
+    """Scoring rules drive the match quality gate. See module docstring
+    in cover_search.py for the canonical rule list.
+
+    Reference weights (from design):
+      +50 allowlist channel
+      +30 "piano cover" / "piano arrangement" / "solo piano" in title
+      +20 wanted title is substring of found title (after normalize)
+      +10 wanted artist appears in title or channel
+      -20 "karaoke" / "tutorial" / "how to play" / "lesson" in title
+    """
+
+    def test_allowlist_channel_adds_50(self):
+        from backend.services.cover_search import score_candidate
+        # "jacob's piano" is in the moderate tier of the piano allowlist.
+        # Channel bonus only, nothing else matches. Moderate tier gets
+        # exactly +50 (no easy-tier bonus), which is the "baseline" we
+        # test here. Easy-tier channels get +60 — covered by
+        # TestPianoTierPreference below.
+        entry = _entry(title="My Song", channel="Jacob's Piano")
+        assert score_candidate(entry, wanted_title="unrelated song", wanted_artist=None) == 50
+
+    def test_piano_keyword_adds_30(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="Some Song Piano Cover", channel="No One")
+        assert score_candidate(entry, wanted_title="unrelated", wanted_artist=None) == 30
+
+    def test_piano_arrangement_also_counts(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="My Song Piano Arrangement")
+        assert score_candidate(entry, wanted_title="unrelated", wanted_artist=None) == 30
+
+    def test_solo_piano_also_counts(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="My Song - Solo Piano")
+        assert score_candidate(entry, wanted_title="unrelated", wanted_artist=None) == 30
+
+    def test_title_substring_adds_20(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="Hotel California Random Thing")
+        assert score_candidate(entry, wanted_title="Hotel California", wanted_artist=None) == 20
+
+    def test_title_substring_is_case_insensitive(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="HOTEL CALIFORNIA - something")
+        assert score_candidate(entry, wanted_title="Hotel California", wanted_artist=None) == 20
+
+    def test_artist_in_title_adds_10(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="A song by Queen", channel="No One")
+        assert score_candidate(entry, wanted_title="unrelated", wanted_artist="Queen") == 10
+
+    def test_artist_in_channel_adds_10(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="Unrelated", channel="Adele Official")
+        assert score_candidate(entry, wanted_title="unrelated-nope", wanted_artist="Adele") == 10
+
+    def test_karaoke_subtracts_20(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="Bohemian Rhapsody Karaoke Version")
+        # title match (+20) + karaoke penalty (-20) = 0
+        assert score_candidate(entry, wanted_title="Bohemian Rhapsody", wanted_artist=None) == 0
+
+    def test_tutorial_subtracts_20(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="How to Play Hotel California on Piano Tutorial")
+        # Has "piano" keyword (+30?) — actually no, "how to play" is a penalty.
+        # Let's check: "tutorial" in title → -20
+        # "Hotel California" substring → +20
+        # No "piano cover" (it's "piano tutorial" which is a tutorial, not a cover)
+        # Expected: 20 - 20 = 0. This test forces us to think about the token
+        # rules carefully: "piano cover" matches, but "piano tutorial" doesn't.
+        result = score_candidate(
+            entry, wanted_title="Hotel California", wanted_artist=None
+        )
+        assert result == 0
+
+    def test_perfect_match_max_score(self):
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="Bohemian Rhapsody - Queen (Piano Cover)",
+            channel="Jacob's Piano",
+        )
+        # Moderate-tier allowlist +50, piano cover +30, title match +20,
+        # artist match +10 = 110. Easy-tier would add +10 more (see
+        # TestPianoTierPreference::test_easy_tier_perfect_match_scores_120).
+        assert score_candidate(
+            entry, wanted_title="Bohemian Rhapsody", wanted_artist="Queen"
+        ) == 110
+
+    def test_realistic_good_match_scores_60(self):
+        from backend.services.cover_search import score_candidate
+        # Random piano cover channel, clear piano cover title, title matches.
+        # 30 (piano cover) + 20 (title) + 10 (artist) = 60.
+        # This exactly meets the default threshold of 60 — the dry-run
+        # showed most legitimate pop covers land here, so we want them to
+        # clear. Bumping the scorer must not drop this below 60.
+        entry = _entry(
+            title="Bohemian Rhapsody - Queen Piano Cover",
+            channel="Some Random Channel",
+        )
+        assert score_candidate(
+            entry, wanted_title="Bohemian Rhapsody", wanted_artist="Queen"
+        ) == 60
+
+    def test_moderate_tier_with_title_only_scores_70(self):
+        from backend.services.cover_search import score_candidate
+        # Moderate-tier channel (+50) + title substring (+20) = 70.
+        # This is the minimum "clearly a hit" shape: allowlisted channel
+        # posts a video that mentions the target song in its title but
+        # doesn't say "piano cover" in the title. Exactly clears the
+        # legacy 70 threshold and sits above the current 60 threshold.
+        entry = _entry(
+            title="Bohemian Rhapsody",
+            channel="Jacob's Piano",
+        )
+        assert score_candidate(
+            entry, wanted_title="Bohemian Rhapsody", wanted_artist=None
+        ) == 70
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: find_piano_cover orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestFindPianoCover:
+    """Mocks yt-dlp's search to exercise the candidate selection logic."""
+
+    def test_returns_best_candidate_above_threshold(self):
+        from backend.services.cover_search import find_piano_cover
+
+        search_results = [
+            _entry(title="Bohemian Rhapsody Tutorial", channel="Other"),  # 0
+            _entry(title="Bohemian Rhapsody Piano Cover", channel="Jacob's Piano"),  # 100
+            _entry(title="Bohemian Rhapsody Karaoke", channel="Other"),  # 0
+        ]
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = search_results
+            result = find_piano_cover(
+                title="Bohemian Rhapsody", artist="Queen", min_score=70
+            )
+
+        assert result is not None
+        assert result.url == search_results[1]["url"]
+        assert result.score == 100
+        assert result.channel == "Jacob's Piano"
+
+    def test_returns_none_when_all_candidates_below_threshold(self):
+        from backend.services.cover_search import find_piano_cover
+
+        search_results = [
+            _entry(title="Some Other Thing"),   # 0
+            _entry(title="Karaoke Version"),    # -20
+        ]
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = search_results
+            result = find_piano_cover(
+                title="Bohemian Rhapsody", artist="Queen", min_score=70
+            )
+
+        assert result is None
+
+    def test_empty_search_results_returns_none(self):
+        from backend.services.cover_search import find_piano_cover
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = []
+            result = find_piano_cover(title="Obscure Song", artist=None)
+
+        assert result is None
+
+    def test_yt_dlp_failure_returns_none(self):
+        from backend.services.cover_search import find_piano_cover
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.side_effect = RuntimeError("network down")
+            result = find_piano_cover(title="Hotel California", artist="Eagles")
+
+        assert result is None  # Silent failure — caller falls back to direct transcription
+
+    def test_query_includes_artist_when_provided(self):
+        from backend.services.cover_search import find_piano_cover
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = []
+            find_piano_cover(title="Yesterday", artist="The Beatles")
+
+        # Should have called with a query containing both title and artist.
+        called_query = mock_search.call_args.args[0]
+        assert "yesterday" in called_query.lower()
+        assert "the beatles" in called_query.lower()
+        assert "piano cover" in called_query.lower()
+
+    def test_query_works_without_artist(self):
+        from backend.services.cover_search import find_piano_cover
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = []
+            find_piano_cover(title="River Flows In You", artist=None)
+
+        called_query = mock_search.call_args.args[0]
+        assert "river flows in you" in called_query.lower()
+        assert "piano cover" in called_query.lower()
+
+    def test_default_threshold_is_60_accepts_triple_signal_match(self):
+        from backend.services.cover_search import find_piano_cover
+
+        # A non-allowlist channel with the full "piano cover + title +
+        # artist" triple scores exactly 60. The default threshold must
+        # let this through — this is the common case for pop covers,
+        # surfaced by the dry-run against real YouTube.
+        search_results = [
+            _entry(
+                title="Someone Like You - Adele Piano Cover",
+                channel="Random Pianist",
+            ),
+        ]
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = search_results
+            # No min_score override — must use the module default.
+            result = find_piano_cover(title="Someone Like You", artist="Adele")
+
+        assert result is not None, "score 60 must clear the default threshold"
+        assert result.score == 60
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: metadata probe for the original URL
+# ---------------------------------------------------------------------------
+#
+# Before we can search for a cover, we need to know the song title + artist
+# of whatever the user pasted. yt-dlp can fetch video metadata (title,
+# uploader, track, artist) without downloading any audio. probe_youtube_metadata
+# wraps that call and normalizes the output into a (title, artist) tuple that
+# feeds directly into find_piano_cover().
+
+
+class TestProbeYoutubeMetadata:
+    """Resolves a YouTube URL to (song_title, artist) using yt-dlp's
+    extract_info(download=False). The title should come from the
+    'track' or 'title' field; the artist from 'artist', 'creator', or
+    'uploader' depending on which the video has."""
+
+    def test_extracts_music_metadata_when_present(self):
+        from backend.services.cover_search import probe_youtube_metadata
+
+        # Official music videos often have structured 'track' and 'artist'
+        # fields that YouTube Music populates.
+        with patch("backend.services.cover_search._yt_dlp_extract_info") as mock_ei:
+            mock_ei.return_value = {
+                "title": "Bohemian Rhapsody (Official Video)",
+                "track": "Bohemian Rhapsody",
+                "artist": "Queen",
+                "uploader": "Queen Official",
+            }
+            title, artist = probe_youtube_metadata("https://youtu.be/fJ9rUzIMcZQ")
+
+        # Title is lowercased by normalize_title so it can feed directly
+        # into find_piano_cover's substring matching.
+        assert title == "bohemian rhapsody"
+        assert artist == "Queen"
+
+    def test_falls_back_to_title_when_track_missing(self):
+        from backend.services.cover_search import probe_youtube_metadata
+
+        # User uploads without music metadata — fall back to the 'title'
+        # field (which normalize_title will clean up downstream).
+        with patch("backend.services.cover_search._yt_dlp_extract_info") as mock_ei:
+            mock_ei.return_value = {
+                "title": "Hotel California [Official Video]",
+                "uploader": "Eagles VEVO",
+            }
+            title, artist = probe_youtube_metadata("https://youtu.be/BciS5krYL80")
+
+        # normalize_title strips the "[Official Video]" noise tag
+        assert title == "hotel california"
+        # artist falls back to uploader
+        assert artist == "Eagles VEVO"
+
+    def test_returns_none_on_yt_dlp_failure(self):
+        from backend.services.cover_search import probe_youtube_metadata
+
+        # Network failure, invalid URL, geo-blocked — all silent.
+        with patch("backend.services.cover_search._yt_dlp_extract_info") as mock_ei:
+            mock_ei.side_effect = RuntimeError("network down")
+            result = probe_youtube_metadata("https://youtu.be/bad")
+
+        assert result is None
+
+    def test_returns_none_when_metadata_has_no_title(self):
+        from backend.services.cover_search import probe_youtube_metadata
+
+        # Without any title-shaped field, we can't form a search query.
+        with patch("backend.services.cover_search._yt_dlp_extract_info") as mock_ei:
+            mock_ei.return_value = {"uploader": "Random Channel"}
+            result = probe_youtube_metadata("https://youtu.be/weird")
+
+        assert result is None
+
+    def test_prefers_artist_field_over_creator_and_uploader(self):
+        from backend.services.cover_search import probe_youtube_metadata
+
+        # Precedence: artist > creator > uploader. Make sure the function
+        # picks the most-specific one available.
+        with patch("backend.services.cover_search._yt_dlp_extract_info") as mock_ei:
+            mock_ei.return_value = {
+                "track": "Clocks",
+                "artist": "Coldplay",
+                "creator": "Coldplay VEVO",
+                "uploader": "Coldplay - Topic",
+            }
+            _, artist = probe_youtube_metadata("https://youtu.be/clocks")
+
+        assert artist == "Coldplay"
+
+
+# ---------------------------------------------------------------------------
+# Layer 5: contract field for per-job opt-in
+# ---------------------------------------------------------------------------
+#
+# The user toggles "try to find a clean piano cover" on the upload screen.
+# That choice travels through the pipeline as a field on InputMetadata so
+# the ingest stage can read it and decide whether to run cover_search.
+
+
+class TestPreferCleanSourceField:
+    """InputMetadata must carry a ``prefer_clean_source`` flag so the
+    user's per-request choice survives the trip from POST /v1/jobs
+    through Celery dispatch into the ingest worker."""
+
+    def test_prefer_clean_source_defaults_to_false(self):
+        from shared.contracts import InputMetadata
+        meta = InputMetadata(source="title_lookup")
+        assert meta.prefer_clean_source is False
+
+    def test_prefer_clean_source_accepts_true(self):
+        from shared.contracts import InputMetadata
+        meta = InputMetadata(
+            source="title_lookup",
+            title="https://youtu.be/abc",
+            prefer_clean_source=True,
+        )
+        assert meta.prefer_clean_source is True
+
+    def test_prefer_clean_source_round_trips_json(self):
+        # The contract is serialized via model_dump()/model_validate() between
+        # Celery tasks, so the field must survive JSON encoding.
+        from shared.contracts import InputMetadata
+        original = InputMetadata(source="title_lookup", prefer_clean_source=True)
+        roundtripped = InputMetadata.model_validate(original.model_dump(mode="json"))
+        assert roundtripped.prefer_clean_source is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 6: Settings — feature toggle + tunable threshold
+# ---------------------------------------------------------------------------
+#
+# The cover search runs inside the ingest worker, so its behavior needs to
+# be controllable at deploy time via environment variables. Two knobs:
+#
+#   OHSHEET_COVER_SEARCH_ENABLED       — kill switch for the whole feature
+#   OHSHEET_COVER_SEARCH_MIN_SCORE     — per-env threshold override
+#
+# These let operators flip the feature off on a bad-release day without
+# touching code, and let them crank strictness up on quality-sensitive
+# environments while the default holds elsewhere.
+
+
+class TestCoverSearchSettings:
+    """Config must expose cover_search knobs so operators can tune the
+    feature without editing code."""
+
+    def test_cover_search_enabled_defaults_true(self):
+        # Feature-flag default: on. The user's per-job prefer_clean_source
+        # still gates whether the search runs per request, but operators
+        # need a global kill switch for emergency disablement.
+        from backend.config import Settings
+        s = Settings()
+        assert s.cover_search_enabled is True
+
+    def test_cover_search_min_score_defaults_to_60(self):
+        # Global default must match find_piano_cover's hardcoded default
+        # so tests and runtime agree. When this drifts from cover_search.py,
+        # one of them has been updated without the other and reviewers
+        # should catch it.
+        from backend.config import Settings
+        s = Settings()
+        assert s.cover_search_min_score == 60
+
+    def test_cover_search_settings_overridable_via_env(self, monkeypatch):
+        # pydantic-settings reads OHSHEET_* at Settings() construction,
+        # so each Settings() call reflects the current env.
+        from backend.config import Settings
+        monkeypatch.setenv("OHSHEET_COVER_SEARCH_ENABLED", "false")
+        monkeypatch.setenv("OHSHEET_COVER_SEARCH_MIN_SCORE", "80")
+        s = Settings()
+        assert s.cover_search_enabled is False
+        assert s.cover_search_min_score == 80
+
+
+# ---------------------------------------------------------------------------
+# PR #47 review: yt-dlp entry URL normalization (Critical)
+# ---------------------------------------------------------------------------
+#
+# yt-dlp's ``extract_flat=True`` mode is inconsistent about where the
+# watch URL ends up — see _normalize_entry_url's docstring for details.
+# The dangerous case is a bare 11-char video ID landing in the ``url``
+# field: it flows unchecked through CoverSearchResult.url →
+# _maybe_swap_for_cover_sync → _download_youtube_sync, where
+# extract_youtube_id rejects it and _download_youtube_sync raises
+# ValueError — crashing the ingest job.
+
+
+class TestNormalizeEntryUrl:
+    """Normalize yt-dlp entries into canonical watch URLs."""
+
+    def test_full_https_url_in_url_field_returned_as_is(self):
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                 "id": "dQw4w9WgXcQ"}
+        assert _normalize_entry_url(entry) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_full_http_url_accepted(self):
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {"url": "http://youtube.com/watch?v=dQw4w9WgXcQ",
+                 "id": "dQw4w9WgXcQ"}
+        assert _normalize_entry_url(entry) == "http://youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_bare_video_id_in_url_field_reconstructed_from_id(self):
+        # The (Critical) case: extract_flat sometimes puts just the
+        # 11-char ID in the "url" field. Without normalization, this
+        # flows into _download_youtube_sync and crashes the job.
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {"url": "dQw4w9WgXcQ", "id": "dQw4w9WgXcQ"}
+        assert _normalize_entry_url(entry) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_webpage_url_wins_when_url_field_is_bare_id(self):
+        # Prefer webpage_url — it's always the full canonical form when
+        # yt-dlp populates it at all.
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {
+            "url": "dQw4w9WgXcQ",
+            "webpage_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "id": "dQw4w9WgXcQ",
+        }
+        assert _normalize_entry_url(entry) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_webpage_url_used_when_url_field_missing(self):
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {
+            "webpage_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "id": "dQw4w9WgXcQ",
+        }
+        assert _normalize_entry_url(entry) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_empty_url_field_falls_back_to_id(self):
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {"url": "", "id": "dQw4w9WgXcQ"}
+        assert _normalize_entry_url(entry) == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def test_nothing_resolvable_returns_empty_string(self):
+        # Caller must drop this entry.
+        from backend.services.cover_search import _normalize_entry_url
+        entry = {"title": "some video", "channel": "some channel"}
+        assert _normalize_entry_url(entry) == ""
+
+    def test_yt_dlp_search_drops_entries_with_unresolvable_url(self):
+        # Integration: _yt_dlp_search must drop unresolvable entries
+        # rather than let bare IDs pass through.
+        import types
+
+        import backend.services.cover_search as cs
+
+        fake_response = {
+            "entries": [
+                {"url": "dQw4w9WgXcQ", "id": "dQw4w9WgXcQ",
+                 "title": "t1", "channel": "c1"},
+                {"title": "t2", "channel": "c2"},  # dropped — no URL
+                {"webpage_url": "https://www.youtube.com/watch?v=abc12345678",
+                 "id": "abc12345678", "title": "t3", "channel": "c3"},
+            ]
+        }
+
+        class _FakeYDL:
+            def __init__(self, opts): pass
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def extract_info(self, query, download): return fake_response
+
+        fake_yt_dlp = types.SimpleNamespace(YoutubeDL=_FakeYDL)
+        with patch.dict("sys.modules", {"yt_dlp": fake_yt_dlp}):
+            entries = cs._yt_dlp_search("anything", top_k=5)
+
+        assert len(entries) == 2
+        assert entries[0]["url"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert entries[1]["url"] == "https://www.youtube.com/watch?v=abc12345678"
+
+
+# ---------------------------------------------------------------------------
+# Layer 7: multi-variant search — piano + chiptune
+# ---------------------------------------------------------------------------
+#
+# The scorer was originally piano-only. Full-band pop mixes are a nightmare
+# for Basic Pitch, but so are many "piano covers" on YouTube — the non-
+# allowlist ones cap at 60 and half the time there IS a cleaner alternative:
+# 8-bit / chiptune covers. Chiptune audio is dramatically easier to transcribe
+# (monophonic channels, pure square/triangle waves, no reverb, no drums
+# mixed into pitched content) so when a chiptune cover of a song exists,
+# it's a BETTER source than a piano cover for our pipeline.
+#
+# The multi-variant refactor: ``find_clean_source`` runs the search once per
+# variant (piano + chiptune by default), scores each variant's candidates
+# against its own channel allowlist + keywords, and returns the single
+# highest-scoring result across all variants. Backward compatibility:
+# ``find_piano_cover`` stays as a thin wrapper that runs the piano variant
+# only so existing callers keep their narrow behavior.
+
+
+class TestPianoTierPreference:
+    """The piano allowlist is tiered: easy beats moderate beats (disabled)
+    advanced. Advanced channels score 0 from channel alone — they only get
+    points from title/artist matches and keywords, which caps them below
+    the 60 threshold unless a chiptune variant rescues the song."""
+
+    def test_easy_tier_channel_gets_60(self):
+        # Easy-tier gets +50 base + +10 tier bonus = 60.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="My Song", channel="Pianote")
+        assert score_candidate(entry, wanted_title="unrelated", wanted_artist=None) == 60
+
+    def test_moderate_tier_channel_gets_50(self):
+        # Moderate-tier gets +50 base, no tier bonus.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(title="My Song", channel="Jacob's Piano")
+        assert score_candidate(entry, wanted_title="unrelated", wanted_artist=None) == 50
+
+    def test_advanced_tier_channel_gets_zero_from_channel(self):
+        # Advanced channels (Rousseau, Pietschmann, Kyle Landry, etc.) are
+        # defined but NOT in the active allowlist. They get no channel
+        # bonus — title/artist/keyword matches only.
+        from backend.services.cover_search import score_candidate
+        for channel in ("Rousseau", "Patrik Pietschmann", "Kyle Landry"):
+            entry = _entry(title="My Song", channel=channel)
+            score = score_candidate(
+                entry, wanted_title="unrelated", wanted_artist=None,
+            )
+            assert score == 0, f"{channel!r} should score 0 from channel alone"
+
+    def test_advanced_channel_scores_below_threshold_for_typical_match(self):
+        # A Rousseau Bohemian Rhapsody Piano Cover match under the
+        # CURRENT active allowlist scores: 0 (advanced not active) +
+        # 30 (piano cover keyword) + 20 (title) + 10 (artist) = 60.
+        # Exactly at the default threshold. One bad keyword (live
+        # recording, karaoke) would drop it. Title-only (no "piano
+        # cover" keyword in the title) would drop it below. This
+        # documents the intended "advanced rarely wins" behavior.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="Bohemian Rhapsody - Queen (Piano Cover)",
+            channel="Rousseau",
+        )
+        score = score_candidate(
+            entry, wanted_title="Bohemian Rhapsody", wanted_artist="Queen",
+        )
+        assert score == 60
+
+    def test_easy_tier_perfect_match_scores_120(self):
+        # Easy-tier gets the full stack: 50 + 10 easy bonus + 30 piano
+        # cover keyword + 20 title + 10 artist = 120. This is the new
+        # ceiling for scoring under the easy/moderate-only active
+        # allowlist.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="Bohemian Rhapsody - Queen (Easy Piano Cover)",
+            channel="Pianote",
+        )
+        score = score_candidate(
+            entry, wanted_title="Bohemian Rhapsody", wanted_artist="Queen",
+        )
+        assert score == 120
+
+    def test_easy_beats_moderate_when_tied_elsewhere(self):
+        # Two candidates with identical title/artist/keyword scoring:
+        # the easy-tier one wins because of the +10 easy bonus.
+        from backend.services.cover_search import find_piano_cover
+
+        search_results = [
+            _entry(
+                title="Song X - Piano Cover",
+                channel="Jacob's Piano",   # moderate: 50 + 30 + 20 = 100
+            ),
+            _entry(
+                title="Song X - Piano Cover",
+                channel="Pianote",          # easy: 50 + 10 + 30 + 20 = 110
+            ),
+        ]
+
+        with patch("backend.services.cover_search._yt_dlp_search") as mock_search:
+            mock_search.return_value = search_results
+            result = find_piano_cover(title="Song X", artist=None)
+
+        assert result is not None
+        assert result.channel == "Pianote"
+        assert result.score == 110
+
+    def test_advanced_tier_exported_for_future_reactivation(self):
+        # PIANO_ADVANCED_CHANNELS should remain defined in the module so
+        # a future PR can reactivate the tier by adding it to the active
+        # allowlist. This test locks in the contract and catches a
+        # silent deletion of the tier data.
+        from backend.services.cover_search import (
+            COVER_CHANNEL_ALLOWLIST,
+            PIANO_ADVANCED_CHANNELS,
+            PIANO_EASY_CHANNELS,
+            PIANO_MODERATE_CHANNELS,
+        )
+        # Advanced list is defined and nonempty.
+        assert len(PIANO_ADVANCED_CHANNELS) >= 3
+        # But it is NOT in the active allowlist.
+        for ch in PIANO_ADVANCED_CHANNELS:
+            assert ch not in COVER_CHANNEL_ALLOWLIST, (
+                f"{ch!r} should not be in the active allowlist"
+            )
+        # The active allowlist equals easy + moderate, nothing else.
+        assert set(COVER_CHANNEL_ALLOWLIST) == (
+            set(PIANO_EASY_CHANNELS) | set(PIANO_MODERATE_CHANNELS)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 7b: trusted tutorial channels
+# ---------------------------------------------------------------------------
+#
+# Some channels brand themselves as "tutorial" but produce clean,
+# transcription-quality audio — Synthesia-style rendered piano with no
+# voiceover or backing track. For those channels the ``-20`` tutorial
+# keyword penalty is the wrong signal: it marks them down for what they
+# call themselves rather than what they actually sound like.
+#
+# We maintain a small ``TRUSTED_TUTORIAL_CHANNELS`` exemption list.
+# Channels in it score the normal allowlist + title + artist bonuses
+# without the tutorial penalty deducted. Matches against yt-dlp's
+# ``uploader_id`` (the ``@handle`` form) so the identifier is unique
+# even for channels whose display names are common words.
+#
+# First entry: Kesh Piano Music (``@keshpianomusic``) — their entire
+# catalog is "Piano Tutorial + MIDI" but the audio is pure rendered
+# piano which Basic Pitch transcribes beautifully.
+
+
+class TestTrustedTutorialChannels:
+    """Trusted-tutorial channels bypass the ``-20`` tutorial penalty.
+
+    The canonical first member is Kesh (``@keshpianomusic``) whose
+    catalog is all "Piano Tutorial" videos but whose audio is
+    transcription-quality piano synthesis.
+    """
+
+    def test_trusted_tutorial_list_exists_and_contains_kesh(self):
+        from backend.services.cover_search import TRUSTED_TUTORIAL_CHANNELS
+        assert isinstance(TRUSTED_TUTORIAL_CHANNELS, (list, tuple, frozenset, set))
+        assert any("kesh" in entry.lower() for entry in TRUSTED_TUTORIAL_CHANNELS), (
+            f"Kesh should seed the trusted-tutorial list: {TRUSTED_TUTORIAL_CHANNELS}"
+        )
+
+    def test_trusted_tutorial_entries_are_lowercase(self):
+        from backend.services.cover_search import TRUSTED_TUTORIAL_CHANNELS
+        for entry in TRUSTED_TUTORIAL_CHANNELS:
+            assert entry == entry.lower(), f"{entry!r} should be lowercase"
+
+    def test_kesh_in_piano_moderate_allowlist(self):
+        # Kesh is on the piano moderate tier (not easy — his tutorials
+        # are for learners but aren't "beginner" simplified).
+        from backend.services.cover_search import PIANO_MODERATE_CHANNELS
+        assert any(
+            "kesh" in entry.lower() for entry in PIANO_MODERATE_CHANNELS
+        ), f"Kesh should be in PIANO_MODERATE_CHANNELS: {PIANO_MODERATE_CHANNELS}"
+
+    def test_kesh_match_via_uploader_id_handle(self):
+        # yt-dlp returns channel="Kesh" (too broad for substring match
+        # because of the "Kesha" collision risk) but also exposes
+        # uploader_id="@keshpianomusic" which is unambiguous. The
+        # scorer must check uploader_id alongside channel so matching
+        # on the handle works.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="River Flows In You - Yiruma - Piano Tutorial + MIDI",
+            channel="Kesh",
+            uploader_id="@keshpianomusic",
+        )
+        score = score_candidate(
+            entry, wanted_title="River Flows In You", wanted_artist="Yiruma",
+        )
+        # allowlist +50 (via uploader_id match) + title match +20 +
+        # artist match +10 - tutorial penalty (SKIPPED for trusted
+        # tutorial) = 80
+        assert score == 80, (
+            f"Kesh + title + artist should score 80 with tutorial penalty "
+            f"exempted; got {score}"
+        )
+
+    def test_kesh_tutorial_penalty_exempt(self):
+        # Specific regression: the -20 tutorial penalty must NOT apply
+        # when the channel is trusted, even though "tutorial" appears
+        # in the title.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="Some Song - Piano Tutorial",
+            channel="Kesh",
+            uploader_id="@keshpianomusic",
+        )
+        # allowlist +50 only; no title/artist match; tutorial penalty
+        # skipped because trusted. Should score 50.
+        score = score_candidate(
+            entry, wanted_title="unrelated song", wanted_artist=None,
+        )
+        assert score == 50
+
+    def test_non_trusted_tutorial_still_penalized(self):
+        # Regression: the exemption must be SPECIFIC to the trusted list.
+        # A random channel with "tutorial" in the title still gets -20.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="River Flows In You - Piano Tutorial",
+            channel="Random Piano Channel",
+            uploader_id="@randomchannel",
+        )
+        # No allowlist, no piano-cover keyword ("piano tutorial"
+        # doesn't match), title match +20, no artist, tutorial -20.
+        # Net: 0.
+        score = score_candidate(
+            entry, wanted_title="River Flows In You", wanted_artist=None,
+        )
+        assert score == 0
+
+    def test_kesh_allowlist_does_not_false_match_kesha_pop_channel(self):
+        # Defensive regression: the pop artist "Kesha" must not trip
+        # the Kesh allowlist. We match on uploader_id handle, not on
+        # channel name substring, so a Kesha-named channel without
+        # the @keshpianomusic handle should score 0.
+        from backend.services.cover_search import score_candidate
+        entry = _entry(
+            title="Kesha Tik Tok Piano Cover",
+            channel="Kesha Fan Covers",
+            uploader_id="@keshafancovers",
+        )
+        # No allowlist match (Kesha != keshpianomusic), piano cover
+        # keyword +30, title/artist +10 (if matched). Should NOT get
+        # the +50 allowlist bonus.
+        score = score_candidate(
+            entry, wanted_title="Tik Tok", wanted_artist="Kesha",
+        )
+        # piano cover keyword +30, title +20, artist +10 = 60 (no
+        # allowlist match = no +50). Confirms the handle-based lookup
+        # is specific enough.
+        assert score == 60
+
+
+class TestChiptuneChannelAllowlist:
+    """Companion to the piano allowlist — a lowercase list of YouTube
+    channels that reliably post clean 8-bit covers of popular songs."""
+
+    def test_chiptune_allowlist_exists_and_nonempty(self):
+        from backend.services.cover_search import CHIPTUNE_CHANNEL_ALLOWLIST
+        assert isinstance(CHIPTUNE_CHANNEL_ALLOWLIST, (list, tuple, frozenset, set))
+        assert len(CHIPTUNE_CHANNEL_ALLOWLIST) >= 3  # Seeded with a few handpicked channels.
+
+    def test_chiptune_allowlist_entries_are_lowercase(self):
+        from backend.services.cover_search import CHIPTUNE_CHANNEL_ALLOWLIST
+        for channel in CHIPTUNE_CHANNEL_ALLOWLIST:
+            assert channel == channel.lower(), f"{channel!r} should be lowercase"
+
+    def test_chiptune_allowlist_disjoint_from_piano_allowlist(self):
+        # Same channel should never be in both lists — it would confuse
+        # the scoring (which variant did the match come from?).
+        from backend.services.cover_search import (
+            CHIPTUNE_CHANNEL_ALLOWLIST,
+            COVER_CHANNEL_ALLOWLIST,
+        )
+        overlap = set(CHIPTUNE_CHANNEL_ALLOWLIST) & set(COVER_CHANNEL_ALLOWLIST)
+        assert overlap == set(), f"channels in both lists: {overlap}"
+
+
+class TestScoreCandidateChiptuneVariant:
+    """When scoring for the chiptune variant, the +50 / +30 weights come
+    from CHIPTUNE_CHANNEL_ALLOWLIST and chiptune keywords instead of the
+    piano defaults."""
+
+    def test_chiptune_allowlist_channel_adds_50(self):
+        from backend.services.cover_search import (
+            CHIPTUNE_VARIANT,
+            score_candidate_for_variant,
+        )
+        entry = _entry(title="Bohemian Rhapsody", channel="8-Bit Universe")
+        score = score_candidate_for_variant(
+            entry,
+            wanted_title="unrelated song",
+            wanted_artist=None,
+            variant=CHIPTUNE_VARIANT,
+        )
+        assert score == 50
+
+    def test_chiptune_keyword_adds_30(self):
+        from backend.services.cover_search import (
+            CHIPTUNE_VARIANT,
+            score_candidate_for_variant,
+        )
+        entry = _entry(title="Bohemian Rhapsody (8 Bit Cover)", channel="Random")
+        score = score_candidate_for_variant(
+            entry,
+            wanted_title="unrelated",
+            wanted_artist=None,
+            variant=CHIPTUNE_VARIANT,
+        )
+        assert score == 30
+
+    def test_chiptune_chiptune_keyword_also_counts(self):
+        from backend.services.cover_search import (
+            CHIPTUNE_VARIANT,
+            score_candidate_for_variant,
+        )
+        entry = _entry(title="Some Song - Chiptune Version", channel="Random")
+        score = score_candidate_for_variant(
+            entry,
+            wanted_title="unrelated",
+            wanted_artist=None,
+            variant=CHIPTUNE_VARIANT,
+        )
+        assert score == 30
+
+    def test_chiptune_scoring_ignores_piano_keywords(self):
+        # A "piano cover" result should NOT get the +30 boost when scored
+        # against the chiptune variant — the variants are independent.
+        from backend.services.cover_search import (
+            CHIPTUNE_VARIANT,
+            score_candidate_for_variant,
+        )
+        entry = _entry(title="Bohemian Rhapsody Piano Cover", channel="Random")
+        score = score_candidate_for_variant(
+            entry,
+            wanted_title="Bohemian Rhapsody",
+            wanted_artist=None,
+            variant=CHIPTUNE_VARIANT,
+        )
+        # +20 title match only. No chiptune keywords, no chiptune allowlist.
+        assert score == 20
+
+    def test_chiptune_allowlist_does_not_score_piano_variant(self):
+        from backend.services.cover_search import (
+            PIANO_VARIANT,
+            score_candidate_for_variant,
+        )
+        entry = _entry(title="Bohemian Rhapsody", channel="8-Bit Universe")
+        score = score_candidate_for_variant(
+            entry,
+            wanted_title="Bohemian Rhapsody",
+            wanted_artist=None,
+            variant=PIANO_VARIANT,
+        )
+        # Only +20 title match — 8-Bit Universe isn't in the piano allowlist
+        # and the title has no piano keywords.
+        assert score == 20
+
+    def test_chiptune_perfect_match_max_score(self):
+        from backend.services.cover_search import (
+            CHIPTUNE_VARIANT,
+            score_candidate_for_variant,
+        )
+        entry = _entry(
+            title="Bohemian Rhapsody - Queen (8 Bit Cover)",
+            channel="8-Bit Universe",
+        )
+        score = score_candidate_for_variant(
+            entry,
+            wanted_title="Bohemian Rhapsody",
+            wanted_artist="Queen",
+            variant=CHIPTUNE_VARIANT,
+        )
+        # allowlist +50, chiptune keyword +30, title match +20, artist +10 = 110
+        assert score == 110
+
+
+class TestFindCleanSource:
+    """The multi-variant orchestrator. Runs the search once per variant
+    and returns the highest-scoring candidate across all of them."""
+
+    def test_returns_piano_match_when_it_outscores_chiptune(self):
+        from backend.services.cover_search import find_clean_source
+
+        # piano query returns a Jacob's Piano (moderate tier) match → score 110
+        # chiptune query returns a Random channel with only title+keyword → 50
+        def _search(query, *, top_k=5):
+            if "piano cover" in query:
+                return [_entry(
+                    title="Bohemian Rhapsody - Queen (Piano Cover)",
+                    channel="Jacob's Piano",
+                )]
+            if "8 bit" in query:
+                return [_entry(
+                    title="Bohemian Rhapsody 8 bit cover",
+                    channel="Random Chip Channel",
+                )]
+            return []
+
+        with patch("backend.services.cover_search._yt_dlp_search", side_effect=_search):
+            result = find_clean_source("Bohemian Rhapsody", "Queen")
+
+        assert result is not None
+        assert result.channel == "Jacob's Piano"
+        assert result.score == 110
+
+    def test_returns_chiptune_match_when_it_outscores_piano(self):
+        from backend.services.cover_search import find_clean_source
+
+        # piano query returns a non-allowlist result with weak match → 20
+        # chiptune query returns a strong allowlist match → 110
+        def _search(query, *, top_k=5):
+            if "piano cover" in query:
+                return [_entry(title="Bohemian Rhapsody weak", channel="Random")]
+            if "8 bit" in query:
+                return [_entry(
+                    title="Bohemian Rhapsody - Queen (8 Bit Cover)",
+                    channel="8-Bit Universe",
+                )]
+            return []
+
+        with patch("backend.services.cover_search._yt_dlp_search", side_effect=_search):
+            result = find_clean_source("Bohemian Rhapsody", "Queen")
+
+        assert result is not None
+        assert result.channel == "8-Bit Universe"
+        assert result.score == 110
+
+    def test_returns_none_when_both_variants_below_threshold(self):
+        from backend.services.cover_search import find_clean_source
+
+        def _search(query, *, top_k=5):
+            return [_entry(title="Unrelated", channel="Random")]
+
+        with patch("backend.services.cover_search._yt_dlp_search", side_effect=_search):
+            result = find_clean_source("Bohemian Rhapsody", "Queen", min_score=60)
+
+        assert result is None
+
+    def test_one_variant_failing_does_not_block_the_other(self):
+        # If piano search crashes but chiptune succeeds, we should still
+        # return the chiptune result instead of silently returning None.
+        from backend.services.cover_search import find_clean_source
+
+        def _search(query, *, top_k=5):
+            if "piano cover" in query:
+                raise RuntimeError("piano search hiccup")
+            return [_entry(
+                title="Bohemian Rhapsody - Queen 8 bit cover",
+                channel="8-Bit Universe",
+            )]
+
+        with patch("backend.services.cover_search._yt_dlp_search", side_effect=_search):
+            result = find_clean_source("Bohemian Rhapsody", "Queen")
+
+        assert result is not None
+        assert result.channel == "8-Bit Universe"
+
+    def test_queries_every_variant_even_when_first_yields_match(self):
+        # We don't short-circuit: every variant runs so the scorer can
+        # pick the absolute best across all of them. This test guards
+        # against a "first-match-wins" regression.
+        from backend.services.cover_search import find_clean_source
+
+        calls: list[str] = []
+
+        def _search(query, *, top_k=5):
+            calls.append(query)
+            return [_entry(title="Generic", channel="Random")]
+
+        with patch("backend.services.cover_search._yt_dlp_search", side_effect=_search):
+            find_clean_source("Bohemian Rhapsody", "Queen")
+
+        # Both "piano cover" and "8 bit cover" queries should have fired.
+        assert any("piano cover" in q for q in calls), calls
+        assert any("8 bit" in q for q in calls), calls
+
+    def test_find_piano_cover_remains_piano_only_for_backward_compat(self):
+        # Explicit regression test: find_piano_cover MUST keep running
+        # the piano variant only. Downstream mocks (test_ingest_cover_search)
+        # still patch this name and count on the narrow semantics.
+        from backend.services.cover_search import find_piano_cover
+
+        calls: list[str] = []
+
+        def _search(query, *, top_k=5):
+            calls.append(query)
+            return []
+
+        with patch("backend.services.cover_search._yt_dlp_search", side_effect=_search):
+            find_piano_cover("Bohemian Rhapsody", "Queen")
+
+        # Only the piano query should have fired.
+        assert len(calls) == 1
+        assert "piano cover" in calls[0]
+        assert "8 bit" not in calls[0]

--- a/tests/test_engrave_pdf_render.py
+++ b/tests/test_engrave_pdf_render.py
@@ -1,0 +1,65 @@
+"""Smoke test for the LilyPond / MuseScore PDF render path.
+
+Gates on whether a real PDF renderer is on ``$PATH``. When neither
+``lilypond`` nor a ``musescore*`` binary is installed, this is skipped
+so it doesn't break dev machines without the engraver tooling. The
+production Docker image installs ``lilypond`` via apt (see
+``Dockerfile``), so CI runs inside that image will execute this path.
+"""
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from backend.services.engrave import _STUB_PDF, _engrave_sync, _render_pdf_bytes
+from tests.fixtures import load_score_fixture
+
+
+def _has_real_renderer() -> bool:
+    if shutil.which("musicxml2ly") and shutil.which("lilypond"):
+        return True
+    return any(
+        shutil.which(b) for b in ("musescore4", "musescore3", "mscore", "MuseScore4")
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_real_renderer(),
+    reason="no lilypond/MuseScore on PATH — production image installs lilypond",
+)
+
+
+def test_engrave_emits_real_pdf_not_stub() -> None:
+    """A fixture routed through ``_engrave_sync`` produces a real PDF.
+
+    Uses ``c_major_scale`` as the smoke case: it's small, uses both
+    hands, and has been rendering cleanly through music21 since PR-1.
+    """
+    score = load_score_fixture("c_major_scale")
+    pdf_bytes, musicxml_bytes, _midi_bytes, _chord_count = _engrave_sync(
+        score, title="Smoke Test", composer="pytest",
+    )
+
+    assert musicxml_bytes.startswith(b"<?xml"), "musicxml should be real xml"
+    assert pdf_bytes != _STUB_PDF, (
+        "a real renderer is on PATH but _render_pdf_bytes fell through to the stub"
+    )
+    assert pdf_bytes.startswith(b"%PDF-"), "output is not a PDF"
+    assert len(pdf_bytes) > 1024, (
+        f"PDF suspiciously small ({len(pdf_bytes)} bytes) — likely a render failure"
+    )
+
+
+def test_render_pdf_bytes_direct_call() -> None:
+    """``_render_pdf_bytes`` on plausible MusicXML returns a real PDF.
+
+    Keeps the pdf path under test even if future refactors move the
+    high-level ``_engrave_sync`` plumbing around.
+    """
+    score = load_score_fixture("single_note")
+    _, musicxml_bytes, _, _ = _engrave_sync(score, title="", composer="")
+
+    pdf_bytes = _render_pdf_bytes(musicxml_bytes)
+    assert pdf_bytes != _STUB_PDF
+    assert pdf_bytes.startswith(b"%PDF-")

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -1,0 +1,762 @@
+"""Engrave quality harness — L1 (MIDI round-trip) + L2 (notation lints).
+
+This is the first layer of the evaluation harness described in
+``docs/engrave-improvement-plan.md`` Phase 0.2. It runs every score
+fixture in ``tests/fixtures/scores/`` through ``_engrave_sync`` and:
+
+- **L1 — MIDI round-trip.** Parses the emitted MIDI with ``pretty_midi``
+  and asserts that every fixture note is present in the output (by
+  pitch + attack count). Catches dropped notes and wrong-pitch
+  regressions.
+- **L2 — Notation quality lints.** Parses the emitted MusicXML with
+  ``lxml`` and runs structural xpath checks: ``<voice>`` in range,
+  ``<divisions>`` ≤ 480, pitches within the 88-key piano range, note
+  count consistent with the fixture.
+
+A dedicated test pins the onset-only semantics of ``timing_offset_ms``
+against the ``humanized_with_offsets`` fixture (see plan Phase 1.2).
+"""
+from __future__ import annotations
+
+import io
+from collections import Counter
+
+import pytest
+
+from backend.contracts import HumanizedPerformance, PianoScore, beat_to_sec
+from backend.services.engrave import _engrave_sync
+from tests.fixtures import FIXTURE_NAMES, load_score_fixture
+
+# ---------------------------------------------------------------------------
+# MusicXML step → semitone table for pitch decoding
+# ---------------------------------------------------------------------------
+
+_STEP_TO_SEMITONE = {"C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11}
+
+
+def _musicxml_pitch_to_midi(pitch_elem) -> int:
+    step = pitch_elem.findtext("step")
+    octave = int(pitch_elem.findtext("octave"))
+    alter_text = pitch_elem.findtext("alter")
+    alter = int(float(alter_text)) if alter_text else 0
+    return (octave + 1) * 12 + _STEP_TO_SEMITONE[step] + alter
+
+
+def _expected_note_pitches(fixture) -> list[int]:
+    """Return the MIDI pitches of every note in a fixture.
+
+    For a ``PianoScore`` this is ``rh + lh``. For a
+    ``HumanizedPerformance`` it's ``expressive_notes`` — same count, but
+    with the timing offsets baked in.
+    """
+    if isinstance(fixture, HumanizedPerformance):
+        return [n.pitch for n in fixture.expressive_notes]
+    if isinstance(fixture, PianoScore):
+        return [n.pitch for n in fixture.right_hand] + [n.pitch for n in fixture.left_hand]
+    raise TypeError(f"Unexpected fixture type: {type(fixture).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Engrave-once-per-fixture cache
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def engraved_artifacts() -> dict[str, tuple[bytes, bytes]]:
+    """Run each fixture through ``_engrave_sync`` once per test module.
+
+    Returns ``{name: (musicxml_bytes, midi_bytes)}``. Running engrave is
+    cheap but music21's importer is slow (~1s) and we don't want to pay
+    it for every parametrized test.
+    """
+    cache: dict[str, tuple[bytes, bytes]] = {}
+    for name in FIXTURE_NAMES:
+        fixture = load_score_fixture(name)
+        _pdf, musicxml, midi, _chord_count = _engrave_sync(fixture, title=name, composer="test")
+        cache[name] = (musicxml, midi)
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# L1 — MIDI round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l1_midi_round_trip(name: str, engraved_artifacts):
+    """Every fixture note round-trips to MIDI with the right pitch + count."""
+    import pretty_midi
+
+    fixture = load_score_fixture(name)
+    _, midi_bytes = engraved_artifacts[name]
+    assert midi_bytes, f"engrave emitted empty MIDI for fixture {name!r}"
+
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    actual_pitches = [note.pitch for inst in midi.instruments for note in inst.notes]
+    expected_pitches = _expected_note_pitches(fixture)
+
+    actual_counter = Counter(actual_pitches)
+    expected_counter = Counter(expected_pitches)
+
+    # The same-pitch overlap resolver in engrave.py:94-103 may collapse
+    # two overlapping attacks into a single sustained note, so for that
+    # specific fixture we only assert "at least one attack per pitch."
+    # Every other fixture is strict.
+    if name == "overlapping_same_pitch":
+        assert set(actual_counter.keys()) == set(expected_counter.keys()), (
+            f"{name}: pitch set mismatch — expected {sorted(expected_counter)} "
+            f"got {sorted(actual_counter)}"
+        )
+        assert sum(actual_counter.values()) >= 1
+    else:
+        assert actual_counter == expected_counter, (
+            f"{name}: MIDI pitch counts diverge from the fixture.\n"
+            f"  expected: {sorted(expected_counter.items())}\n"
+            f"  got:      {sorted(actual_counter.items())}"
+        )
+
+
+def test_l1_humanized_timing_offset_is_onset_only(engraved_artifacts):
+    """``timing_offset_ms`` is an onset-only nudge — release stays fixed.
+
+    The fixture's first RH note is C4 at beat 0, duration 1 beat, with
+    ``timing_offset_ms = +20``. At 120 BPM one beat is 0.5 s, so an
+    onset-only shift produces ``onset = 0.020 s`` and
+    ``offset = 0.500 s`` (duration compressed to 0.480 s).
+
+    Mirrors ``humanize._humanize_timing``, which models downbeat
+    anticipation / backbeat push as attack-time gestures only.
+    """
+    import pretty_midi
+
+    fixture = load_score_fixture("humanized_with_offsets")
+    assert isinstance(fixture, HumanizedPerformance)
+
+    _, midi_bytes = engraved_artifacts["humanized_with_offsets"]
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    notes_by_pitch = {}
+    for inst in midi.instruments:
+        for n in inst.notes:
+            notes_by_pitch.setdefault(n.pitch, []).append(n)
+
+    # First RH note: pitch 60 (C4), beat 0, timing_offset_ms=+20, duration=1 beat
+    rh0 = fixture.expressive_notes[0]
+    assert rh0.pitch == 60
+    assert rh0.timing_offset_ms == pytest.approx(20.0)
+
+    c4_notes = sorted(notes_by_pitch[60], key=lambda n: n.start)
+    first = c4_notes[0]
+
+    tempo_map = fixture.score.metadata.tempo_map
+    unshifted_offset_sec = beat_to_sec(rh0.onset_beat + rh0.duration_beat, tempo_map)
+    assert first.end == pytest.approx(unshifted_offset_sec, abs=0.001), (
+        f"expected offset unchanged at {unshifted_offset_sec:.3f}s, got {first.end:.3f}s "
+        "(timing_offset_ms leaked into the release boundary)"
+    )
+
+
+def test_l1_humanized_pedal_reaches_midi(engraved_artifacts):
+    """Sustain pedal events must emit CC64 on/off in the output MIDI."""
+    import pretty_midi
+
+    _, midi_bytes = engraved_artifacts["humanized_with_offsets"]
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    cc64 = [
+        cc
+        for inst in midi.instruments
+        for cc in inst.control_changes
+        if cc.number == 64
+    ]
+    assert any(cc.value >= 64 for cc in cc64), "no sustain pedal ON (CC64 ≥ 64)"
+    assert any(cc.value < 64 for cc in cc64), "no sustain pedal OFF (CC64 < 64)"
+
+
+def test_l1_humanized_expression_emits_all_pedal_ccs(engraved_artifacts):
+    """Plan phase 1.5 — sostenuto → CC66, una corda → CC67 in addition to sustain → CC64.
+
+    The ``humanized_with_expression`` fixture carries one of each pedal
+    type; the engraver must write on/off edges for all three controllers.
+    """
+    import pretty_midi
+
+    _, midi_bytes = engraved_artifacts["humanized_with_expression"]
+    midi = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    by_cc: dict[int, list[int]] = {}
+    for inst in midi.instruments:
+        for cc in inst.control_changes:
+            by_cc.setdefault(cc.number, []).append(cc.value)
+
+    for cc_num, label in ((64, "sustain"), (66, "sostenuto"), (67, "una_corda")):
+        assert cc_num in by_cc, f"{label}: no CC{cc_num} events in MIDI"
+        values = by_cc[cc_num]
+        assert any(v >= 64 for v in values), f"{label}: no CC{cc_num} ON edge"
+        assert any(v < 64 for v in values), f"{label}: no CC{cc_num} OFF edge"
+
+
+# ---------------------------------------------------------------------------
+# L2 — Notation quality lints
+# ---------------------------------------------------------------------------
+
+_PIANO_MIN_MIDI = 21   # A0
+_PIANO_MAX_MIDI = 108  # C8
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_voice_numbers_in_range(name: str, engraved_artifacts):
+    """Every ``<voice>`` element must be an integer in [1, 4].
+
+    music21 omits ``<voice>`` entirely for single-voice parts, so a
+    missing element is also fine — we only complain about values that
+    are present and out of range.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+    voices = [int(e.text) for e in root.iter("voice")]
+    bad = [v for v in voices if not 1 <= v <= 4]
+    assert not bad, f"{name}: out-of-range <voice> values: {sorted(set(bad))}"
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_divisions_is_twelve(name: str, engraved_artifacts):
+    """``<divisions>`` must be exactly 12 per quarter.
+
+    PR-9 (plan phase 2.4) sets ``music21.defaults.divisionsPerQuarter=12``
+    before export so the grid is fixed by construction — 16th = 3
+    divisions, 8th = 6, triplet-8th = 4, quarter = 12. Prior to PR-9 the
+    value was music21's shipped default of 10080, which OSMD cannot
+    consume; this test would catch either regression.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+    divisions = [int(e.text) for e in root.iter("divisions")]
+    assert divisions, f"{name}: no <divisions> element in MusicXML"
+    assert set(divisions) == {12}, (
+        f"{name}: expected <divisions>12</divisions>, got {sorted(set(divisions))}"
+    )
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_pitches_in_piano_range(name: str, engraved_artifacts):
+    """Every pitched ``<note>`` must land on an 88-key piano (A0..C8)."""
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+    out_of_range: list[int] = []
+    for pitch_elem in root.iter("pitch"):
+        midi = _musicxml_pitch_to_midi(pitch_elem)
+        if not _PIANO_MIN_MIDI <= midi <= _PIANO_MAX_MIDI:
+            out_of_range.append(midi)
+    assert not out_of_range, f"{name}: pitches outside piano range: {sorted(set(out_of_range))}"
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_l2_note_count_matches_fixture(name: str, engraved_artifacts):
+    """MusicXML note-attack count agrees with the fixture's note count.
+
+    Tied continuations (``<tie type="stop"/>``) are excluded — they
+    represent the same attack that spans a barline. Rests are skipped.
+    """
+    from lxml import etree
+
+    fixture = load_score_fixture(name)
+    expected = len(_expected_note_pitches(fixture))
+
+    musicxml, _ = engraved_artifacts[name]
+    root = etree.fromstring(musicxml)
+
+    attack_count = 0
+    for note in root.iter("note"):
+        if note.find("rest") is not None:
+            continue
+        tie_stops = [t for t in note.findall("tie") if t.get("type") == "stop"]
+        if tie_stops and len(tie_stops) == len(note.findall("tie")):
+            # Pure tie-continuation (no concurrent start) — not a new attack.
+            continue
+        attack_count += 1
+
+    assert attack_count == expected, (
+        f"{name}: MusicXML has {attack_count} note attacks, fixture has {expected}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# L2 — "Stop dropping data" lints (plan phase 1.3–1.6 / PR-5)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_humanized_dynamics_rendered(engraved_artifacts):
+    """Static dynamic + hairpin from the expression map reach MusicXML.
+
+    The ``humanized_with_expression`` fixture carries a ``p`` at beat 0
+    and a ``crescendo`` at beat 4. The static mark becomes a
+    ``<dynamics>`` element; the hairpin becomes a ``<words>cresc.</words>``
+    text direction.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["humanized_with_expression"]
+    root = etree.fromstring(musicxml)
+
+    dyn_children = [c.tag for dyn in root.iter("dynamics") for c in dyn]
+    assert "p" in dyn_children, (
+        f"expected <dynamics><p/></dynamics>; got dynamics children {dyn_children}"
+    )
+
+    words = [w.text for w in root.iter("words")]
+    assert "cresc." in words, f"expected 'cresc.' text direction; got {words}"
+
+
+def test_l2_humanized_pedal_text_rendered(engraved_artifacts):
+    """Sustain / sostenuto / una corda all surface as MusicXML text directions.
+
+    Sustain uses the standard "Ped." / "*" pair; sostenuto and una corda
+    use descriptive labels because MusicXML has no dedicated glyphs.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["humanized_with_expression"]
+    root = etree.fromstring(musicxml)
+    words = [w.text for w in root.iter("words")]
+
+    for expected in ("Ped.", "*", "Sost. Ped.", "una corda", "tre corde"):
+        assert expected in words, (
+            f"expected pedal word {expected!r} in MusicXML; got {words}"
+        )
+
+
+def test_l2_humanized_fermata_rendered(engraved_artifacts):
+    """A ``fermata`` articulation emits a ``<fermata>`` element in <notations>."""
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["humanized_with_expression"]
+    root = etree.fromstring(musicxml)
+    fermatas = list(root.iter("fermata"))
+    assert fermatas, "no <fermata> element in rendered MusicXML"
+
+
+# ---------------------------------------------------------------------------
+# L2 — Grand-staff structure (plan phase 2.3 / PR-8)
+# ---------------------------------------------------------------------------
+
+
+def _count_staff(musicxml: bytes, staff: int) -> int:
+    """Count pitched ``<note>`` elements tagged with ``<staff>{staff}</staff>``."""
+    from lxml import etree
+
+    count = 0
+    for note in etree.fromstring(musicxml).iter("note"):
+        if note.find("rest") is not None:
+            continue
+        staff_elem = note.find("staff")
+        if staff_elem is not None and int(staff_elem.text) == staff:
+            count += 1
+    return count
+
+
+def test_l2_grand_staff_single_part(engraved_artifacts):
+    """Piano scores render as one ``<part>`` with ``<staves>2</staves>``.
+
+    Plan phase 2.3 / PR-8 — before this change, engrave emitted two
+    separate parts ("Right Hand", "Left Hand") which renderers drew as
+    two stacked instruments without a brace. The fix is ``PartStaff`` +
+    ``StaffGroup(symbol='brace')``, which music21 collapses into a single
+    multi-staff part at export time. The part-list label is "Piano",
+    not the per-hand labels used for in-engine bookkeeping.
+    """
+    from lxml import etree
+
+    # two_hand_chordal is the canonical grand-staff fixture: triads in
+    # RH, octaves in LH — both must end up on the same part.
+    musicxml, _ = engraved_artifacts["two_hand_chordal"]
+    root = etree.fromstring(musicxml)
+
+    parts = root.findall("part")
+    assert len(parts) == 1, f"expected single merged part, got {len(parts)}"
+
+    score_parts = root.findall("part-list/score-part")
+    assert len(score_parts) == 1
+    part_name = score_parts[0].findtext("part-name")
+    assert part_name == "Piano", f"expected part-name 'Piano', got {part_name!r}"
+
+    staves = [int(e.text) for e in root.iter("staves")]
+    assert staves and max(staves) == 2, (
+        f"expected <staves>2</staves>, got {staves}"
+    )
+
+    # Staff 1 gets the 12 RH notes, staff 2 gets the 8 LH notes.
+    assert _count_staff(musicxml, 1) == 12
+    assert _count_staff(musicxml, 2) == 8
+
+
+def test_l2_two_voices_preserved_on_same_staff(engraved_artifacts):
+    """Plan phase 3.1 / PR-10: two-voice RH content keeps both voices.
+
+    The ``bach_invention_excerpt`` fixture carries 8 RH notes on
+    ``voice=1`` (upper line, quarters) and 4 RH notes on ``voice=2``
+    (lower line, half notes). Before PR-10 the engrave sanitizer
+    collapsed every ``<voice>`` tag to 1, destroying music21's
+    stems-up-melody / stems-down-accompaniment separation. The fix is
+    explicit music21 ``Voice`` sub-streams + a post-``makeNotation``
+    id-rename from the 0-indexed integers music21 stamps during
+    measure construction back to the MusicXML-valid ``1``/``2``.
+
+    What we check: (a) both voice numbers are present, (b) at least
+    one ``<backup>`` element exists (music21 emits ``<backup>`` before
+    switching from voice 1 to voice 2 within a measure), and (c) the
+    note counts per voice match the fixture — allowing one extra
+    voice-2 attack for the tie-continuation music21 inserts where a
+    half note bridges the barline.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["bach_invention_excerpt"]
+    root = etree.fromstring(musicxml)
+
+    voice_counts: dict[str, int] = {}
+    for note in root.iter("note"):
+        if note.find("rest") is not None:
+            continue
+        v = note.findtext("voice")
+        if v is not None:
+            voice_counts[v] = voice_counts.get(v, 0) + 1
+
+    assert "1" in voice_counts and "2" in voice_counts, (
+        f"expected both <voice>1</voice> and <voice>2</voice>; got {voice_counts}"
+    )
+    assert voice_counts["1"] == 8, f"voice 1 count {voice_counts['1']} != 8"
+    # Voice 2 = 4 half notes in the fixture; expect 4 or 5 (tie split at barline).
+    assert voice_counts["2"] in (4, 5), f"voice 2 count {voice_counts['2']} not in (4, 5)"
+    assert "0" not in voice_counts, (
+        "<voice>0</voice> is invalid MusicXML; sanitizer should have remapped it"
+    )
+
+    backups = list(root.iter("backup"))
+    assert backups, "expected <backup> elements separating voice 1 from voice 2"
+
+
+def test_l2_rh_only_fixture_still_single_part(engraved_artifacts):
+    """An empty-LH fixture still emits a grand staff — just with an empty
+    bass stave. This catches the regression where dropping LH content
+    would also drop the ``<staves>2</staves>`` declaration.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["empty_left_hand"]
+    root = etree.fromstring(musicxml)
+    assert len(root.findall("part")) == 1
+    staves = [int(e.text) for e in root.iter("staves")]
+    assert staves and max(staves) == 2
+
+
+def test_engrave_does_not_leak_music21_defaults():
+    """``music21.defaults.divisionsPerQuarter`` must be restored after engrave.
+
+    PR-9 overrides this global to 12 around ``s.write("musicxml", ...)``
+    so OSMD-friendly divisions come out by construction. The override
+    must be wrapped in try/finally so that other music21 callers (eval
+    scripts, arrange's makeNotation in a shared process, etc.) keep
+    seeing the upstream default of 10080.
+    """
+    import music21
+
+    from backend.services.engrave import _engrave_sync
+
+    prior = music21.defaults.divisionsPerQuarter
+    _pdf, _xml, _midi, _chord_count = _engrave_sync(
+        load_score_fixture("c_major_scale"), title="t", composer="c"
+    )
+    assert music21.defaults.divisionsPerQuarter == prior
+
+
+# ---------------------------------------------------------------------------
+# L2 — Tuplet survival (plan phase 3.4 / PR-13)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_triplet_eighths_render_as_tuplet(engraved_artifacts):
+    """Plan phase 3.4 — triplet-8ths survive without engrave re-quantizing.
+
+    The ``triplet_eighths`` fixture carries 12 RH notes at 1/3-beat
+    spacing over 4 beats — a clean triplet grid from arrange's
+    ``_estimate_best_grid`` path. Before PR-13, engrave re-quantized
+    every Part to ``quarterLengthDivisors=(4, 3)`` as a safety net
+    inherited from the divisions=10080 era; the coarser divisor tuple
+    could not represent triplet-16ths and the re-quantize silently
+    dropped fine resolution.
+
+    After PR-13 engrave trusts arrange's grid directly and music21's
+    ``makeNotation`` auto-detects the tuplet bracket. What we check:
+
+    - Each triplet-8th duration = divisions/3 (at divisions=12, that's 4).
+    - The MusicXML carries ``<time-modification>`` elements with
+      ``<actual-notes>3</actual-notes>`` / ``<normal-notes>2</normal-notes>``
+      on each triplet member — the standard "3 in the time of 2"
+      encoding for an 8th-note triplet.
+    - At least 12 such time-modification blocks land on RH (one per
+      triplet 8th).
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["triplet_eighths"]
+    root = etree.fromstring(musicxml)
+
+    # Every triplet 8th should have <time-modification> with 3/2 ratio.
+    triplet_members = 0
+    for note in root.iter("note"):
+        if note.find("rest") is not None:
+            continue
+        tm = note.find("time-modification")
+        if tm is None:
+            continue
+        actual = tm.findtext("actual-notes")
+        normal = tm.findtext("normal-notes")
+        if actual == "3" and normal == "2":
+            triplet_members += 1
+
+    assert triplet_members >= 12, (
+        f"expected ≥12 triplet-8th members with <time-modification>3:2</time-modification>, "
+        f"got {triplet_members}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# L2 — Key signature verification (plan phase 3.3 / PR-12)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_key_signature_override_on_mislabel(engraved_artifacts):
+    """Plan phase 3.3 — Krumhansl-Schmuckler overrides a mislabeled key.
+
+    The ``mislabeled_key`` fixture is an unambiguous F# minor piece
+    tagged as ``C:major``. After the KS analyzer runs in
+    ``_resolve_key_signature``, the MusicXML ``<key><fifths>`` element
+    should show ``3`` (F# minor / A major — three sharps) instead of
+    ``0`` (C major — no accidentals).
+
+    Without the override, every F#/G#/C# in the piece would render as
+    an explicit accidental on each note head — unreadable.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["mislabeled_key"]
+    root = etree.fromstring(musicxml)
+    fifths = [int(e.text) for e in root.iter("fifths")]
+    assert fifths, "no <fifths> element in mislabeled_key MusicXML"
+    assert set(fifths) == {3}, (
+        f"expected <fifths>3</fifths> (F# minor override), got {sorted(set(fifths))}"
+    )
+    modes = [e.text for e in root.iter("mode")]
+    assert modes and all(m == "minor" for m in modes), (
+        f"expected <mode>minor</mode>, got {modes}"
+    )
+
+
+def test_l2_key_signature_low_correlation_trusts_label():
+    """Plan phase 3.3 — low KS correlation leaves the declared key alone.
+
+    Builds a throwaway score out of a highly chromatic tone row so the
+    Krumhansl-Schmuckler correlation lands well below the 0.80 override
+    floor. Even if the analyzer's tonic guess disagrees with the
+    declared key, the override must **not** fire — the histogram is too
+    ambiguous to trust.
+    """
+    import music21
+
+    from backend.contracts import (
+        SCHEMA_VERSION,
+        PianoScore,
+        ScoreMetadata,
+        ScoreNote,
+        TempoMapEntry,
+    )
+    from backend.services.engrave import _resolve_key_signature
+
+    # All 12 pitch classes once each — maximum chromatic, no tonal
+    # center, correlation should collapse.
+    row = [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71]
+    score = PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=[
+            ScoreNote(id=f"rh-{i:04d}", pitch=p, onset_beat=float(i),
+                      duration_beat=1.0, velocity=80, voice=1)
+            for i, p in enumerate(row)
+        ],
+        left_hand=[],
+        metadata=ScoreMetadata(
+            key="C:major",
+            time_signature=(4, 4),
+            tempo_map=[TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)],
+            difficulty="intermediate",
+            sections=[],
+            chord_symbols=[],
+        ),
+    )
+
+    root, mode, overridden = _resolve_key_signature(score, music21)
+    assert not overridden, (
+        f"chromatic tone row should not trigger override; got {root}:{mode}"
+    )
+    assert (root, mode) == ("C", "major"), (
+        f"expected declared C:major to survive, got {root}:{mode}"
+    )
+
+
+def test_l2_key_signature_trusts_correct_label(engraved_artifacts):
+    """Plan phase 3.3 — KS does **not** override when the label agrees.
+
+    Every existing fixture except ``mislabeled_key`` is honestly
+    labeled as C:major. The override must keep quiet on all of them so
+    we don't drift the declared key based on analyzer noise.
+    """
+    from lxml import etree
+
+    for name in FIXTURE_NAMES:
+        if name == "mislabeled_key":
+            continue
+        musicxml, _ = engraved_artifacts[name]
+        root = etree.fromstring(musicxml)
+        fifths = [int(e.text) for e in root.iter("fifths")]
+        assert set(fifths) == {0}, (
+            f"{name}: unexpected key-signature override — expected <fifths>0</fifths>, "
+            f"got {sorted(set(fifths))}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# L2 — Chord symbol filter gate (plan phase 3.2 / PR-11)
+# ---------------------------------------------------------------------------
+
+
+def test_l2_chord_symbols_filter_gate(engraved_artifacts):
+    """Plan phase 3.2 — only the three clean labels reach MusicXML.
+
+    The ``chord_symbols`` fixture carries seven input labels covering
+    every branch of ``_attach_chord_symbols``:
+
+    - ``C:maj7``, ``Dm7``, ``F:maj7`` — high-confidence, parseable, ≥3 pitches **→ rendered**
+    - ``G5`` — pitch-octave shape **→ dropped (shape gate)**
+    - ``C:maj`` — below 0.5 confidence **→ dropped (confidence gate)**
+    - ``???`` — unparseable **→ dropped (parse gate)**
+    - ``C5`` — pitch-octave shape **→ dropped (shape gate)**
+
+    Assertion: exactly three ``<harmony>`` elements land in the output,
+    with roots ``{C, D, F}``.
+    """
+    from lxml import etree
+
+    musicxml, _ = engraved_artifacts["chord_symbols"]
+    root = etree.fromstring(musicxml)
+    harmonies = list(root.iter("harmony"))
+    assert len(harmonies) == 3, (
+        f"expected 3 rendered chord symbols after filter gate, got {len(harmonies)}"
+    )
+
+    roots = {h.findtext("root/root-step") for h in harmonies}
+    assert roots == {"C", "D", "F"}, (
+        f"expected chord roots {{C, D, F}}, got {roots}"
+    )
+
+
+def test_l2_chord_symbols_flag_reflects_filter(tmp_path):
+    """``EngravedScoreData.includes_chord_symbols`` must gate on the *rendered*
+    count, not the raw input count. PR-11 (plan phase 3.2) wires the
+    filter-gate return value all the way out through ``EngraveService``
+    so the flag stops lying about what's on the page.
+    """
+    import asyncio
+
+    from backend.services.engrave import EngraveService
+    from backend.storage.local import LocalBlobStore
+    from tests.fixtures import load_score_fixture
+
+    svc = EngraveService(LocalBlobStore(tmp_path))
+    fixture = load_score_fixture("chord_symbols")
+    out = asyncio.run(
+        svc.run(fixture, job_id="test-pr11-chord-flag", title="t", composer="c")
+    )
+    assert out.metadata.includes_chord_symbols is True
+
+
+def test_l2_chord_symbols_flag_false_when_all_filtered(tmp_path):
+    """Input with *only* bad chord labels → ``includes_chord_symbols`` is False.
+
+    Previously the flag was ``len(chord_symbols) > 0``, which would
+    return True even when every label was about to be dropped. Build a
+    throwaway score with three shape-gate-failing labels and verify the
+    flag flips to False after rendering.
+    """
+    import asyncio
+
+    from backend.contracts import (
+        SCHEMA_VERSION,
+        PianoScore,
+        ScoreChordEvent,
+        ScoreMetadata,
+        ScoreNote,
+        TempoMapEntry,
+    )
+    from backend.services.engrave import EngraveService
+    from backend.storage.local import LocalBlobStore
+
+    score = PianoScore(
+        schema_version=SCHEMA_VERSION,
+        right_hand=[
+            ScoreNote(id="rh-0000", pitch=60, onset_beat=0.0, duration_beat=1.0,
+                      velocity=80, voice=1),
+            ScoreNote(id="rh-0001", pitch=62, onset_beat=1.0, duration_beat=1.0,
+                      velocity=80, voice=1),
+        ],
+        left_hand=[],
+        metadata=ScoreMetadata(
+            key="C:major",
+            time_signature=(4, 4),
+            tempo_map=[TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)],
+            difficulty="intermediate",
+            sections=[],
+            chord_symbols=[
+                ScoreChordEvent(beat=0.0, duration_beat=1.0, label="G5",
+                                root=67, confidence=0.99),
+                ScoreChordEvent(beat=1.0, duration_beat=1.0, label="C3",
+                                root=48, confidence=0.99),
+            ],
+        ),
+    )
+
+    svc = EngraveService(LocalBlobStore(tmp_path))
+    out = asyncio.run(
+        svc.run(score, job_id="test-pr11-chord-flag-false", title="t", composer="c")
+    )
+    assert out.metadata.includes_chord_symbols is False, (
+        "flag should be False when every input chord is filtered out"
+    )
+
+
+def test_l2_engraved_flags_reflect_rendered_content(engraved_artifacts):
+    """``EngravedScoreData.includes_dynamics / includes_pedal_marks`` must
+    now report True when the humanized input populates them.
+
+    The flag flip is the PR-5 counterpart to the phase 1.1 "truthful
+    flags" change — phase 1.1 could only flip the flags to False because
+    engrave wasn't rendering those markings yet.
+    """
+    import asyncio
+    import tempfile
+    from pathlib import Path
+
+    from backend.services.engrave import EngraveService
+    from backend.storage.local import LocalBlobStore
+    from tests.fixtures import load_score_fixture
+
+    # EngraveService writes artifacts to a blob store before returning,
+    # so stand up a throwaway local store rooted in a tmp dir.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        svc = EngraveService(LocalBlobStore(Path(tmpdir)))
+        fixture = load_score_fixture("humanized_with_expression")
+        out = asyncio.run(
+            svc.run(fixture, job_id="test-pr5-flags", title="t", composer="c")
+        )
+        assert out.metadata.includes_dynamics is True
+        assert out.metadata.includes_pedal_marks is True

--- a/tests/test_ingest_cover_search.py
+++ b/tests/test_ingest_cover_search.py
@@ -1,0 +1,413 @@
+"""Tests for the cover_search integration inside IngestService.
+
+When a job arrives with ``prefer_clean_source=True``, the ingest stage
+should:
+
+  1. Probe the user's YouTube URL for (title, artist)
+  2. Search YouTube for a piano cover of that song
+  3. If a candidate clears the score threshold, SWAP the URL that
+     gets passed to ``_download_youtube_sync`` for the cover's URL
+  4. Otherwise, fall back silently to downloading the original URL
+
+The whole feature is gated by ``cover_search_enabled`` in Settings so
+operators can flip it off globally. The silent-failure contract is
+preserved — any cover_search exception must fall back to the original
+URL, never crash the job.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from backend.contracts import (
+    SCHEMA_VERSION,
+    InputBundle,
+    InputMetadata,
+    RemoteAudioFile,
+)
+from backend.services.cover_search import CoverSearchResult
+from backend.services.ingest import IngestService
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def blob_store(tmp_path):
+    from backend.storage.local import LocalBlobStore
+    return LocalBlobStore(tmp_path / "blob")
+
+
+@pytest.fixture
+def service(blob_store):
+    return IngestService(blob_store=blob_store)
+
+
+def _make_bundle(
+    url: str = "https://youtube.com/watch?v=dQw4w9WgXcQ",
+    *,
+    prefer_clean_source: bool = True,
+) -> InputBundle:
+    return InputBundle(
+        schema_version=SCHEMA_VERSION,
+        audio=None,
+        midi=None,
+        metadata=InputMetadata(
+            title=url,
+            artist=None,
+            source="title_lookup",
+            prefer_clean_source=prefer_clean_source,
+        ),
+    )
+
+
+def _fake_downloaded_audio(source_url: str) -> tuple[RemoteAudioFile, str, str]:
+    """Build the tuple _download_youtube_sync normally returns.
+
+    ``source_url`` is embedded in the content_hash so tests can assert
+    which URL the downloader was actually called with.
+    """
+    return (
+        RemoteAudioFile(
+            uri="file:///tmp/fake.wav",
+            format="wav",
+            sample_rate=44100,
+            duration_sec=60.0,
+            channels=2,
+            content_hash=f"hash-for-{source_url}",
+        ),
+        "Downloaded Video Title",
+        "Downloaded Uploader",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: cover found, URL swapped
+# ---------------------------------------------------------------------------
+
+
+class TestCoverSearchSwapsUrl:
+    """When prefer_clean_source=True and a high-scoring cover exists,
+    the ingest stage should pass the cover URL to _download_youtube_sync."""
+
+    def test_swaps_to_cover_url_when_match_clears_threshold(self, service):
+        bundle = _make_bundle(prefer_clean_source=True)
+        cover_url = "https://youtube.com/watch?v=rouss12cvr1"
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = ("bohemian rhapsody", "Queen")
+            mock_find.return_value = CoverSearchResult(
+                url=cover_url,
+                score=110,
+                channel="Rousseau",
+                title="Bohemian Rhapsody - Queen (Piano Cover)",
+            )
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            result = asyncio.run(service.run(bundle))
+
+        # _download_youtube_sync must have received the COVER url, not the user's.
+        mock_dl.assert_called_once()
+        called_url = mock_dl.call_args.args[0]
+        assert called_url == cover_url
+        assert result.audio is not None
+        assert result.audio.content_hash == f"hash-for-{cover_url}"
+
+    def test_probe_and_search_receive_correct_args(self, service):
+        bundle = _make_bundle(
+            url="https://youtu.be/fJ9rUzIMcZQ",
+            prefer_clean_source=True,
+        )
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = ("bohemian rhapsody", "Queen")
+            mock_find.return_value = None  # below threshold → no swap
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            asyncio.run(service.run(bundle))
+
+        # probe is called with the original URL
+        mock_probe.assert_called_once_with("https://youtu.be/fJ9rUzIMcZQ")
+        # find_clean_source gets the probed title + artist
+        mock_find.assert_called_once()
+        call = mock_find.call_args
+        # title is first positional arg, artist is second
+        assert call.args[0] == "bohemian rhapsody"
+        assert call.args[1] == "Queen"
+
+
+# ---------------------------------------------------------------------------
+# Fallback path: no cover / probe failed / search failed
+# ---------------------------------------------------------------------------
+
+
+class TestCoverSearchFallsBackToOriginal:
+    """Any failure in the cover-search chain must leave the original
+    URL in place — the silent-failure contract."""
+
+    def test_falls_back_when_find_clean_source_returns_none(self, service):
+        original_url = "https://youtube.com/watch?v=origvid1111"
+        bundle = _make_bundle(original_url, prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = ("some title", "some artist")
+            mock_find.return_value = None
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            asyncio.run(service.run(bundle))
+
+        # Original URL is what actually gets downloaded.
+        called_url = mock_dl.call_args.args[0]
+        assert called_url == original_url
+
+    def test_falls_back_when_probe_returns_none(self, service):
+        original_url = "https://youtube.com/watch?v=origvid1111"
+        bundle = _make_bundle(original_url, prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = None  # probe failed
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            asyncio.run(service.run(bundle))
+
+        # find_clean_source should NOT even be called if the probe failed —
+        # no point searching for a song we couldn't identify.
+        mock_find.assert_not_called()
+        called_url = mock_dl.call_args.args[0]
+        assert called_url == original_url
+
+    def test_falls_back_when_find_clean_source_raises(self, service):
+        # find_clean_source is documented as silent-failure, but defensive
+        # depth: if it somehow does raise, ingest still must not crash.
+        original_url = "https://youtube.com/watch?v=origvid1111"
+        bundle = _make_bundle(original_url, prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = ("title", "artist")
+            mock_find.side_effect = RuntimeError("unexpected crash")
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            # Must not propagate
+            result = asyncio.run(service.run(bundle))
+
+        called_url = mock_dl.call_args.args[0]
+        assert called_url == original_url
+        assert result.audio is not None
+
+    def test_falls_back_when_cover_result_has_non_youtube_parseable_url(self, service):
+        # Defense-in-depth for the (Critical) PR #47 review finding: even
+        # if _yt_dlp_search's URL normalization misses a pathological entry
+        # and cover_search returns a CoverSearchResult with a bare video ID
+        # (or any other string that urlparse can't turn into a YouTube URL),
+        # _maybe_swap_for_cover_sync must refuse to propagate it downstream.
+        # Otherwise _download_youtube_sync raises ValueError and crashes
+        # the whole ingest job — exactly what the silent-failure contract
+        # is meant to prevent.
+        original_url = "https://youtube.com/watch?v=origvid1111"
+        bundle = _make_bundle(original_url, prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = ("bohemian rhapsody", "Queen")
+            mock_find.return_value = CoverSearchResult(
+                url="dQw4w9WgXcQ",  # ← bare video ID — extract_youtube_id rejects it
+                score=110,
+                channel="Rousseau",
+                title="Bohemian Rhapsody (Piano Cover)",
+            )
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            # Must not crash — the bad URL is rejected and we fall back.
+            asyncio.run(service.run(bundle))
+
+        called_url = mock_dl.call_args.args[0]
+        assert called_url == original_url
+
+
+# ---------------------------------------------------------------------------
+# Gating: prefer_clean_source=False and cover_search_enabled=False
+# ---------------------------------------------------------------------------
+
+
+class TestCoverSearchGating:
+    """cover_search should only run when BOTH the per-job flag and the
+    global setting are on."""
+
+    def test_prefer_clean_source_false_skips_cover_search(self, service):
+        bundle = _make_bundle(prefer_clean_source=False)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+            asyncio.run(service.run(bundle))
+
+        mock_probe.assert_not_called()
+        mock_find.assert_not_called()
+
+    def test_global_kill_switch_skips_cover_search(self, service, monkeypatch):
+        # Simulate OHSHEET_COVER_SEARCH_ENABLED=false via the settings
+        # singleton. Ingest reads this at run-time so a fresh setting
+        # takes effect without restarting the service.
+        import backend.services.ingest as ingest_mod
+        monkeypatch.setattr(ingest_mod.settings, "cover_search_enabled", False)
+
+        bundle = _make_bundle(prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+            asyncio.run(service.run(bundle))
+
+        mock_probe.assert_not_called()
+        mock_find.assert_not_called()
+
+    def test_uses_configured_min_score_threshold(self, service, monkeypatch):
+        # If operator bumps OHSHEET_COVER_SEARCH_MIN_SCORE=90, that value
+        # must propagate into find_clean_source's min_score parameter.
+        import backend.services.ingest as ingest_mod
+        monkeypatch.setattr(ingest_mod.settings, "cover_search_min_score", 90)
+
+        bundle = _make_bundle(prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = ("title", "artist")
+            mock_find.return_value = None
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+            asyncio.run(service.run(bundle))
+
+        mock_find.assert_called_once()
+        # min_score should be passed as kwarg
+        assert mock_find.call_args.kwargs.get("min_score") == 90
+
+
+# ---------------------------------------------------------------------------
+# Non-applicable paths: audio upload, non-YouTube title
+# ---------------------------------------------------------------------------
+
+
+class TestCoverSearchSkipsNonYoutubeInputs:
+    """Cover search should never run on inputs that don't match the
+    YouTube-URL-via-title-lookup shape."""
+
+    def test_non_youtube_title_skips_cover_search(self, service):
+        bundle = InputBundle(
+            schema_version=SCHEMA_VERSION,
+            audio=None,
+            midi=None,
+            metadata=InputMetadata(
+                title="Yesterday",  # plain song title, not a URL
+                artist="The Beatles",
+                source="title_lookup",
+                prefer_clean_source=True,
+            ),
+        )
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            asyncio.run(service.run(bundle))
+
+        mock_probe.assert_not_called()
+        mock_find.assert_not_called()
+        mock_dl.assert_not_called()
+
+    def test_audio_upload_skips_cover_search(self, service):
+        existing_audio = RemoteAudioFile(
+            uri="file:///tmp/uploaded.wav",
+            format="wav",
+            sample_rate=44100,
+            duration_sec=120.0,
+            channels=2,
+        )
+        bundle = InputBundle(
+            schema_version=SCHEMA_VERSION,
+            audio=existing_audio,
+            midi=None,
+            metadata=InputMetadata(
+                title="https://youtube.com/watch?v=dQw4w9WgXcQ",
+                artist=None,
+                source="audio_upload",
+                prefer_clean_source=True,
+            ),
+        )
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+        ):
+            asyncio.run(service.run(bundle))
+
+        mock_probe.assert_not_called()
+        mock_find.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Static bundle builder: from_title_lookup must accept prefer_clean_source
+# ---------------------------------------------------------------------------
+
+
+class TestFromTitleLookupBuilder:
+    """PR #47 review (Important) #3: the static
+    IngestService.from_title_lookup builder is used by scripts, tests,
+    and any future caller that doesn't hit the API. Before the fix it
+    silently dropped the prefer_clean_source flag because the builder
+    didn't accept it, so any non-API caller would see the cover_search
+    fast path skipped without knowing why. The live API route
+    constructs InputBundle directly, so production is unaffected."""
+
+    def test_from_title_lookup_defaults_to_prefer_clean_source_false(self):
+        bundle = IngestService.from_title_lookup("Yesterday", artist="The Beatles")
+        assert bundle.metadata.prefer_clean_source is False
+
+    def test_from_title_lookup_accepts_prefer_clean_source_true(self):
+        bundle = IngestService.from_title_lookup(
+            "Yesterday",
+            artist="The Beatles",
+            prefer_clean_source=True,
+        )
+        assert bundle.metadata.prefer_clean_source is True
+
+    def test_from_title_lookup_prefer_clean_source_is_keyword_only(self):
+        # prefer_clean_source must be keyword-only to prevent positional
+        # shadowing of artist (a common mistake with a 2-arg signature).
+        import pytest
+        with pytest.raises(TypeError):
+            IngestService.from_title_lookup("Yesterday", "The Beatles", True)  # type: ignore[misc]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,6 +1,10 @@
 import time
+from unittest.mock import patch
+
+import pytest
 
 from backend.config import settings
+from backend.contracts import RemoteAudioFile
 
 
 def _upload_audio(client):
@@ -8,6 +12,26 @@ def _upload_audio(client):
         "/v1/uploads/audio",
         files={"file": ("song.wav", b"RIFFfake wav data", "audio/wav")},
     ).json()
+
+
+@pytest.fixture
+def mock_youtube_download():
+    """Stub out _download_youtube_sync so YouTube-URL tests don't hit the
+    network. Returns a minimal RemoteAudioFile + title/uploader tuple so
+    the ingest stage completes normally."""
+    with patch("backend.services.ingest._download_youtube_sync") as mock_dl:
+        mock_dl.return_value = (
+            RemoteAudioFile(
+                uri="file:///tmp/fake.wav",
+                format="wav",
+                sample_rate=44100,
+                duration_sec=60.0,
+                channels=2,
+            ),
+            "Mock Song Title",
+            "Mock Uploader",
+        )
+        yield mock_dl
 
 
 def test_create_job_from_audio_runs_to_completion(client):
@@ -55,11 +79,121 @@ def test_create_job_rejects_both_audio_and_midi(client):
     assert response.status_code == 400
 
 
+def test_create_job_rejects_audio_with_nonexistent_uri(client):
+    # Integrity: clients must not be able to forge a RemoteAudioFile
+    # pointing at a blob URI that was never uploaded. Without this
+    # check the route accepted the request, pushed it through stub
+    # stages, and reported a successful job — the user only saw the
+    # problem when they tried to play the resulting "audio" (which
+    # was nothing at all).
+    bogus_audio = {
+        "uri": "file:///tmp/this-blob-was-never-uploaded.wav",
+        "format": "wav",
+        "sample_rate": 44100,
+        "duration_sec": 1.0,
+        "channels": 2,
+        "content_hash": "0" * 64,
+    }
+    response = client.post(
+        "/v1/jobs",
+        json={"audio": bogus_audio, "title": "Forged", "artist": "Ghost"},
+    )
+    assert response.status_code == 400
+    assert "uri" in response.json()["detail"].lower()
+
+
+def test_create_job_rejects_midi_with_nonexistent_uri(client):
+    bogus_midi = {
+        "uri": "file:///tmp/never-uploaded.mid",
+        "ticks_per_beat": 480,
+        "content_hash": "0" * 64,
+    }
+    response = client.post(
+        "/v1/jobs",
+        json={"midi": bogus_midi, "title": "Forged", "artist": "Ghost"},
+    )
+    assert response.status_code == 400
+    assert "uri" in response.json()["detail"].lower()
+
+
 def test_create_job_title_lookup_only(client):
     response = client.post("/v1/jobs", json={"title": "Yesterday", "artist": "The Beatles"})
     assert response.status_code == 202
     job = response.json()
     assert job["variant"] == "full"
+
+
+# ---------------------------------------------------------------------------
+# prefer_clean_source: per-job opt-in to the cover_search fast path
+# ---------------------------------------------------------------------------
+#
+# The upload screen has a "find a clean piano cover" toggle. When the user
+# flips it on, the frontend must be able to pass prefer_clean_source=true
+# in the POST /v1/jobs body, and that flag must land on the InputBundle's
+# metadata so the ingest stage can read it. These tests exercise the route
+# wiring; the ingest-side consumption is tested in test_ingest_cover_search.
+
+
+def test_prefer_clean_source_defaults_to_false_when_omitted(client):
+    # Omitting the flag must NOT break the request (backward compat with
+    # existing frontends that don't know about this field yet).
+    response = client.post("/v1/jobs", json={"title": "Yesterday"})
+    assert response.status_code == 202
+
+
+def test_prefer_clean_source_true_is_accepted_by_create_job(client, mock_youtube_download):
+    response = client.post(
+        "/v1/jobs",
+        json={"title": "https://youtu.be/fJ9rUzIMcZQ", "prefer_clean_source": True},
+    )
+    assert response.status_code == 202, response.text
+
+
+def test_prefer_clean_source_is_rejected_on_bad_type(client):
+    # Pydantic should reject a non-bool value cleanly — documented contract.
+    response = client.post(
+        "/v1/jobs",
+        json={"title": "Yesterday", "prefer_clean_source": "sometimes"},
+    )
+    assert response.status_code == 422
+
+
+def test_prefer_clean_source_lands_on_bundle_metadata(client, mock_youtube_download):
+    # The submitted flag must survive the trip into the JobManager's stored
+    # InputBundle — otherwise the ingest stage never sees it.
+    from backend.api.deps import get_job_manager
+    from backend.main import app
+
+    response = client.post(
+        "/v1/jobs",
+        json={"title": "https://youtu.be/fJ9rUzIMcZQ", "prefer_clean_source": True},
+    )
+    assert response.status_code == 202, response.text
+    job_id = response.json()["job_id"]
+
+    # Reach into the in-memory JobManager to verify the stored bundle.
+    # Same DI singleton the route uses, so the record is guaranteed to exist.
+    manager = app.dependency_overrides.get(get_job_manager, get_job_manager)()
+    record = manager.get(job_id)
+    assert record is not None
+    assert record.bundle.metadata.prefer_clean_source is True
+
+
+def test_prefer_clean_source_false_lands_on_bundle_metadata(client, mock_youtube_download):
+    from backend.api.deps import get_job_manager
+    from backend.main import app
+
+    response = client.post(
+        "/v1/jobs",
+        json={"title": "https://youtu.be/fJ9rUzIMcZQ", "prefer_clean_source": False},
+    )
+    assert response.status_code == 202, response.text
+    job_id = response.json()["job_id"]
+
+    manager = app.dependency_overrides.get(get_job_manager, get_job_manager)()
+    record = manager.get(job_id)
+    assert record is not None
+    assert record.bundle.metadata.prefer_clean_source is False
 
 
 def test_get_job_returns_404_for_unknown(client):

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -27,3 +27,60 @@ def test_upload_midi_returns_remote_midi_file(client):
     body = response.json()
     assert body["uri"].startswith("file://")
     assert body["ticks_per_beat"] == 480
+
+
+def test_upload_midi_rejects_unknown_extension(client):
+    # Parity with the audio endpoint: filename extension must be .mid/.midi.
+    response = client.post(
+        "/v1/uploads/midi",
+        files={"file": ("song.txt", b"MThd\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00",
+                        "text/plain")},
+    )
+    assert response.status_code == 415
+
+
+def test_upload_midi_rejects_arbitrary_bytes_with_midi_extension(client):
+    # Security / integrity: /v1/uploads/midi must validate that the
+    # uploaded bytes are actually a MIDI file, not just that the
+    # filename happens to end in .mid. Without the magic-header check,
+    # a client could upload ANY bytes (JSON, an executable, random
+    # garbage) and get a successful 200 with a blob URI they could then
+    # pass to /v1/jobs.
+    #
+    # The Standard MIDI File spec requires every SMF to begin with the
+    # 4-byte "MThd" chunk header. We check only these 4 bytes — deeper
+    # structural validation is the ingest stage's job.
+    response = client.post(
+        "/v1/uploads/midi",
+        files={"file": ("totally_not_midi.mid", b"this is a plain text file",
+                        "audio/midi")},
+    )
+    assert response.status_code == 415
+    assert "midi" in response.json()["detail"].lower()
+
+
+def test_upload_midi_rejects_empty_file(client):
+    # Edge case of the same validation: zero-byte file can't start with MThd.
+    response = client.post(
+        "/v1/uploads/midi",
+        files={"file": ("empty.mid", b"", "audio/midi")},
+    )
+    assert response.status_code == 415
+
+
+def test_upload_midi_accepts_valid_smf_header(client):
+    # Regression guard: the fix must not reject real MIDI files. A
+    # minimal valid SMF header starts with "MThd" + 4-byte length +
+    # 6-byte header body (format, ntrks, division).
+    smf_header = (
+        b"MThd"              # magic
+        b"\x00\x00\x00\x06"  # chunk length = 6
+        b"\x00\x00"          # format = 0 (single track)
+        b"\x00\x01"          # ntrks = 1
+        b"\x01\xe0"          # division = 480 ticks/quarter
+    )
+    response = client.post(
+        "/v1/uploads/midi",
+        files={"file": ("valid.mid", smf_header, "audio/midi")},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

Promotes the current **QA** line to **main** for production. This roll-up covers CI/deploy hardening, a large engrave and testing upgrade, and a critical API consistency fix validated on QA.

## What ships

### CI, environments, and release guardrails (#50)
- GitHub **QA** and **prod** environments with branch-aware deploy routing (`qa` vs `main` pushes).
- **Branch guard** workflow: only PRs whose head branch is `qa` may target `main` (enable as a required check on `main` if not already).
- **Caddy** `DOMAIN` placeholder for one compose path across environments; deployment and release-flow docs.

### Engrave quality, evaluation, and versioning (#51)
- **Evaluation harness**: committed score fixtures, L1 MIDI round-trip checks, and L2 MusicXML lints so engrave changes stay regression-tested.
- **Notation and rendering**: dynamics, pedal, fermata, grand staff (`PartStaff` + brace), divisions fixed at 12 for OSMD, up to two voices per staff, filtered chord symbols, Krumhansl–Schmuckler key check, removal of redundant re-quantize; **LilyPond** in the production image for real PDFs; metadata flags aligned with actual output.
- **Version visibility**: health/version wiring, Flutter footer, Docker `APP_VERSION`, pubspec sync script, semantic-release config and CI dry-run checks; system design doc brought in line with the as-built stack.

### Deploy / runtime fix (#53)
- Pin the API orchestrator to **`--workers 1`** so in-memory `JobManager` is not split across uvicorn workers (fixes intermittent **job not found** on QA when create and poll hit different workers).

## Release tagging

There is **no manual tag on this PR**. After merge to `main`, the [**Release** workflow](https://github.com/Oh-Sheet-Team/oh-sheet/blob/main/.github/workflows/release.yml) runs **python-semantic-release**: it bumps versions in `pyproject.toml` (and related packages), syncs `frontend/pubspec.yaml`, and pushes the **`v{version}`** git tag (`tag_format = "v{version}"` in `pyproject.toml`). Ensure `RELEASE_PAT` is configured for that workflow if tagging should succeed.

Merge when CI is green and QA sign-off is complete.

Made with [Cursor](https://cursor.com)