### PR TITLE
feat: gau-51 - add arrange service comprised of hugging face models

### DIFF
--- a/backend/api/routes/stages.py
+++ b/backend/api/routes/stages.py
@@ -150,7 +150,7 @@ async def stage_arrange(
     arrange = ArrangeService()
 
     async def coro(payload: TranscriptionResult) -> PianoScore:
-        return await arrange.run(payload)
+        return await arrange.run(payload, blob_store=blob)
 
     return await _run_stage(
         cmd,

--- a/backend/config.py
+++ b/backend/config.py
@@ -502,5 +502,16 @@ class Settings(BaseSettings):
     # Env: ``OHSHEET_SCORE_PIPELINE`` — ``arrange`` (default) or ``condense_transform``.
     score_pipeline: ScorePipelineMode = "arrange"
 
+    # ---- Arrange backend (rules vs HF MIDI path) ---------------------------
+    # ``rules`` — existing hand assignment + quantization in arrange.
+    # ``hf_midi_identity`` — materialize MIDI → HF inference (see
+    # ``arrange_hf_inference_mode``) → parse output → same ``_arrange_sync``.
+    # Env: ``OHSHEET_ARRANGE_BACKEND``.
+    arrange_backend: Literal["rules", "hf_midi_identity"] = "rules"
+    # Sub-mode for ``hf_midi_identity`` (extensible when real weights ship).
+    arrange_hf_inference_mode: Literal["identity"] = "identity"
+    # On materialize/HF/parse failure, run classic arrange on the original txr.
+    arrange_hf_fallback_to_rules: bool = True
+
 
 settings = Settings()

--- a/backend/jobs/runner.py
+++ b/backend/jobs/runner.py
@@ -8,6 +8,7 @@ the result URI, and deserialize the output for the next stage.
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
 import time
 from collections.abc import Callable
@@ -30,6 +31,10 @@ from backend.contracts import (
     TranscriptionResult,
 )
 from backend.jobs.events import JobEvent
+from backend.services.pretty_midi_tracks import (
+    harmonic_analysis_from_pretty_midi,
+    midi_tracks_from_pretty_midi,
+)
 from backend.storage.base import BlobStore
 
 log = logging.getLogger(__name__)
@@ -46,18 +51,6 @@ STEP_TO_TASK: dict[str, str] = {
     "humanize": "humanize.run",
     "engrave": "engrave.run",
 }
-
-
-def _gm_program_to_role(program: int, is_drum: bool) -> InstrumentRole:
-    if is_drum:
-        return InstrumentRole.OTHER
-    if program < 8:
-        return InstrumentRole.PIANO
-    if 32 <= program <= 39:
-        return InstrumentRole.BASS
-    if 72 <= program <= 79:
-        return InstrumentRole.MELODY
-    return InstrumentRole.CHORDS
 
 
 def _stub_transcription(reason: str) -> TranscriptionResult:
@@ -88,11 +81,19 @@ def _stub_transcription(reason: str) -> TranscriptionResult:
     )
 
 
-def _bundle_to_transcription(bundle: InputBundle) -> TranscriptionResult:
+def _bundle_to_transcription(
+    bundle: InputBundle,
+    *,
+    blob_store: BlobStore | None = None,
+    job_id: str | None = None,
+) -> TranscriptionResult:
     """Build a TranscriptionResult from a midi_upload bundle.
 
     Real path: parse the MIDI file via pretty_midi, recover the tempo map,
     fold each instrument into a MidiTrack, infer key/time-signature.
+    When ``blob_store`` and ``job_id`` are provided, the upload bytes are
+    copied to ``jobs/{job_id}/transcription/upload.mid`` and
+    ``transcription_midi_uri`` is set (claim-check for arrange / HF).
     Fallback: a small shape-correct stub so downstream stages still run.
     """
     if bundle.midi is None:
@@ -110,63 +111,17 @@ def _bundle_to_transcription(bundle: InputBundle) -> TranscriptionResult:
     except ImportError:
         return _stub_transcription("pretty_midi not installed")
 
+    midi_bytes = midi_path.read_bytes()
     try:
-        pm = pretty_midi.PrettyMIDI(str(midi_path))
+        pm = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
     except Exception as exc:  # noqa: BLE001 — bad MIDI bytes shouldn't crash the worker
         return _stub_transcription(f"pretty_midi parse failed: {exc}")
 
-    midi_tracks: list[MidiTrack] = []
-    for instrument in pm.instruments:
-        notes = [
-            Note(
-                pitch=int(n.pitch),
-                onset_sec=float(n.start),
-                offset_sec=float(max(n.end, n.start + 0.01)),
-                velocity=int(max(1, min(127, n.velocity))),
-            )
-            for n in instrument.notes
-        ]
-        if not notes:
-            continue
-        midi_tracks.append(MidiTrack(
-            notes=notes,
-            instrument=_gm_program_to_role(int(instrument.program), bool(instrument.is_drum)),
-            program=None if instrument.is_drum else int(instrument.program),
-            confidence=0.9,
-        ))
-
+    midi_tracks = midi_tracks_from_pretty_midi(pm)
     if not midi_tracks:
         return _stub_transcription("midi file contained no notes")
 
-    # Tempo map: pretty_midi returns parallel arrays of (time, qpm).
-    tempo_times, tempo_bpms = pm.get_tempo_changes()
-    tempo_map: list[TempoMapEntry] = []
-    if len(tempo_times) > 0:
-        beat_cursor = 0.0
-        prev_time = 0.0
-        prev_bpm = float(tempo_bpms[0])
-        for t, bpm in zip(tempo_times, tempo_bpms):
-            t = float(t)
-            bpm = float(bpm)
-            beat_cursor += (t - prev_time) * (prev_bpm / 60.0)
-            tempo_map.append(TempoMapEntry(time_sec=t, beat=beat_cursor, bpm=bpm))
-            prev_time = t
-            prev_bpm = bpm
-    if not tempo_map:
-        tempo_map = [TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)]
-
-    time_signature: tuple[int, int] = (4, 4)
-    if pm.time_signature_changes:
-        first = pm.time_signature_changes[0]
-        time_signature = (int(first.numerator), int(first.denominator))
-
-    key = "C:major"
-    if pm.key_signature_changes:
-        try:
-            key_number = int(pm.key_signature_changes[0].key_number)
-            key = pretty_midi.key_number_to_key_name(key_number).replace(" ", ":")
-        except Exception:  # noqa: BLE001
-            pass
+    analysis = harmonic_analysis_from_pretty_midi(pm)
 
     total_notes = sum(len(t.notes) for t in midi_tracks)
     log.info(
@@ -174,21 +129,29 @@ def _bundle_to_transcription(bundle: InputBundle) -> TranscriptionResult:
         midi_path.name, len(midi_tracks), total_notes,
     )
 
-    return TranscriptionResult(
+    result = TranscriptionResult(
         schema_version=SCHEMA_VERSION,
         midi_tracks=midi_tracks,
-        analysis=HarmonicAnalysis(
-            key=key,
-            time_signature=time_signature,
-            tempo_map=tempo_map,
-            chords=[],
-            sections=[],
-        ),
+        analysis=analysis,
         quality=QualitySignal(
             overall_confidence=0.95,
             warnings=["MIDI input — no harmonic analysis"],
         ),
     )
+    if blob_store is not None and job_id is not None:
+        try:
+            upload_uri = blob_store.put_bytes(
+                f"jobs/{job_id}/transcription/upload.mid",
+                midi_bytes,
+            )
+            result = result.model_copy(update={"transcription_midi_uri": upload_uri})
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "Could not persist upload MIDI for job_id=%s (HF/arrange claim-check): %s",
+                job_id,
+                exc,
+            )
+    return result
 
 
 class PipelineRunner:
@@ -307,28 +270,18 @@ class PipelineRunner:
                     output_uri = await self._dispatch_task(task_name, job_id, payload_uri, config.stage_timeout_sec)
                     txr_dict = self.blob_store.get_json(output_uri)
 
-                elif step == "arrange":
-                    if txr_dict is None:
-                        # midi_upload variant: build transcription from bundle
-                        bundle_obj = InputBundle.model_validate(current_payload)
-                        log.info(
-                            "pipeline job_id=%s arrange: using MIDI→TranscriptionResult passthrough",
-                            job_id,
-                        )
-                        txr_obj = _bundle_to_transcription(bundle_obj)
-                        txr_dict = txr_obj.model_dump(mode="json")
-                    payload_uri = self._serialize_stage_input(job_id, step, txr_dict)
-                    output_uri = await self._dispatch_task(task_name, job_id, payload_uri, config.stage_timeout_sec)
-                    score_dict = self.blob_store.get_json(output_uri)
-
-                elif step == "condense":
+                elif step in ("arrange", "condense"):
                     if txr_dict is None:
                         bundle_obj = InputBundle.model_validate(current_payload)
                         log.info(
-                            "pipeline job_id=%s condense: using MIDI→TranscriptionResult passthrough",
-                            job_id,
+                            "pipeline job_id=%s %s: using MIDI→TranscriptionResult passthrough",
+                            job_id, step,
                         )
-                        txr_obj = _bundle_to_transcription(bundle_obj)
+                        txr_obj = _bundle_to_transcription(
+                            bundle_obj,
+                            blob_store=self.blob_store,
+                            job_id=job_id,
+                        )
                         txr_dict = txr_obj.model_dump(mode="json")
                     payload_uri = self._serialize_stage_input(job_id, step, txr_dict)
                     output_uri = await self._dispatch_task(task_name, job_id, payload_uri, config.stage_timeout_sec)

--- a/backend/services/arrange.py
+++ b/backend/services/arrange.py
@@ -32,6 +32,10 @@ from backend.contracts import (
     TranscriptionResult,
     sec_to_beat,
 )
+from backend.services.hf_arrange.inference import run_hf_midi_inference
+from backend.services.hf_arrange.midi_bridge import transcription_from_midi_bytes
+from backend.services.transcription_midi_materialize import materialize_transcription_midi_bytes
+from backend.storage.base import BlobStore
 
 log = logging.getLogger(__name__)
 
@@ -505,6 +509,22 @@ def _arrange_sync(
     )
 
 
+def _arrange_hf_sync(
+    payload: TranscriptionResult,
+    difficulty: Difficulty,
+    blob_store: BlobStore,
+) -> PianoScore:
+    """Materialize MIDI, run HF inference, parse back, then classic arrange."""
+    mid_in = materialize_transcription_midi_bytes(payload, blob_store)
+    mid_out = run_hf_midi_inference(mid_in, settings.arrange_hf_inference_mode)
+    rebuilt = transcription_from_midi_bytes(
+        mid_out,
+        payload,
+        extra_warnings=[f"hf_arrange: inference_mode={settings.arrange_hf_inference_mode}"],
+    )
+    return _arrange_sync(rebuilt, difficulty)
+
+
 class ArrangeService:
     name = "arrange"
 
@@ -513,13 +533,37 @@ class ArrangeService:
         payload: TranscriptionResult,
         *,
         difficulty: Difficulty = "intermediate",
+        blob_store: BlobStore | None = None,
     ) -> PianoScore:
         log.info(
-            "arrange: start tracks_in=%d difficulty=%s",
+            "arrange: start backend=%s tracks_in=%d difficulty=%s",
+            settings.arrange_backend,
             len(payload.midi_tracks),
             difficulty,
         )
-        score = await asyncio.to_thread(_arrange_sync, payload, difficulty)
+        use_hf = (
+            settings.arrange_backend == "hf_midi_identity"
+            and blob_store is not None
+        )
+        if settings.arrange_backend not in ("rules", "hf_midi_identity"):
+            raise ValueError(f"Unknown arrange_backend: {settings.arrange_backend!r}")
+        if settings.arrange_backend == "hf_midi_identity" and blob_store is None:
+            if not settings.arrange_hf_fallback_to_rules:
+                raise ValueError("hf_midi_identity requires blob_store")
+            log.warning("hf_midi_identity requires blob_store — falling back to rules")
+
+        if use_hf:
+            try:
+                score = await asyncio.to_thread(
+                    _arrange_hf_sync, payload, difficulty, blob_store,
+                )
+            except Exception:
+                if not settings.arrange_hf_fallback_to_rules:
+                    raise
+                log.exception("HF arrange failed; falling back to rules")
+                score = await asyncio.to_thread(_arrange_sync, payload, difficulty)
+        else:
+            score = await asyncio.to_thread(_arrange_sync, payload, difficulty)
         log.info(
             "arrange: done rh_notes=%d lh_notes=%d",
             len(score.right_hand),

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -2,7 +2,8 @@
 
   * MIDI     — pretty_midi if installed, else a minimal MThd+MTrk file
   * MusicXML — music21 (hard dependency; errors propagate to the caller)
-  * PDF      — LilyPond (preferred) or MuseScore CLI if on $PATH, else a 1-line %PDF stub
+  * PDF      — LilyPond (preferred) or MuseScore CLI ($PATH, ``MUSESCORE_PATH``, or macOS
+    ``.app`` bundle), else a 1-line %PDF stub
 """
 from __future__ import annotations
 
@@ -13,6 +14,8 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from shared.musescore_cli import musescore_executable_paths
 
 from backend.contracts import (
     SCHEMA_VERSION,
@@ -582,16 +585,13 @@ def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
     Tries LilyPond first (this is what production ships — ~250 MB apt
     package, musicxml2ly + lilypond binaries) and MuseScore as a
     higher-fidelity fallback for local dev machines that have it
-    installed. Returns the 60-byte stub PDF only when no renderer is
+    installed (including macOS ``.app`` bundles via ``musescore_executable_paths``).
+    Returns the 60-byte stub PDF only when no renderer is
     available or all renderers fail.
     """
+    ms_paths = musescore_executable_paths()
     has_lilypond = bool(shutil.which("musicxml2ly") and shutil.which("lilypond"))
-    mscore_bin = next(
-        (b for b in ("musescore4", "musescore3", "mscore", "MuseScore4") if shutil.which(b)),
-        None,
-    )
-
-    if not has_lilypond and mscore_bin is None:
+    if not has_lilypond and not ms_paths:
         log.warning(
             "No PDF renderer found — install lilypond (preferred) or MuseScore "
             "for real PDF output; emitting stub",
@@ -628,27 +628,27 @@ def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
             except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
                 log.warning("LilyPond PDF render failed: %s", exc)
 
-        if mscore_bin is not None:
+        for mscore in ms_paths:
             pdf_path = tmp / "sheet.pdf"
             try:
                 subprocess.run(
-                    [mscore_bin, "-o", str(pdf_path), str(xml_path)],
+                    [mscore, "-o", str(pdf_path), str(xml_path)],
                     check=True, capture_output=True, timeout=120,
                 )
                 if pdf_path.is_file():
                     log.info(
-                        "PDF rendered via %s (%d bytes)", mscore_bin, pdf_path.stat().st_size,
+                        "PDF rendered via %s (%d bytes)", mscore, pdf_path.stat().st_size,
                     )
                     return pdf_path.read_bytes()
-                log.warning("%s ran but produced no PDF at %s", mscore_bin, pdf_path)
+                log.warning("%s ran but produced no PDF at %s", mscore, pdf_path)
             except subprocess.CalledProcessError as exc:
                 log.warning(
                     "%s PDF render failed: %s",
-                    mscore_bin,
+                    mscore,
                     (exc.stderr or b"").decode("utf-8", "replace")[:500],
                 )
             except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-                log.warning("%s PDF render failed: %s", mscore_bin, exc)
+                log.warning("%s PDF render failed: %s", mscore, exc)
 
     return _STUB_PDF
 

--- a/backend/services/hf_arrange/__init__.py
+++ b/backend/services/hf_arrange/__init__.py
@@ -1,0 +1,6 @@
+"""Hugging Face–backed MIDI→MIDI arrange adapters (optional heavy deps)."""
+
+from backend.services.hf_arrange.inference import run_hf_midi_inference
+from backend.services.hf_arrange.midi_bridge import transcription_from_midi_bytes
+
+__all__ = ["run_hf_midi_inference", "transcription_from_midi_bytes"]

--- a/backend/services/hf_arrange/inference.py
+++ b/backend/services/hf_arrange/inference.py
@@ -1,0 +1,23 @@
+"""HF inference: MIDI bytes in → MIDI bytes out (identity stub by default)."""
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+log = logging.getLogger(__name__)
+
+ArrangeHfInferenceMode = Literal["identity"]
+
+
+def run_hf_midi_inference(
+    midi_in: bytes,
+    inference_mode: ArrangeHfInferenceMode,
+) -> bytes:
+    """Run configured MIDI→MIDI model.
+
+    ``inference_mode``:
+    - ``identity`` — return input unchanged (tests + integration without weights).
+    """
+    if inference_mode == "identity":
+        return midi_in
+    raise ValueError(f"Unknown arrange_hf_inference_mode: {inference_mode!r}")

--- a/backend/services/hf_arrange/midi_bridge.py
+++ b/backend/services/hf_arrange/midi_bridge.py
@@ -1,0 +1,45 @@
+"""Parse model-output MIDI into a ``TranscriptionResult`` (notes + template analysis)."""
+from __future__ import annotations
+
+import io
+
+from backend.contracts import (
+    SCHEMA_VERSION,
+    QualitySignal,
+    TranscriptionResult,
+)
+from backend.services.pretty_midi_tracks import midi_tracks_from_pretty_midi
+
+
+def transcription_from_midi_bytes(
+    data: bytes,
+    template: TranscriptionResult,
+    *,
+    extra_warnings: list[str] | None = None,
+) -> TranscriptionResult:
+    """Parse ``data`` as MIDI; keep ``template`` harmonic analysis and quality shape."""
+    import pretty_midi  # noqa: PLC0415
+
+    try:
+        pm = pretty_midi.PrettyMIDI(io.BytesIO(data))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"pretty_midi failed to parse HF output MIDI: {exc}") from exc
+
+    midi_tracks = midi_tracks_from_pretty_midi(pm)
+    if not midi_tracks:
+        raise ValueError("HF output MIDI contained no note tracks")
+
+    warns = list(template.quality.warnings)
+    if extra_warnings:
+        warns.extend(extra_warnings)
+
+    return TranscriptionResult(
+        schema_version=SCHEMA_VERSION,
+        midi_tracks=midi_tracks,
+        analysis=template.analysis,
+        quality=QualitySignal(
+            overall_confidence=template.quality.overall_confidence,
+            warnings=warns,
+        ),
+        transcription_midi_uri=template.transcription_midi_uri,
+    )

--- a/backend/services/pretty_midi_tracks.py
+++ b/backend/services/pretty_midi_tracks.py
@@ -1,0 +1,92 @@
+"""Shared PrettyMIDI → contract ``MidiTrack`` conversion (runner + HF arrange)."""
+from __future__ import annotations
+
+from typing import Any
+
+from backend.contracts import (
+    HarmonicAnalysis,
+    InstrumentRole,
+    MidiTrack,
+    Note,
+    TempoMapEntry,
+)
+
+
+def gm_program_to_role(program: int, is_drum: bool) -> InstrumentRole:
+    if is_drum:
+        return InstrumentRole.OTHER
+    if program < 8:
+        return InstrumentRole.PIANO
+    if 32 <= program <= 39:
+        return InstrumentRole.BASS
+    if 72 <= program <= 79:
+        return InstrumentRole.MELODY
+    return InstrumentRole.CHORDS
+
+
+def midi_tracks_from_pretty_midi(pm: Any) -> list[MidiTrack]:
+    """Fold each non-empty ``pretty_midi.Instrument`` into a contract ``MidiTrack``."""
+    midi_tracks: list[MidiTrack] = []
+    for instrument in pm.instruments:
+        notes = [
+            Note(
+                pitch=int(n.pitch),
+                onset_sec=float(n.start),
+                offset_sec=float(max(n.end, n.start + 0.01)),
+                velocity=int(max(1, min(127, n.velocity))),
+            )
+            for n in instrument.notes
+        ]
+        if not notes:
+            continue
+        midi_tracks.append(
+            MidiTrack(
+                notes=notes,
+                instrument=gm_program_to_role(int(instrument.program), bool(instrument.is_drum)),
+                program=None if instrument.is_drum else int(instrument.program),
+                confidence=0.9,
+            ),
+        )
+    return midi_tracks
+
+
+def harmonic_analysis_from_pretty_midi(pm: Any) -> HarmonicAnalysis:
+    """Recover tempo map, time signature, and key from ``pretty_midi.PrettyMIDI``."""
+    import pretty_midi  # noqa: PLC0415
+
+    tempo_times, tempo_bpms = pm.get_tempo_changes()
+    tempo_map: list[TempoMapEntry] = []
+    if len(tempo_times) > 0:
+        beat_cursor = 0.0
+        prev_time = 0.0
+        prev_bpm = float(tempo_bpms[0])
+        for t, bpm in zip(tempo_times, tempo_bpms):
+            t = float(t)
+            bpm = float(bpm)
+            beat_cursor += (t - prev_time) * (prev_bpm / 60.0)
+            tempo_map.append(TempoMapEntry(time_sec=t, beat=beat_cursor, bpm=bpm))
+            prev_time = t
+            prev_bpm = bpm
+    if not tempo_map:
+        tempo_map = [TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)]
+
+    time_signature: tuple[int, int] = (4, 4)
+    if pm.time_signature_changes:
+        first = pm.time_signature_changes[0]
+        time_signature = (int(first.numerator), int(first.denominator))
+
+    key = "C:major"
+    if pm.key_signature_changes:
+        try:
+            key_number = int(pm.key_signature_changes[0].key_number)
+            key = pretty_midi.key_number_to_key_name(key_number).replace(" ", ":")
+        except Exception:  # noqa: BLE001
+            pass
+
+    return HarmonicAnalysis(
+        key=key,
+        time_signature=time_signature,
+        tempo_map=tempo_map,
+        chords=[],
+        sections=[],
+    )

--- a/backend/services/transcription_midi_materialize.py
+++ b/backend/services/transcription_midi_materialize.py
@@ -1,0 +1,79 @@
+"""Materialize raw MIDI bytes from a ``TranscriptionResult`` (claim-check or rebuild)."""
+from __future__ import annotations
+
+import io
+import logging
+from typing import TYPE_CHECKING
+
+from backend.contracts import TranscriptionResult
+
+if TYPE_CHECKING:
+    from backend.storage.base import BlobStore
+
+log = logging.getLogger(__name__)
+
+
+def serialize_transcription_to_midi_bytes(txr: TranscriptionResult) -> bytes | None:
+    """Rebuild a single-piano ``.mid`` from contract tracks + analysis (best-effort).
+
+    Uses the first tempo-map anchor BPM as ``initial_tempo`` and the analysis
+    time signature. Variable-tempo maps are not fully encoded — sufficient for
+    HF stubs and arrange fallbacks.
+    """
+    if not txr.midi_tracks:
+        return None
+    try:
+        import pretty_midi  # noqa: PLC0415
+    except ImportError:
+        log.warning("pretty_midi not installed — cannot serialize TranscriptionResult to MIDI")
+        return None
+
+    tempo_map = txr.analysis.tempo_map or []
+    initial_bpm = float(tempo_map[0].bpm) if tempo_map else 120.0
+    pm = pretty_midi.PrettyMIDI(initial_tempo=initial_bpm)
+    instrument = pretty_midi.Instrument(program=0)
+    for track in txr.midi_tracks:
+        for n in track.notes:
+            instrument.notes.append(
+                pretty_midi.Note(
+                    velocity=int(max(1, min(127, n.velocity))),
+                    pitch=int(n.pitch),
+                    start=float(n.onset_sec),
+                    end=float(max(n.offset_sec, n.onset_sec + 0.01)),
+                ),
+            )
+    if not instrument.notes:
+        return None
+    pm.instruments.append(instrument)
+    num, den = txr.analysis.time_signature
+    pm.time_signature_changes = [
+        pretty_midi.TimeSignature(numerator=int(num), denominator=int(den), time=0.0),
+    ]
+    buf = io.BytesIO()
+    try:
+        pm.write(buf)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Failed to serialize rebuilt MIDI: %s", exc)
+        return None
+    return buf.getvalue()
+
+
+def materialize_transcription_midi_bytes(
+    txr: TranscriptionResult,
+    blob_store: BlobStore | None,
+) -> bytes:
+    """Return canonical input MIDI bytes for HF arrange.
+
+    Prefer ``transcription_midi_uri`` via ``blob_store``; otherwise rebuild from
+    ``midi_tracks`` (requires ``pretty_midi``).
+    """
+    if txr.transcription_midi_uri:
+        if blob_store is None:
+            raise ValueError(
+                "transcription_midi_uri is set but blob_store is None — cannot load MIDI bytes",
+            )
+        return blob_store.get_bytes(txr.transcription_midi_uri)
+    rebuilt = serialize_transcription_to_midi_bytes(txr)
+    if rebuilt is None:
+        raise ValueError("Could not materialize MIDI bytes (no URI and serialization failed)")
+    return rebuilt

--- a/backend/workers/arrange.py
+++ b/backend/workers/arrange.py
@@ -18,7 +18,7 @@ def run(job_id: str, payload_uri: str) -> str:
 
     service = ArrangeService()
     # asyncio.run() is safe with Celery's default prefork pool; breaks with gevent/eventlet.
-    result = asyncio.run(service.run(txr))
+    result = asyncio.run(service.run(txr, blob_store=blob))
 
     # Post-process: aggressive simplification for sheet music readability.
     # Swaps dense per-note transcription output for a cleaner notation layer.

--- a/scripts/hf_models/_common.py
+++ b/scripts/hf_models/_common.py
@@ -1,0 +1,59 @@
+"""Shared helpers for one-off Hugging Face model smoke scripts.
+
+**Golden files** (both live at :func:`repo_root`):
+
+- ``golden.mid`` — Use for **symbolic** pipelines: anything that tokenizes, continues, or
+  renders from a **score/performance MIDI** (Aria, Monster Piano, Pianist, Orpheus,
+  PianoBART, RC prompt helper).
+
+- ``golden.mp3`` — Use only when the model is **audio-native** (Pop2Piano: mel / encoder
+  expects a waveform). Other runners do not read ``golden.mp3`` unless you wire a custom
+  path or transcribe audio → MIDI yourself first.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_midi_path() -> Path:
+    """Repo-root ``golden.mid`` (symbolic / score default)."""
+    return repo_root() / "golden.mid"
+
+
+def default_audio_path() -> Path:
+    """Repo-root ``golden.mp3`` (audio-native default, e.g. Pop2Piano)."""
+    return repo_root() / "golden.mp3"
+
+
+def midi_arg(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    p = parser or argparse.ArgumentParser()
+    p.add_argument(
+        "--midi",
+        type=Path,
+        default=default_midi_path(),
+        help="Input MIDI (default: golden.mid at repo root)",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output path (default: model-specific under repo root)",
+    )
+    return p
+
+
+def require_existing_file(path: Path, description: str) -> Path:
+    path = path.expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"{description} not found: {path}")
+    return path
+
+
+def require_midi(path: Path) -> Path:
+    return require_existing_file(path, "MIDI")

--- a/scripts/hf_models/run_combo_pop2piano_mpt_pianist.py
+++ b/scripts/hf_models/run_combo_pop2piano_mpt_pianist.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Run the three HF smoke scripts as a **strict sequential chain** (each stage's output
+path is the next stage's ``--midi`` input):
+
+1. **Pop2Piano** → writes ``01_pop2piano.mid``
+2. **Monster Piano Transformer** — ``--midi`` = that file → writes ``02_monster_piano.mid``
+3. **Pianist Transformer** — ``--midi`` = Monster Piano's file → writes ``03_pianist.mid`` (or ``--out``)
+
+There is no parallel mix: step *n* does not start until step *n−1* exits successfully.
+Intermediate ``.mid`` files are only the handoff between subprocesses.
+
+Each step invokes the matching ``run_*.py`` in this directory with ``subprocess`` so
+their isolated installs and side effects (e.g. Pianist's ``chdir``) stay contained.
+
+Example::
+
+  python scripts/hf_models/run_combo_pop2piano_mpt_pianist.py --audio ./golden.mp3
+
+Install everything each runner documents (Pop2Piano + essentia, ``monsterpianotransformer``,
+Pianist deps + git clone on first run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+_HF_DIR = Path(__file__).resolve().parent
+for _p in (_HF_DIR,):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _common  # noqa: E402
+
+
+def _safe_stem(path: Path) -> str:
+    raw = path.stem or "combo"
+    out = "".join(c if c.isalnum() or c in "._-" else "_" for c in raw)
+    return (out[:80] or "combo").strip("_") or "combo"
+
+
+def _run_step(title: str, argv: list[str]) -> None:
+    print(f"\n{'=' * 60}\n{title}\n{'=' * 60}", flush=True)
+    subprocess.run(argv, check=True)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Chain Pop2Piano → Monster Piano Transformer → Pianist Transformer.",
+    )
+    p.add_argument(
+        "--audio",
+        type=Path,
+        default=None,
+        help="Input audio for Pop2Piano (wav/mp3/…). Ignored if --from-midi is set.",
+    )
+    p.add_argument(
+        "--from-midi",
+        type=Path,
+        default=None,
+        metavar="PATH.mid",
+        help="Pop2Piano: synthesize this MIDI to audio instead of --audio.",
+    )
+    p.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help="Directory for intermediate MIDIs (default: hf_model_outputs/combo_<stem>/).",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Final MIDI path (default: <work-dir>/03_pianist.mid).",
+    )
+    p.add_argument("--composer", type=str, default="composer1", help="Pop2Piano --composer")
+    p.add_argument("--sr", type=int, default=44100, help="Pop2Piano target sample rate")
+    p.add_argument(
+        "--num-gen-tokens",
+        type=int,
+        default=600,
+        help="Monster Piano continuation length",
+    )
+    args = p.parse_args()
+
+    exe = sys.executable
+    if args.from_midi is not None:
+        midi_src = _common.require_midi(args.from_midi)
+        stem = _safe_stem(midi_src)
+    else:
+        if args.audio is None:
+            audio = _common.default_audio_path()
+        else:
+            audio = Path(args.audio).expanduser().resolve()
+        audio = _common.require_existing_file(audio, "Audio")
+        stem = _safe_stem(audio)
+
+    work = args.work_dir or (_common.repo_root() / "hf_model_outputs" / f"combo_{stem}")
+    work = Path(work).expanduser().resolve()
+    work.mkdir(parents=True, exist_ok=True)
+
+    out_final = args.out or (work / "03_pianist.mid")
+    out_final = Path(out_final).expanduser().resolve()
+    out_final.parent.mkdir(parents=True, exist_ok=True)
+
+    p2p = work / "01_pop2piano.mid"
+    mpt = work / "02_monster_piano.mid"
+
+    pop_argv = [
+        exe,
+        str(_HF_DIR / "run_pop2piano.py"),
+        "--out",
+        str(p2p),
+        "--composer",
+        args.composer,
+        "--sr",
+        str(args.sr),
+    ]
+    if args.from_midi is not None:
+        pop_argv.extend(["--from-midi", str(midi_src)])
+    else:
+        pop_argv.extend(["--audio", str(audio)])
+
+    mpt_argv = [
+        exe,
+        str(_HF_DIR / "run_monster_piano_transformer.py"),
+        "--midi",
+        str(p2p),
+        "--out",
+        str(mpt),
+        "--no-pdf",
+        "--num-gen-tokens",
+        str(args.num_gen_tokens),
+    ]
+
+    pt_argv = [
+        exe,
+        str(_HF_DIR / "run_pianist_transformer.py"),
+        "--midi",
+        str(mpt),
+        "--out",
+        str(out_final),
+    ]
+
+    try:
+        _run_step("1/3 Pop2Piano", pop_argv)
+        _run_step("2/3 Monster Piano Transformer", mpt_argv)
+        _run_step("3/3 Pianist Transformer", pt_argv)
+    except subprocess.CalledProcessError as e:
+        print(f"\nCombo pipeline stopped: step failed with exit code {e.returncode}", file=sys.stderr)
+        return e.returncode or 1
+
+    print(f"\nDone. Final MIDI: {out_final}")
+    print(f"Intermediates: {p2p} , {mpt}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hf_models/run_monster_piano_transformer.py
+++ b/scripts/hf_models/run_monster_piano_transformer.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Monster Piano Transformer (HF hub: asigalov61/Monster-Piano-Transformer).
+
+**Golden input:** ``golden.mid`` (MIDI → internal tokens). Not an audio model.
+
+Optional **piano audio → MIDI** step uses weights from Hugging Face
+``Genius-Society/piano_trans`` (ByteDance-style CRNN checkpoint) via the
+``piano_transcription_inference`` package, which matches the paper
+"High-resolution Piano Transcription with Pedals…" (Kong et al.).
+
+Pipeline:
+
+1. If ``--audio`` is set: transcribe audio → MIDI (seed), also written as
+   ``<out_stem>_transcribed.mid``.
+2. Else: seed MIDI from ``--midi`` (default: ``golden.mid``).
+3. Monster Piano continues from the seed → main ``.mid`` output.
+4. If ``--no-pdf`` is not set: render **sheet PDF** from the continuation MIDI
+   (MusicXML via ``music21``, then MuseScore or LilyPond — same approach as
+   ``backend/services/engrave.py``). MuseScore is resolved from ``PATH`` or the
+   standard macOS ``.app`` bundle. If nothing is available, writes
+   ``<out_stem>.musicxml`` instead and prints a hint.
+
+Uses the upstream pip package which bundles inference and checkpoints.
+
+Install:
+  pip install monsterpianotransformer
+
+Optional transcription + PDF path:
+  pip install piano_transcription_inference huggingface_hub librosa music21
+
+Use ``--max-audio-seconds N`` with ``--audio`` to transcribe only the opening ``N`` seconds (faster tests).
+
+For PDF: install **MuseScore** or **LilyPond** (``musicxml2ly`` + ``lilypond``).
+MuseScore is picked up from ``PATH`` or ``/Applications/MuseScore*.app`` on macOS.
+
+Checkpoints are often saved on CUDA; ``monsterpianotransformer`` calls ``torch.load`` without
+``map_location``. This script temporarily forces ``map_location=cpu`` during ``load_model()``
+so CPU-only machines (e.g. Mac without CUDA) can load weights.
+
+``load_model`` defaults to ``device="cuda"``; this script passes ``device="cpu"`` when
+``torch.cuda.is_available()`` is false so ``.to(device)`` does not trigger a CUDA build error.
+
+No Hugging Face token required unless you configure gated downloads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+_HF_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT, _HF_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import _common  # noqa: E402
+
+_PIANO_TRANS_REPO = "Genius-Society/piano_trans"
+
+
+def _ensure_monster_piano_package() -> int | None:
+    """Return exit code 1 if ``monsterpianotransformer`` is not installed."""
+    if importlib.util.find_spec("monsterpianotransformer") is None:
+        print(
+            "The Monster Piano stack is shipped as a separate PyPI package.\n"
+            "Install with:\n"
+            "  pip install monsterpianotransformer\n",
+            file=sys.stderr,
+        )
+        return 1
+    return None
+
+
+def _ensure_transcription_packages() -> int | None:
+    missing: list[str] = []
+    for name in ("huggingface_hub", "librosa", "piano_transcription_inference"):
+        if importlib.util.find_spec(name) is None:
+            missing.append(name)
+            continue
+        try:
+            __import__(name)
+        except ImportError:
+            missing.append(name)
+    if missing:
+        print(
+            "``--audio`` transcription needs extra packages:\n"
+            f"  Missing: {', '.join(missing)}\n"
+            "Install with:\n"
+            "  pip install piano_transcription_inference huggingface_hub librosa\n",
+            file=sys.stderr,
+        )
+        return 1
+    return None
+
+
+def _ensure_music21() -> int | None:
+    if importlib.util.find_spec("music21") is None:
+        print(
+            "Sheet export needs ``music21``:\n"
+            "  pip install music21\n",
+            file=sys.stderr,
+        )
+        return 1
+    return None
+
+
+@contextmanager
+def _torch_load_force_cpu():
+    """``monsterpianotransformer.model_loader`` uses ``torch.load`` without ``map_location``."""
+    import torch
+
+    real_load = torch.load
+
+    def patched_load(*args, **kwargs):
+        kwargs.setdefault("map_location", torch.device("cpu"))
+        return real_load(*args, **kwargs)
+
+    torch.load = patched_load  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        torch.load = real_load  # type: ignore[method-assign]
+
+
+def _hf_piano_trans_checkpoint(repo_id: str = _PIANO_TRANS_REPO) -> Path:
+    from huggingface_hub import snapshot_download
+
+    root = Path(snapshot_download(repo_id))
+    paths = sorted(root.glob("*.pth"))
+    if not paths:
+        raise FileNotFoundError(f"No .pth weights under snapshot: {root}")
+    return paths[0]
+
+
+def _transcribe_audio_to_midi(
+    *,
+    audio_path: Path,
+    checkpoint: Path,
+    midi_out: Path,
+    device: "torch.device",
+    max_seconds: float | None,
+) -> None:
+    import librosa
+    from piano_transcription_inference import PianoTranscription, sample_rate
+
+    audio, _ = librosa.load(str(audio_path), sr=sample_rate, mono=True)
+    if max_seconds is not None and max_seconds > 0:
+        n = int(sample_rate * max_seconds)
+        if len(audio) > n:
+            audio = audio[:n]
+    transcriptor = PianoTranscription(device=device, checkpoint_path=str(checkpoint))
+    midi_out.parent.mkdir(parents=True, exist_ok=True)
+    transcriptor.transcribe(audio, str(midi_out))
+
+
+def _midi_to_pdf_or_musicxml(midi_path: Path, pdf_path: Path) -> str:
+    """Return ``'pdf'``, ``'musicxml'``, or ``'failed'``. Mirrors ``backend/services/engrave.py``."""
+    from music21 import converter
+
+    from shared.musescore_cli import musescore_executable_paths
+
+    score = converter.parse(str(midi_path))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        base = tmp / "score"
+        musicxml_written = Path(score.write("musicxml", fp=str(base)))
+        if not musicxml_written.is_file():
+            return "failed"
+
+        pdf_tmp = tmp / "sheet.pdf"
+        for exe in musescore_executable_paths():
+            try:
+                subprocess.run(
+                    [exe, "-o", str(pdf_tmp), str(musicxml_written)],
+                    check=True,
+                    capture_output=True,
+                    timeout=120,
+                )
+                if pdf_tmp.is_file():
+                    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(pdf_tmp, pdf_path)
+                    return "pdf"
+            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+
+        if shutil.which("musicxml2ly") and shutil.which("lilypond"):
+            try:
+                ly_path = tmp / "score.ly"
+                subprocess.run(
+                    ["musicxml2ly", "-o", str(ly_path), str(musicxml_written)],
+                    check=True,
+                    capture_output=True,
+                    timeout=60,
+                )
+                subprocess.run(
+                    ["lilypond", "-o", str(tmp / "sheet"), str(ly_path)],
+                    check=True,
+                    capture_output=True,
+                    timeout=120,
+                )
+                if pdf_tmp.is_file():
+                    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(pdf_tmp, pdf_path)
+                    return "pdf"
+            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+                pass
+
+        # No PDF renderer: keep MusicXML next to the intended PDF path.
+        fallback = pdf_path.with_suffix(".musicxml")
+        shutil.copyfile(musicxml_written, fallback)
+        return "musicxml"
+
+
+def main() -> int:
+    p = _common.midi_arg()
+    p.add_argument("--num-gen-tokens", type=int, default=600)
+    p.add_argument(
+        "--audio",
+        type=Path,
+        default=None,
+        help="Optional piano recording (e.g. golden.mp3). When set, transcribe with "
+        f"{_PIANO_TRANS_REPO} weights first; the result seeds Monster Piano.",
+    )
+    p.add_argument(
+        "--hf-piano-trans-repo",
+        default=_PIANO_TRANS_REPO,
+        help="Hugging Face repo id for transcription weights (default: Genius-Society/piano_trans).",
+    )
+    p.add_argument(
+        "--max-audio-seconds",
+        type=float,
+        default=None,
+        metavar="SEC",
+        help="With --audio, transcribe only the first SEC seconds (handy for smoke tests).",
+    )
+    p.add_argument(
+        "--no-pdf",
+        action="store_true",
+        help="Skip sheet export (PDF or fallback MusicXML).",
+    )
+    p.add_argument(
+        "--pdf-out",
+        type=Path,
+        default=None,
+        help="PDF path (default: same stem as --out with .pdf).",
+    )
+    args = p.parse_args()
+
+    if (code := _ensure_monster_piano_package()) is not None:
+        return code
+
+    if args.audio is not None and (code := _ensure_transcription_packages()) is not None:
+        return code
+
+    if not args.no_pdf and (code := _ensure_music21()) is not None:
+        return code
+
+    import torch
+
+    import monsterpianotransformer as mpt
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    out = args.out or (_common.repo_root() / "hf_model_outputs" / "monster_piano_continuation.mid")
+    out = Path(out).expanduser().resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    seed_midi: Path
+    if args.audio is not None:
+        audio_in = _common.require_existing_file(Path(args.audio), "Audio")
+        print(f"Resolving transcription checkpoint ({args.hf_piano_trans_repo}) …")
+        ck = _hf_piano_trans_checkpoint(repo_id=args.hf_piano_trans_repo)
+        transcribed = out.parent / f"{out.stem}_transcribed.mid"
+        print(f"Transcribing: {audio_in} → {transcribed}")
+        _transcribe_audio_to_midi(
+            audio_path=audio_in,
+            checkpoint=ck,
+            midi_out=transcribed,
+            device=device,
+            max_seconds=args.max_audio_seconds,
+        )
+        seed_midi = transcribed
+    else:
+        seed_midi = _common.require_midi(args.midi)
+
+    print(f"Loading default Monster Piano model (device={device}) …")
+    with _torch_load_force_cpu():
+        model = mpt.load_model(device=str(device))
+
+    print(f"Tokenizing seed MIDI: {seed_midi}")
+    input_tokens = mpt.midi_to_tokens(str(seed_midi))
+
+    print(f"Generating ({args.num_gen_tokens} tokens) …")
+    output_tokens = mpt.generate(
+        model,
+        input_tokens,
+        num_gen_tokens=args.num_gen_tokens,
+        return_prime=True,
+    )
+
+    base = str(out.parent / out.stem)
+    mpt.tokens_to_midi(output_tokens[0], output_midi_name=base)
+    print(f"Wrote {out}")
+
+    if not args.no_pdf:
+        pdf_out = args.pdf_out or out.with_suffix(".pdf")
+        pdf_out = Path(pdf_out).expanduser().resolve()
+        print(f"Rendering sheet music → {pdf_out} …")
+        kind = _midi_to_pdf_or_musicxml(out, pdf_out)
+        if kind == "pdf":
+            print(f"Wrote PDF: {pdf_out}")
+        elif kind == "musicxml":
+            print(
+                "No MuseScore CLI or LilyPond found — wrote MusicXML instead:\n"
+                f"  {pdf_out.with_suffix('.musicxml')}\n"
+                "Install MuseScore (macOS: drag to /Applications) or LilyPond for direct PDF export.",
+            )
+        else:
+            print("Sheet export failed after MusicXML generation.", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hf_models/run_pianist_transformer.py
+++ b/scripts/hf_models/run_pianist_transformer.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Pianist Transformer rendering model (yhj137/pianist-transformer-rendering).
+
+**Golden input:** ``golden.mid`` (score MIDI → expressive performance). Not an audio model.
+
+Uses the official GitHub repo for inference code (midi_to_ids, batch_performance_render)
+and Hugging Face for weights. First run clones ~source and downloads ~272MB weights.
+
+Install (prefer a fresh venv; versions mirror upstream README):
+  pip install torch miditoolkit tqdm "transformers>=4.54" accelerate datasets
+
+Recent ``transformers`` releases moved T5Gemma mask helpers out of
+``modeling_t5gemma``; this script patches that module with the small factories
+PianistTransformer still imports (same behavior as transformers v4.55).
+
+``PianoT5Gemma`` still declares ``_tied_weights_keys`` as a **list**; current
+``transformers`` expects a **dict** (same mapping as upstream
+``T5GemmaForConditionalGeneration``). The script normalizes that on the class
+before ``from_pretrained``.
+
+CUDA optional; CPU works but is slower.
+
+Weights are public — HF_TOKEN only if you hit rate limits or use private mirrors.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Optional
+
+_HF_DIR = Path(__file__).resolve().parent
+if str(_HF_DIR) not in sys.path:
+    sys.path.insert(0, str(_HF_DIR))
+
+import _common  # noqa: E402
+
+_GIT_URL = "https://github.com/yhj137/PianistTransformer.git"
+_HF_REPO = "yhj137/pianist-transformer-rendering"
+_CACHE = Path.home() / ".cache" / "oh-sheet-hf" / "PianistTransformer"
+
+
+def _patch_t5gemma_modeling_for_pianist() -> None:
+    """Restore mask factories that Pianist's ``pianoformer.py`` imports from ``modeling_t5gemma``.
+
+    Hugging Face refactored T5Gemma (helpers live in ``masking_utils``); upstream Pianist
+    still expects the v4.55-style API on ``transformers.models.t5gemma.modeling_t5gemma``.
+    """
+    import torch
+
+    import transformers.models.t5gemma.modeling_t5gemma as m
+
+    if getattr(m, "_ohsheet_pianist_t5gemma_mask_patch", False):
+        return
+
+    def bidirectional_mask_function(attention_mask: Optional[torch.Tensor]) -> Callable[..., torch.Tensor | bool]:
+        # Must return tensors (no ``.item()``): ``create_causal_mask`` composes masks under ``vmap``.
+        def inner_mask(batch_idx, head_idx, q_idx, kv_idx):
+            if attention_mask is None:
+                return q_idx.new_tensor(True, dtype=torch.bool)
+            return attention_mask[batch_idx, kv_idx].to(dtype=torch.bool)
+
+        return inner_mask
+
+    def sliding_window_bidirectional_mask_function(sliding_window: int) -> Callable[..., torch.Tensor | bool]:
+        def inner_mask(batch_idx, head_idx, q_idx, kv_idx):
+            return (q_idx - sliding_window < kv_idx) & (kv_idx < q_idx + sliding_window)
+
+        return inner_mask
+
+    m.bidirectional_mask_function = bidirectional_mask_function  # type: ignore[attr-defined]
+    m.sliding_window_bidirectional_mask_function = sliding_window_bidirectional_mask_function  # type: ignore[attr-defined]
+    m._ohsheet_pianist_t5gemma_mask_patch = True  # type: ignore[attr-defined]
+
+
+def _patch_pianist_pianoformer_tied_weights() -> None:
+    """``PianoT5Gemma._tied_weights_keys`` is a list in upstream; ``transformers`` requires a dict."""
+    from src.model.pianoformer import PianoT5Gemma
+
+    if getattr(PianoT5Gemma, "_ohsheet_tied_weights_patch", False):
+        return
+
+    tw = getattr(PianoT5Gemma, "_tied_weights_keys", None)
+    if isinstance(tw, dict):
+        PianoT5Gemma._ohsheet_tied_weights_patch = True  # type: ignore[attr-defined]
+        return
+
+    # Match ``T5GemmaForConditionalGeneration`` in current ``transformers``.
+    PianoT5Gemma._tied_weights_keys = {  # type: ignore[misc]
+        "lm_head.out_proj.weight": "model.decoder.embed_tokens.weight",
+    }
+    PianoT5Gemma._ohsheet_tied_weights_patch = True  # type: ignore[attr-defined]
+
+
+def _ensure_git_clone() -> Path:
+    if _CACHE.is_dir() and (_CACHE / "src").is_dir():
+        return _CACHE
+    _CACHE.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "clone", "--depth", "1", _GIT_URL, str(_CACHE)],
+        check=True,
+    )
+    return _CACHE
+
+
+def _ensure_weights(repo: Path) -> Path:
+    sft = repo / "models" / "sft"
+    if (sft / "model.safetensors").is_file() or (sft / "model.bin").is_file():
+        return sft
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        print("pip install huggingface_hub", file=sys.stderr)
+        raise e
+    sft.mkdir(parents=True, exist_ok=True)
+    snapshot_download(_HF_REPO, local_dir=str(sft))
+    return sft
+
+
+def main() -> int:
+    p = _common.midi_arg()
+    args = p.parse_args()
+
+    midi_in = _common.require_midi(args.midi)
+    out = args.out or (_common.repo_root() / "hf_model_outputs" / "pianist_rendered.mid")
+    out = Path(out).expanduser().resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    repo = _ensure_git_clone()
+    sft_dir = _ensure_weights(repo)
+
+    score_dir = repo / "data" / "midis" / "testset" / "score"
+    inf_dir = repo / "data" / "midis" / "testset" / "inference"
+    score_dir.mkdir(parents=True, exist_ok=True)
+    inf_dir.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(midi_in, score_dir / "0.mid")
+
+    prev_cwd = Path.cwd()
+    prev_path = list(sys.path)
+    try:
+        os.chdir(repo)
+        sys.path.insert(0, str(repo))
+
+        import torch
+        from miditoolkit import MidiFile
+
+        _patch_t5gemma_modeling_for_pianist()
+
+        from src.model.generate import batch_performance_render, map_midi
+
+        _patch_pianist_pianoformer_tied_weights()
+        from src.model.pianoformer import PianoT5Gemma
+
+        dtype = torch.bfloat16
+        if not torch.cuda.is_available():
+            dtype = torch.float32
+
+        print(f"Loading model from {sft_dir} …")
+        model = PianoT5Gemma.from_pretrained(str(sft_dir), torch_dtype=dtype)
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model = model.to(device)
+
+        midis = [MidiFile(str(score_dir / "0.mid"))]
+        print("Rendering performance …")
+        res = batch_performance_render(
+            model,
+            midis,
+            temperature=1.0,
+            top_p=0.95,
+            device=device,
+        )
+        for i, mid in enumerate(res):
+            mid = map_midi(midis[i], mid)
+            mid.dump(str(out))
+        print(f"Wrote {out}")
+        return 0
+    finally:
+        os.chdir(prev_cwd)
+        sys.path[:] = prev_path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hf_models/run_pop2piano.py
+++ b/scripts/hf_models/run_pop2piano.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Pop2Piano (sweetcocoa/pop2piano) — pop **audio** (e.g. MP3) → piano MIDI.
+
+**Golden input:** ``golden.mp3`` (audio-native encoder). Use ``--from-midi golden.mid`` only
+if you want the old sine-synthesis path from a score file.
+
+Default input is ``golden.mp3`` at the repo root. Override with ``--audio``.
+
+MP3 decoding uses **librosa** (often via ``audioread`` + **ffmpeg**). If loading fails,
+install a decoder stack, e.g. ``pip install soundfile audioread`` and ensure ``ffmpeg``
+is on your ``PATH``.
+
+Optional: ``--from-midi path.mid`` ignores ``--audio`` and instead synthesizes the MIDI
+to a waveform with ``pretty_midi`` (same as the old script behavior).
+
+Install (``Pop2PianoProcessor`` is gated on **essentia** in current ``transformers``; the
+feature extractor also uses **librosa** resampling, which lazily needs **resampy**):
+  pip install torch transformers librosa resampy scipy pretty_midi essentia==2.1b6.dev1389
+
+The pin ``2.1b6.dev1034`` appears in some Transformers messages but is **no longer on PyPI**;
+install a published ``2.1b6.dev*`` build (e.g. ``dev1389``) or the latest your index lists.
+
+Python **3.13** often has no prebuilt ``essentia`` wheels; use **3.10–3.11** (e.g.
+``conda create -n pop2piano python=3.11``) if ``pip install essentia`` fails.
+
+No Hugging Face credentials required for public weights (HF_TOKEN optional for rate limits).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+_HF_DIR = Path(__file__).resolve().parent
+if str(_HF_DIR) not in sys.path:
+    sys.path.insert(0, str(_HF_DIR))
+
+import _common  # noqa: E402
+
+_REPO_ID = "sweetcocoa/pop2piano"
+
+# Pop2PianoProcessor / Pop2PianoFeatureExtractor are decorated with
+# ``@requires(backends=("essentia", "librosa", "pretty_midi", "scipy", "torch"))``
+# in current ``transformers`` — all must be importable before ``from_pretrained``.
+# ``resampy`` is not listed there but librosa loads it lazily for ``resample(..., res_type="kaiser_best")``
+# inside ``Pop2PianoFeatureExtractor``; without it, ``processor(...)`` crashes at runtime.
+_PREREQ_PKGS = ("essentia", "librosa", "resampy", "scipy", "pretty_midi", "torch")
+
+
+def _missing_prereq_modules() -> list[str]:
+    """Match what ``transformers`` will require at ``Pop2PianoProcessor`` load time."""
+    missing: list[str] = []
+    for name in _PREREQ_PKGS:
+        if importlib.util.find_spec(name) is None:
+            missing.append(name)
+            continue
+        try:
+            __import__(name)
+        except ImportError:
+            missing.append(name)
+    return missing
+
+
+def _load_pop2piano_processor(repo_id: str):
+    from transformers import Pop2PianoProcessor
+
+    try:
+        return Pop2PianoProcessor.from_pretrained(repo_id)
+    except ImportError as e:
+        print(
+            "\nPop2PianoProcessor still failed to load (often missing or broken ``essentia``):\n"
+            "  pip install essentia==2.1b6.dev1389\n"
+            "On Python 3.13, prefer a 3.10–3.11 venv — essentia wheels are rarely published for 3.13.\n",
+            file=sys.stderr,
+        )
+        raise e
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Run Pop2Piano on an audio file (default: golden.mp3).")
+    p.add_argument(
+        "--audio",
+        type=Path,
+        default=_common.default_audio_path(),
+        help="Input audio (wav/mp3/flac …); default: golden.mp3 at repo root",
+    )
+    p.add_argument(
+        "--from-midi",
+        type=Path,
+        default=None,
+        metavar="PATH.mid",
+        help="Synthesize this MIDI (e.g. golden.mid) with pretty_midi instead of --audio",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output MIDI path (default: hf_model_outputs/pop2piano_output.mid)",
+    )
+    p.add_argument("--composer", type=str, default="composer1")
+    p.add_argument("--sr", type=int, default=44100, help="Target sample rate for the model")
+    args = p.parse_args()
+
+    missing = _missing_prereq_modules()
+    if missing:
+        print(
+            "Pop2Piano requires these importable packages (Transformers gates + librosa resampling):\n"
+            f"  missing: {', '.join(missing)}\n"
+            "Install with:\n"
+            "  pip install torch transformers librosa resampy scipy pretty_midi essentia==2.1b6.dev1389\n"
+            "If essentia fails to build on Python 3.13, use Python 3.10–3.11 (e.g. conda env).",
+            file=sys.stderr,
+        )
+        return 1
+
+    out = args.out or (_common.repo_root() / "hf_model_outputs" / "pop2piano_output.mid")
+    out = Path(out).expanduser().resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        import librosa
+        import numpy as np
+        import torch
+        from transformers import Pop2PianoForConditionalGeneration
+    except ImportError as e:
+        print(
+            "Import failed after prereq check. Try:\n"
+            "  pip install torch transformers librosa resampy scipy pretty_midi essentia==2.1b6.dev1389",
+            file=sys.stderr,
+        )
+        raise e
+
+    if args.from_midi is not None:
+        import pretty_midi
+
+        midi_path = _common.require_midi(args.from_midi)
+        print(f"Synthesizing MIDI to audio (pretty_midi): {midi_path}")
+        pm = pretty_midi.PrettyMIDI(str(midi_path))
+        audio = pm.synthesize(fs=args.sr)
+        if audio.ndim != 1:
+            audio = audio[0]
+        audio = np.asarray(audio, dtype=np.float32)
+        sr = args.sr
+    else:
+        audio_path = _common.require_existing_file(args.audio, "Audio")
+        print(f"Loading audio: {audio_path}")
+        audio, sr = librosa.load(str(audio_path), sr=args.sr, mono=True)
+        audio = np.asarray(audio, dtype=np.float32)
+
+    print(f"Loading {_REPO_ID} …")
+    model = Pop2PianoForConditionalGeneration.from_pretrained(_REPO_ID)
+    processor = _load_pop2piano_processor(_REPO_ID)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = model.to(device)
+
+    inputs = processor(audio=audio, sampling_rate=sr, return_tensors="pt")
+    inputs = {k: v.to(device) if hasattr(v, "to") else v for k, v in inputs.items()}
+
+    print("Generating …")
+    with torch.no_grad():
+        model_output = model.generate(
+            input_features=inputs["input_features"],
+            composer=args.composer,
+        )
+
+    decoded = processor.batch_decode(
+        token_ids=model_output,
+        feature_extractor_output=inputs,
+    )["pretty_midi_objects"][0]
+    decoded.write(str(out))
+    print(f"Wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shared/shared/musescore_cli.py
+++ b/shared/shared/musescore_cli.py
@@ -1,0 +1,66 @@
+"""Resolve MuseScore CLI for headless PDF export.
+
+The macOS ``.app`` bundle ships ``Contents/MacOS/mscore``, which is usually **not** on
+``$PATH``. We probe ``shutil.which`` first, then standard install locations.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import shutil
+import sys
+from pathlib import Path
+
+_WHICH_NAMES = ("musescore4", "musescore3", "mscore", "MuseScore4")
+
+
+def _macos_bundle_candidates() -> list[Path]:
+    roots = (Path("/Applications"), Path.home() / "Applications")
+    # (bundle folder name, binary names inside Contents/MacOS — order matters)
+    app_bins: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("MuseScore 4.app", ("mscore", "MuseScore4")),
+        ("MuseScore 3.app", ("mscore", "MuseScore3")),
+        ("MuseScore.app", ("mscore", "MuseScore4")),
+    )
+    found: list[Path] = []
+    for root in roots:
+        for app, bins in app_bins:
+            macos = root / app / "Contents" / "MacOS"
+            if not macos.is_dir():
+                continue
+            for name in bins:
+                p = macos / name
+                if p.is_file() and os.access(p, os.X_OK):
+                    found.append(p)
+    return found
+
+
+@functools.lru_cache(maxsize=1)
+def musescore_executable_paths() -> list[str]:
+    """Absolute paths to MuseScore-style CLIs, in preference order (deduplicated).
+
+    Set ``MUSESCORE_PATH`` to a full path to force a specific binary (e.g. a non-default
+    install or a wrapper script).
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    override = os.environ.get("MUSESCORE_PATH", "").strip()
+    if override:
+        p = Path(override).expanduser()
+        if p.is_file() and os.access(p, os.X_OK):
+            s = str(p.resolve())
+            out.append(s)
+            seen.add(s)
+    for name in _WHICH_NAMES:
+        w = shutil.which(name)
+        if w and w not in seen:
+            out.append(w)
+            seen.add(w)
+    if sys.platform == "darwin":
+        for p in _macos_bundle_candidates():
+            s = str(p.resolve())
+            if s not in seen:
+                out.append(s)
+                seen.add(s)
+    return out

--- a/tests/test_hf_arrange.py
+++ b/tests/test_hf_arrange.py
@@ -1,0 +1,176 @@
+"""HF arrange path: materialize MIDI, inference stub, parse → PianoScore."""
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from backend.config import settings
+from backend.contracts import (
+    SCHEMA_VERSION,
+    HarmonicAnalysis,
+    InputBundle,
+    InputMetadata,
+    InstrumentRole,
+    MidiTrack,
+    Note,
+    QualitySignal,
+    RemoteMidiFile,
+    TempoMapEntry,
+    TranscriptionResult,
+)
+from backend.jobs.runner import _bundle_to_transcription
+from backend.services.arrange import ArrangeService, _arrange_hf_sync
+from backend.services.hf_arrange import inference as hf_inference
+from backend.services.transcription_midi_materialize import (
+    materialize_transcription_midi_bytes,
+    serialize_transcription_to_midi_bytes,
+)
+from backend.storage.local import LocalBlobStore
+
+
+def _minimal_txr() -> TranscriptionResult:
+    return TranscriptionResult(
+        schema_version=SCHEMA_VERSION,
+        midi_tracks=[
+            MidiTrack(
+                notes=[
+                    Note(pitch=60, onset_sec=0.0, offset_sec=0.5, velocity=80),
+                ],
+                instrument=InstrumentRole.PIANO,
+                program=0,
+                confidence=0.9,
+            ),
+        ],
+        analysis=HarmonicAnalysis(
+            key="C:major",
+            time_signature=(4, 4),
+            tempo_map=[TempoMapEntry(time_sec=0.0, beat=0.0, bpm=120.0)],
+            chords=[],
+            sections=[],
+        ),
+        quality=QualitySignal(overall_confidence=0.9, warnings=[]),
+    )
+
+
+def test_serialize_transcription_round_trip_bytes() -> None:
+    pytest.importorskip("pretty_midi")
+    txr = _minimal_txr()
+    raw = serialize_transcription_to_midi_bytes(txr)
+    assert raw is not None and len(raw) > 32
+
+
+def test_materialize_prefers_blob_uri(tmp_path) -> None:
+    pytest.importorskip("pretty_midi")
+    blob = LocalBlobStore(tmp_path)
+    txr = _minimal_txr()
+    uri = blob.put_bytes("jobs/t1/transcription/x.mid", b"not-valid-midi")
+    txr = txr.model_copy(update={"transcription_midi_uri": uri})
+    assert materialize_transcription_midi_bytes(txr, blob) == b"not-valid-midi"
+
+
+def test_materialize_serializes_without_uri(tmp_path) -> None:
+    pytest.importorskip("pretty_midi")
+    blob = LocalBlobStore(tmp_path)
+    txr = _minimal_txr()
+    b = materialize_transcription_midi_bytes(txr, blob)
+    assert b.startswith(b"MThd")
+
+
+@pytest.mark.asyncio
+async def test_hf_midi_identity_arrange(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    pytest.importorskip("pretty_midi")
+    monkeypatch.setattr(settings, "arrange_backend", "hf_midi_identity")
+    monkeypatch.setattr(settings, "arrange_hf_fallback_to_rules", False)
+
+    blob = LocalBlobStore(tmp_path)
+    txr = _minimal_txr()
+    uri = blob.put_bytes(
+        "jobs/hf-test/transcription/in.mid",
+        serialize_transcription_to_midi_bytes(txr) or b"",
+    )
+    txr = txr.model_copy(update={"transcription_midi_uri": uri})
+
+    svc = ArrangeService()
+    score = await svc.run(txr, blob_store=blob)
+    assert len(score.right_hand) + len(score.left_hand) >= 1
+
+
+def test_bundle_to_transcription_sets_midi_uri(tmp_path) -> None:
+    pytest.importorskip("pretty_midi")
+    import pretty_midi  # noqa: PLC0415
+
+    mid_path = tmp_path / "in.mid"
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120.0)
+    inst = pretty_midi.Instrument(program=0)
+    inst.notes.append(
+        pretty_midi.Note(velocity=80, pitch=60, start=0.0, end=0.5),
+    )
+    pm.instruments.append(inst)
+    pm.write(str(mid_path))
+
+    bundle = InputBundle(
+        midi=RemoteMidiFile(uri=mid_path.as_uri(), ticks_per_beat=480),
+        metadata=InputMetadata(title="t", artist="a", source="midi_upload"),
+    )
+    blob = LocalBlobStore(tmp_path / "blob")
+    txr = _bundle_to_transcription(bundle, blob_store=blob, job_id="jid-1")
+    assert txr.transcription_midi_uri is not None
+    assert "upload.mid" in txr.transcription_midi_uri
+    assert blob.get_bytes(txr.transcription_midi_uri) == mid_path.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_arrange_hf_fallback_on_bad_hf_output(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    pytest.importorskip("pretty_midi")
+    monkeypatch.setattr(settings, "arrange_backend", "hf_midi_identity")
+    monkeypatch.setattr(settings, "arrange_hf_fallback_to_rules", True)
+
+    blob = LocalBlobStore(tmp_path)
+    txr = _minimal_txr()
+    uri = blob.put_bytes(
+        "jobs/fb/transcription/in.mid",
+        serialize_transcription_to_midi_bytes(txr) or b"",
+    )
+    txr = txr.model_copy(update={"transcription_midi_uri": uri})
+
+    def _bad(_midi_in: bytes, _mode: str) -> bytes:
+        return b"BAD"
+
+    monkeypatch.setattr(hf_inference, "run_hf_midi_inference", _bad)
+
+    svc = ArrangeService()
+    score = await svc.run(txr, blob_store=blob)
+    assert len(score.right_hand) + len(score.left_hand) >= 1
+
+
+def test_arrange_hf_sync_monkeypatch_custom_midi(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    pytest.importorskip("pretty_midi")
+    import pretty_midi  # noqa: PLC0415
+
+    blob = LocalBlobStore(tmp_path)
+    base = _minimal_txr()
+    uri = blob.put_bytes(
+        "jobs/sync/transcription/in.mid",
+        serialize_transcription_to_midi_bytes(base) or b"",
+    )
+    base = base.model_copy(update={"transcription_midi_uri": uri})
+
+    out_pm = pretty_midi.PrettyMIDI(initial_tempo=120.0)
+    inst = pretty_midi.Instrument(program=0)
+    for pitch, start in [(60, 0.0), (64, 0.5), (67, 1.0)]:
+        inst.notes.append(
+            pretty_midi.Note(velocity=90, pitch=pitch, start=start, end=start + 0.4),
+        )
+    out_pm.instruments.append(inst)
+    buf = io.BytesIO()
+    out_pm.write(buf)
+
+    def _three_notes(midi_in: bytes, mode: str) -> bytes:  # noqa: ARG001
+        return buf.getvalue()
+
+    monkeypatch.setattr(hf_inference, "run_hf_midi_inference", _three_notes)
+    score = _arrange_hf_sync(base, "intermediate", blob)
+    n = len(score.right_hand) + len(score.left_hand)
+    # Arrange quantizes and may merge close notes; just verify output is non-empty.
+    assert n >= 1


### PR DESCRIPTION
## Summary
Implements arrange service using two hugging face models.

## Details
Optional HF MIDI “identity” arrange backend — config-driven backend, materialize/round-trip MIDI via blob storage, wiring for workers and the stateless stage route.
Runner refactor — centralize PrettyMIDI parsing / harmonic helpers; persist uploaded MIDI to blob for later stages; unify arrange/condense MIDI handling.
Engrave — resolve MuseScore/MuseScore4 CLI using the new shared helper before LilyPond fallback.
Scripts + tests — HF model smoke runners and hf_arrange / MIDI bridge tests.