### PR TITLE
Fix some bugs

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg gcc g++ 
     && rm -rf /var/lib/apt/lists/*
 
 COPY shared/ shared/
-RUN pip install --no-cache-dir ./shared
+# Editable so bind-mounting ./shared in docker-compose tracks host changes.
+RUN pip install --no-cache-dir -e ./shared
 
 COPY pyproject.toml .
 COPY backend/ backend/

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -338,6 +338,131 @@ def _attach_pedal_marks(part, pedal_events, music21) -> None:  # noqa: ANN001
         part.insert(off_beat, music21.expressions.TextExpression(off_label))
 
 
+def _approximate_ql_for_musicxml_export(ql: float, music21) -> float:  # noqa: ANN001
+    """Pick a ``quarterLength`` near ``ql`` that music21 can encode to MusicXML.
+
+    Transcription grids often produce floats that are not exact rationals music21
+    can express as a single ``Duration`` (``type == 'inexpressible'``). Try
+    ``Fraction(...).limit_denominator`` at increasing denominators and keep the
+    closest candidate that passes the exporter's type rules.
+    """
+    from fractions import Fraction
+
+    dur_mod = music21.duration
+    min_safe = float(dur_mod.convertTypeToQuarterLength("1024th"))
+    if ql <= 0:
+        return min_safe
+
+    best: float | None = None
+    best_err = float("inf")
+    for lim in (
+        32, 48, 64, 96, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048,
+        4096, 8192, 16384, 32768, 65536, 131072, 262144,
+    ):
+        cand = float(Fraction(ql).limit_denominator(lim))
+        if cand <= 0:
+            continue
+        d = dur_mod.Duration(cand)
+        if _duration_needs_musicxml_coercion(d):
+            continue
+        err = abs(cand - ql)
+        if err < best_err:
+            best_err = err
+            best = cand
+
+    if best is not None:
+        return best
+
+    # Last resort: snap to 1/384 quarter (finer than our divisions=12 grid).
+    step = 1.0 / 384.0
+    k = max(1, round(ql / step))
+    return k * step
+
+
+def _duration_needs_musicxml_coercion(d) -> bool:  # noqa: ANN001 — music21 Duration
+    """True if music21 would raise when exporting this duration to MusicXML.
+
+    ``makeNotation`` can attach tuplets whose ``durationNormal`` is a
+    ``2048th`` — valid internally but rejected by ``typeToMusicXMLType``
+    (see music21 ``m21ToXml``). We also treat any other duration type the
+    exporter refuses the same way so future music21 versions stay covered.
+    """
+    from music21.musicxml.m21ToXml import typeToMusicXMLType  # noqa: PLC0415
+    from music21.musicxml.xmlObjects import MusicXMLExportException  # noqa: PLC0415
+
+    try:
+        typeToMusicXMLType(d.type)
+    except MusicXMLExportException:
+        return True
+    for tup in d.tuplets:
+        dn = tup.durationNormal
+        if dn is not None:
+            try:
+                typeToMusicXMLType(dn.type)
+            except MusicXMLExportException:
+                return True
+        da = tup.durationActual
+        if da is not None:
+            try:
+                typeToMusicXMLType(da.type)
+            except MusicXMLExportException:
+                return True
+    return False
+
+
+def _coerce_durations_for_musicxml_export(part, music21) -> None:  # noqa: ANN001
+    """Normalize note/rest durations so MusicXML export cannot fail on types
+    like ``2048th`` tuplet brackets.
+
+    First pass rebuilds each offending duration from its ``quarterLength``
+    alone (music21 usually picks sane tuplets). If types are still rejected,
+    very short lengths are clamped to a ``1024th``. If the duration is still
+    bad (common for float noise → ``inexpressible``), snap ``quarterLength``
+    to a nearby rational via ``_approximate_ql_for_musicxml_export``.
+    """
+    dur_mod = music21.duration
+    min_safe_ql = float(dur_mod.convertTypeToQuarterLength("1024th"))
+
+    for elem in part.recurse().notesAndRests:
+        d = elem.duration
+        if not _duration_needs_musicxml_coercion(d):
+            continue
+        ql_orig = float(d.quarterLength)
+        if ql_orig <= 0:
+            continue
+        ql = ql_orig
+        elem.duration = dur_mod.Duration(ql)
+        if not _duration_needs_musicxml_coercion(elem.duration):
+            continue
+        if ql < min_safe_ql:
+            ql = min_safe_ql
+            elem.duration = dur_mod.Duration(ql)
+            if not _duration_needs_musicxml_coercion(elem.duration):
+                log.warning(
+                    "engrave: raised sub–1024th duration ql=%s to %s for MusicXML",
+                    ql_orig,
+                    ql,
+                )
+                continue
+        approx = _approximate_ql_for_musicxml_export(ql, music21)
+        elem.duration = dur_mod.Duration(approx)
+        if not _duration_needs_musicxml_coercion(elem.duration):
+            if approx != ql_orig:
+                log.warning(
+                    "engrave: snapped unexportable duration ql=%s -> %s for MusicXML",
+                    ql_orig,
+                    approx,
+                )
+            continue
+        # Should be unreachable; keep export from crashing.
+        elem.duration = dur_mod.Duration(min_safe_ql)
+        log.warning(
+            "engrave: fell back to minimum duration ql=%s -> %s for MusicXML",
+            ql_orig,
+            min_safe_ql,
+        )
+
+
 def _render_musicxml_bytes(
     score: PianoScore,
     perf: HumanizedPerformance | None,
@@ -492,6 +617,9 @@ def _render_musicxml_bytes(
         # which is LCM(2, 3, 4) — every grid value arrange can emit
         # lands on an integer ``<duration>``.
         part.makeNotation(inPlace=True)
+        # makeNotation can still emit tuplets MusicXML refuses (e.g. a
+        # ``2048th`` tuplet "normal" type). Coerce before ``write()``.
+        _coerce_durations_for_musicxml_export(part, music21)
 
         # makeMeasures rebuilds per-measure Voice sub-streams with fresh
         # integer ids (music21 treats large ints as memory locations and
@@ -523,6 +651,19 @@ def _render_musicxml_bytes(
         ),
     )
 
+    # ``makeNotation=False`` skips the exporter's second ``makeNotation`` pass.
+    # Per-part ``makeNotation`` can still leave one ``Note``/``Rest`` carrying a
+    # ``complex`` multi-component duration or other MusicXML-unwritable shapes;
+    # ``m21ToXml.noteToXml`` then raises (``inexpressible`` / ``complex``). The
+    # supported fix is ``splitAtDurations(recurse=True)`` before export — see
+    # ``music21.converter.subConverters`` tests around ``makeNotation=False``.
+    s.splitAtDurations(recurse=True)
+    _coerce_durations_for_musicxml_export(s, music21)
+    # Rare: rational snap can reintroduce a ``complex`` multi-component view;
+    # a second split is cheap insurance before export.
+    s.splitAtDurations(recurse=True)
+    _coerce_durations_for_musicxml_export(s, music21)
+
     # Force divisions=12 at the exporter boundary. music21's MeasureExporter
     # reads ``defaults.divisionsPerQuarter`` verbatim when stamping the
     # ``<divisions>`` tag (m21ToXml.setMxAttributesObjectForStartOfMeasure)
@@ -537,7 +678,13 @@ def _render_musicxml_bytes(
     prior_divisions = music21.defaults.divisionsPerQuarter
     try:
         music21.defaults.divisionsPerQuarter = 12
-        s.write("musicxml", fp=str(tmp_path))
+        # music21's MusicXML writer defaults to ``makeNotation=True``, which
+        # deep-copies the score and runs ``makeNotation`` again on every part.
+        # That second pass can emit tuplets MusicXML cannot encode (e.g. a
+        # ``2048th`` normal-type) even after our per-part cleanup. We already
+        # called ``makeNotation`` on each ``PartStaff`` above — export the
+        # score as-is. (Requires a well-formed ``Score``; see GeneralObjectExporter.)
+        s.write("musicxml", fp=str(tmp_path), makeNotation=False)
         raw = tmp_path.read_bytes()
         return _sanitize_musicxml_for_osmd(raw), chord_symbols_rendered
     finally:

--- a/backend/storage/local.py
+++ b/backend/storage/local.py
@@ -1,3 +1,23 @@
-"""Re-export from shared package."""
-from shared.storage.local import *  # noqa: F401, F403
-from shared.storage.local import LocalBlobStore as LocalBlobStore  # noqa: F401
+"""Backend `LocalBlobStore`: shared implementation plus API-only helpers.
+
+Docker Compose bind-mounts ``./backend`` into the dev container but not
+``shared``, so the orchestrator can run newer route code against an older
+``ohsheet-shared`` wheel. Subclassing here keeps ``exists()`` available for
+job integrity checks regardless of wheel age; when the wheel includes
+``exists``, we delegate to it.
+"""
+from __future__ import annotations
+
+from shared.storage.local import LocalBlobStore as _SharedLocalBlobStore
+
+
+class LocalBlobStore(_SharedLocalBlobStore):
+    def exists(self, uri: str) -> bool:
+        try:
+            return super().exists(uri)
+        except AttributeError:
+            try:
+                path = self._path_from_uri(uri)
+            except ValueError:
+                return False
+            return path.is_file()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./blob:/app/blob
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       redis:
         condition: service_healthy
@@ -39,6 +40,7 @@ services:
     volumes:
       - ./blob:/app/blob
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       redis:
         condition: service_healthy
@@ -55,6 +57,7 @@ services:
     volumes:
       - ./blob:/app/blob
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       redis:
         condition: service_healthy
@@ -71,6 +74,7 @@ services:
     volumes:
       - ./blob:/app/blob
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       redis:
         condition: service_healthy
@@ -87,6 +91,7 @@ services:
     volumes:
       - ./blob:/app/blob
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       redis:
         condition: service_healthy
@@ -103,6 +108,7 @@ services:
     volumes:
       - ./blob:/app/blob
       - ./backend:/app/backend
+      - ./shared:/app/shared
     depends_on:
       redis:
         condition: service_healthy

--- a/tests/test_engrave_quality.py
+++ b/tests/test_engrave_quality.py
@@ -471,6 +471,122 @@ def test_engrave_does_not_leak_music21_defaults():
     assert music21.defaults.divisionsPerQuarter == prior
 
 
+def test_coerce_musicxml_durations_fixes_2048th_tuplet_bracket() -> None:
+    """``makeNotation``-style tuplets can use a 2048th normal type; MusicXML rejects that."""
+    import music21
+    from music21.duration import Tuplet, durationTupleFromTypeDots
+    from music21.musicxml.m21ToXml import typeToMusicXMLType
+
+    from backend.services.engrave import _coerce_durations_for_musicxml_export
+
+    part = music21.stream.PartStaff()
+    r = music21.note.Rest()
+    r.duration = music21.duration.Duration(1 / 6)
+    nt = Tuplet(3, 2)
+    nt.durationNormal = durationTupleFromTypeDots("2048th", 0)
+    nt.durationActual = durationTupleFromTypeDots("2048th", 0)
+    r.duration.tuplets = (nt,)
+    part.insert(0, r)
+
+    _coerce_durations_for_musicxml_export(part, music21)
+
+    r_out = next(part.recurse().notesAndRests)
+    typeToMusicXMLType(r_out.duration.type)
+    for tup in r_out.duration.tuplets:
+        if tup.durationNormal is not None:
+            typeToMusicXMLType(tup.durationNormal.type)
+        if tup.durationActual is not None:
+            typeToMusicXMLType(tup.durationActual.type)
+
+
+def test_coerce_musicxml_durations_clamps_raw_2048th() -> None:
+    """A bare 2048th note type is also unexportable; coerce to at least 1024th."""
+    import music21
+    from music21.musicxml.m21ToXml import typeToMusicXMLType
+
+    from backend.services.engrave import _coerce_durations_for_musicxml_export
+
+    part = music21.stream.PartStaff()
+    n = music21.note.Note("C4")
+    n.duration = music21.duration.Duration(
+        music21.duration.convertTypeToQuarterLength("2048th"),
+    )
+    part.insert(0, n)
+
+    _coerce_durations_for_musicxml_export(part, music21)
+
+    n_out = next(part.recurse().notesAndRests)
+    typeToMusicXMLType(n_out.duration.type)
+    assert n_out.duration.type != "2048th"
+
+
+def test_coerce_durations_snaps_inexpressible_float_ql() -> None:
+    """Float ``quarterLength`` noise can yield ``duration.type == 'inexpressible'``."""
+    import music21
+
+    from backend.services.engrave import _coerce_durations_for_musicxml_export
+
+    n = music21.note.Note("C4", quarterLength=2.718281828)
+    p = music21.stream.PartStaff()
+    p.append(music21.meter.TimeSignature("4/4"))
+    p.insert(0, n)
+    p.makeNotation(inPlace=True)
+    _coerce_durations_for_musicxml_export(p, music21)
+    n_out = next(p.recurse().notesAndRests)
+    assert n_out.duration.type != "inexpressible"
+
+
+def test_musicxml_write_make_notation_false_needs_split_at_durations() -> None:
+    """Regression: ``complex`` duration on one note breaks MusicXML unless split.
+
+    music21's per-part ``makeNotation`` can leave a single ``Note`` with
+    ``duration.type == 'complex'``. ``write(..., makeNotation=False)`` then
+    raises; ``splitAtDurations(recurse=True)`` is the documented fix (see
+    ``music21.converter.subConverters`` tests).
+    """
+    import tempfile
+    from pathlib import Path
+
+    import music21
+    from music21 import duration, meter, note, stream
+
+    from backend.services.engrave import _coerce_durations_for_musicxml_export
+
+    p = stream.PartStaff()
+    p.append(meter.TimeSignature("4/4"))
+    n = note.Note("C4")
+    d = duration.Duration()
+    d.addDurationTuple(duration.durationTupleFromTypeDots("quarter", 0))
+    d.addDurationTuple(duration.durationTupleFromTypeDots("eighth", 0))
+    n.duration = d
+    p.insert(0, n)
+    p.makeNotation(inPlace=True)
+
+    s = stream.Score()
+    s.insert(0, p)
+
+    from music21.musicxml.xmlObjects import MusicXMLExportException
+
+    with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
+        bad_path = Path(tmp.name)
+    try:
+        with pytest.raises(MusicXMLExportException):
+            s.write("musicxml", fp=str(bad_path), makeNotation=False)
+    finally:
+        bad_path.unlink(missing_ok=True)
+
+    s.splitAtDurations(recurse=True)
+    _coerce_durations_for_musicxml_export(s, music21)
+
+    with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
+        good_path = Path(tmp.name)
+    try:
+        s.write("musicxml", fp=str(good_path), makeNotation=False)
+        assert good_path.stat().st_size > 500
+    finally:
+        good_path.unlink(missing_ok=True)
+
+
 # ---------------------------------------------------------------------------
 # L2 — Tuplet survival (plan phase 3.4 / PR-13)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Seeing some errors when I use certain inputs.

`celery.exceptions.MusicXMLExportException: Cannot convert inexpressible durations to MusicXML.`|
`celery.exceptions.MusicXMLExportException: Cannot convert "2048th" duration to MusicXML (too short).`

### Engrave / MusicXML

Adds duration coercion so floats and makeNotation-generated tuplets (e.g. 2048th “normal” types) do not trip music21 → MusicXML export (typeToMusicXMLType / MusicXMLExportException).
Runs splitAtDurations(recurse=True) (twice, with coercion between passes) so makeNotation=False export does not die on complex / inexpressible durations.
Writes MusicXML with makeNotation=False after explicit per-part notation, avoiding a second makeNotation pass inside the exporter that could reintroduce unwritable tuplets.

### Dev / storage

Dockerfile.dev: installs shared in editable mode (pip install -e ./shared) so bind mounts pick up host changes.
docker-compose.yml: bind-mounts ./shared into the relevant services so orchestrator code and shared stay in sync in dev.
backend/storage/local.py: LocalBlobStore subclass that always exposes exists() for job integrity checks—delegates to the shared wheel when present, otherwise implements a safe fallback (handles older installed ohsheet-shared without exists).

### Tests

New tests/test_engrave_quality.py cases for 2048th tuplet brackets, bare 2048th clamping, inexpressible float QL snapping, and the makeNotation=False + splitAtDurations regression.