### PR TITLE
fix(qa): reclaim VM disk pre-pull + scaffold ml Dockerfile target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,8 +91,24 @@ jobs:
           $SCP /tmp/.env "${VM_USER}@${VM_HOST}:~/oh-sheet/.env.tmp"
           $SSH "mv ~/oh-sheet/.env.tmp ~/oh-sheet/.env && mv ~/oh-sheet/docker-compose.prod.yml ~/oh-sheet/docker-compose.yml"
 
-          # Pull and restart
-          $SSH "cd ~/oh-sheet && sudo docker compose pull && sudo docker compose up -d --remove-orphans && sudo docker image prune -f"
+          # Reclaim disk BEFORE pulling the new image. The app image ships
+          # heavy ML deps (torch/transformers via the [pop2piano] extra),
+          # so a single layer can exceed 1.6 GB. Without an aggressive
+          # pre-pull prune, stale tagged images from prior deploys
+          # accumulate and fill /var/lib/containerd, causing `compose
+          # pull` to abort with "no space left on device" — see run
+          # 24407031842 / job 71295904329. `-a` also removes unused
+          # *tagged* images (plain `-f` only touches dangling ones); the
+          # `until=24h` filter keeps the currently-running image safe
+          # from reclamation. The post-pull prune then reclaims the
+          # just-superseded previous deploy, capped at `until=1h` so a
+          # quick rollback within the hour still has layers to pull.
+          $SSH "cd ~/oh-sheet && \
+                sudo docker image prune -af --filter 'until=24h' && \
+                sudo docker builder prune -af && \
+                sudo docker compose pull && \
+                sudo docker compose up -d --remove-orphans && \
+                sudo docker image prune -af --filter 'until=1h'"
 
       - name: Verify deployment
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,16 @@ RUN flutter pub get
 ARG APP_VERSION=dev
 RUN flutter build web --release --dart-define=API_BASE_URL= --dart-define=APP_VERSION=${APP_VERSION}
 
-# ---- Stage 2: Python runtime ----
+# ---- Stage 2: Shared Python base ----
+# Layers common to both the `api` and `ml` final targets: interpreter,
+# system packages, the ohsheet-shared wheel, and the backend source tree.
+# Splitting this out means BuildKit caches it once and both downstream
+# targets reuse the same base layers, so building both images costs
+# barely more than building one.
+#
 # Python 3.12 for forward-compatibility with torch (MT3 model) which
 # does not yet support 3.13.
-FROM python:3.12-slim
+FROM python:3.12-slim AS python-base
 
 WORKDIR /app
 
@@ -26,16 +32,43 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install shared package first (changes less often)
+# Install shared package first (changes less often). --retries/--timeout
+# harden the install against transient PyPI TLS flakes (`SSLError: record
+# layer failure`) — see incident in run 24407031842 / job 71293097136.
 COPY shared/ shared/
-RUN pip install --no-cache-dir ./shared
+RUN pip install --no-cache-dir --retries 5 --timeout 120 ./shared
+
+COPY pyproject.toml .
+COPY backend/ backend/
+
+# ---- Stage 3a: ML image target ----
+# Staging ground for step 3 of the image-split migration. Not yet
+# consumed by any compose service — the ml target exists today only so
+# CI exercises the multi-target build and catches regressions before
+# worker-transcribe / worker-arrange start using it. Build explicitly
+# with `docker build --target ml .` to produce this image.
+#
+# NOTE: essentia only ships x86_64 Linux wheels — build with
+# --platform linux/amd64 if targeting Apple Silicon hosts.
+FROM python-base AS ml
+
+RUN pip install --no-cache-dir --retries 5 --timeout 120 ".[pop2piano]"
+
+CMD celery -A backend.workers.celery_app worker --loglevel=warning
+
+# ---- Stage 3b: API image target (default) ----
+# This MUST remain the last stage in the file so that `docker build .`
+# (no --target flag) continues to produce the same image the deploy
+# workflow has always published. Every compose service that references
+# ${IMAGE} in docker-compose.prod.yml resolves to this target. Reordering
+# or renaming this stage without also updating .github/workflows/deploy.yml
+# will silently ship the wrong image.
+FROM python-base AS api
 
 # Install Python package with Pop2Piano transcription deps.
 # NOTE: essentia only ships x86_64 Linux wheels — build with
 # --platform linux/amd64 if targeting Apple Silicon hosts.
-COPY pyproject.toml .
-COPY backend/ backend/
-RUN pip install --no-cache-dir ".[pop2piano]"
+RUN pip install --no-cache-dir --retries 5 --timeout 120 ".[pop2piano]"
 
 # Copy Flutter web build into a directory the backend will serve
 COPY --from=flutter-build /app/frontend/build/web /app/static


### PR DESCRIPTION
## Summary

Two changes, bundled so the qa deploy unblocks in one round-trip:

- **`deploy.yml` — prune BEFORE `compose pull`, not after.** The ordering bug caused [run 24407031842 / job 71295904329](https://github.com/Oh-Sheet-Team/oh-sheet/actions/runs/24407031842/job/71295904329) to fail with `no space left on device` in `/var/lib/containerd` ingest while pulling a 1.6 GB+ layer. `-a` (not `-f`) now also reclaims unused *tagged* images from prior deploys; `until=24h` protects the currently-running deploy from being yanked out from under live traffic; the post-pull prune uses `until=1h` so quick rollbacks within the hour still have layers available.
- **`Dockerfile` — refactor into a shared `python-base` with two leaf targets: `ml` and `api`.** The `api` target is intentionally the **last stage**, so `docker build .` with no `--target` flag still picks it and produces the exact same image the workflow publishes today. **True no-op at deploy level.** The new `ml` target is not consumed by any compose service yet — it exists so CI exercises the multi-target build and so step 3 of the image-split migration can flip `worker-transcribe` / `worker-arrange` to it without further Dockerfile changes.
- Both pip installs now carry `--retries 5 --timeout 120` as belt-and-braces against the earlier TLS flake ([run 24407031842 / job 71293097136](https://github.com/Oh-Sheet-Team/oh-sheet/actions/runs/24407031842/job/71293097136): `SSLError: record layer failure` mid-wheel-download).

This is **step 1 of 4** in the image-split migration:
1. ✅ Add `ml` Dockerfile target as no-op scaffold *(this PR)*
2. ✅ Switch compose to pre-built images *(already done on `qa`)*
3. ⬜ Point `worker-transcribe` / `worker-arrange` at `--target ml`
4. ⬜ Drop `[pop2piano]` from the `api` target to actually shrink it

## Test plan

- [ ] QA VM disk manually cleaned via GCP browser SSH (separate step — clears the currently-wedged containerd ingest dir from the failed pull)
- [ ] CI green on this PR
- [ ] After merge into `qa`: `Build & Deploy (qa)` workflow completes successfully (image builds and pushes, VM pulls clean)
- [ ] `/v1/health` on the QA public URL returns 200 post-deploy
- [ ] Slack `#deploys` QA notification fires on success
- [ ] Sanity-check on QA VM: `sudo docker system df -v` shows only current + one prior tagged `oh-sheet/app` image (not the full historical stack)
- [ ] Only after QA is validated: merge `qa` → `main` for PROD rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)