### PR TITLE
feat(inference): FastAPI wrapper for Engraver seq2seq model (GAU-109)

### DIFF
--- a/svc-inference/Dockerfile
+++ b/svc-inference/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY shared/ /app/shared/
+RUN pip install --no-cache-dir /app/shared
+
+COPY svc-inference/ /app/svc-inference/
+RUN cd /app/svc-inference && pip install --no-cache-dir .
+
+ENV OHSHEET_INFERENCE_HOST=0.0.0.0 \
+    OHSHEET_INFERENCE_PORT=8080 \
+    OHSHEET_INFERENCE_RUNNER=stub
+
+EXPOSE 8080
+
+CMD ["uvicorn", "inference.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/svc-inference/inference/__init__.py
+++ b/svc-inference/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Oh Sheet inference microservice — FastAPI wrapper for the engraver model."""

--- a/svc-inference/inference/app.py
+++ b/svc-inference/inference/app.py
@@ -1,0 +1,174 @@
+"""FastAPI entry point for the inference microservice.
+
+Endpoints:
+  GET  /health      — liveness + runner status
+  POST /transcribe  — body: raw performance MIDI; response: MusicXML
+
+Concurrency model: the lifespan hook builds a bounded
+``ThreadPoolExecutor`` and loads the model once. Each request offloads
+the full synchronous pipeline (normalize → chunk → runner × N → stitch)
+to the executor via ``run_in_executor``, so PyTorch tensor ops and the
+constrained beam-search loop never block the event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Request, Response
+
+from inference.config import Settings, get_settings
+from inference.logging_config import setup_logging
+from inference.midi_pipeline import (
+    NormalizedPerformance,
+    ScoreChunk,
+    chunk_performance,
+    normalize_midi,
+    stitch_chunks,
+)
+from inference.model import ModelRunner, create_runner
+
+log = logging.getLogger("inference")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings: Settings = get_settings()
+    setup_logging(settings.log_level)
+
+    runner = create_runner(settings)
+    runner.load()
+    executor = ThreadPoolExecutor(
+        max_workers=settings.max_workers,
+        thread_name_prefix="inference-worker",
+    )
+
+    app.state.settings = settings
+    app.state.runner = runner
+    app.state.executor = executor
+    log.info(
+        "inference service started",
+        extra={
+            "runner": runner.name,
+            "max_workers": settings.max_workers,
+            "device": settings.device,
+        },
+    )
+    try:
+        yield
+    finally:
+        executor.shutdown(wait=True, cancel_futures=False)
+        log.info("inference service stopped")
+
+
+app = FastAPI(title="Oh Sheet Inference", version="0.1.0", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health(request: Request) -> dict:
+    settings: Settings = request.app.state.settings
+    runner: ModelRunner = request.app.state.runner
+    return {
+        "status": "ok",
+        "runner": runner.name,
+        "device": settings.device,
+        "max_workers": settings.max_workers,
+    }
+
+
+@app.post("/transcribe")
+async def transcribe(request: Request) -> Response:
+    settings: Settings = request.app.state.settings
+    runner: ModelRunner = request.app.state.runner
+    executor: ThreadPoolExecutor = request.app.state.executor
+
+    midi_bytes = await request.body()
+    if not midi_bytes:
+        raise HTTPException(status_code=400, detail="empty request body")
+
+    req_id = request.headers.get("x-request-id") or uuid.uuid4().hex[:12]
+    loop = asyncio.get_running_loop()
+    t0 = time.perf_counter()
+    try:
+        musicxml = await loop.run_in_executor(
+            executor, _run_sync_pipeline, midi_bytes, runner, settings, req_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    latency_ms = round((time.perf_counter() - t0) * 1000, 1)
+
+    log.info(
+        "transcribe complete",
+        extra={
+            "request_id": req_id,
+            "latency_ms": latency_ms,
+            "bytes_in": len(midi_bytes),
+            "bytes_out": len(musicxml),
+        },
+    )
+    return Response(
+        content=musicxml,
+        media_type="application/vnd.recordare.musicxml+xml",
+        headers={"x-request-id": req_id},
+    )
+
+
+def _run_sync_pipeline(
+    midi_bytes: bytes,
+    runner: ModelRunner,
+    settings: Settings,
+    req_id: str,
+) -> bytes:
+    t_norm = time.perf_counter()
+    perf: NormalizedPerformance = normalize_midi(midi_bytes)
+    norm_ms = round((time.perf_counter() - t_norm) * 1000, 1)
+
+    t_chunk = time.perf_counter()
+    chunks = chunk_performance(
+        perf,
+        window_beats=settings.chunk_window_beats,
+        stride_beats=settings.chunk_stride_beats,
+    )
+    chunk_ms = round((time.perf_counter() - t_chunk) * 1000, 1)
+
+    results: list[ScoreChunk] = []
+    decode_steps_total = 0
+    rejected_total = 0
+    parse_failures = 0
+    t_decode = time.perf_counter()
+    for ch in chunks:
+        sc = runner.transcribe_chunk(ch)
+        results.append(sc)
+        decode_steps_total += sc.decode_steps
+        rejected_total += sc.rejected_tokens
+        if sc.parse_failed:
+            parse_failures += 1
+    decode_ms = round((time.perf_counter() - t_decode) * 1000, 1)
+
+    t_stitch = time.perf_counter()
+    musicxml = stitch_chunks(results, perf)
+    stitch_ms = round((time.perf_counter() - t_stitch) * 1000, 1)
+
+    log.info(
+        "transcribe stages",
+        extra={
+            "request_id": req_id,
+            "chunk_count": len(chunks),
+            "note_count": len(perf.notes),
+            "tempo_bpm": perf.tempo_bpm,
+            "time_signature": f"{perf.time_signature[0]}/{perf.time_signature[1]}",
+            "normalize_ms": norm_ms,
+            "chunk_ms": chunk_ms,
+            "decode_ms": decode_ms,
+            "stitch_ms": stitch_ms,
+            "beam_width": settings.beam_width,
+            "decode_steps": decode_steps_total,
+            "rejected_tokens": rejected_total,
+            "parse_gate_failures": parse_failures,
+        },
+    )
+    return musicxml

--- a/svc-inference/inference/config.py
+++ b/svc-inference/inference/config.py
@@ -1,0 +1,34 @@
+"""Runtime settings for the inference microservice."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="OHSHEET_INFERENCE_", env_file=".env", extra="ignore")
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+
+    runner: Literal["stub", "seq2seq"] = "stub"
+    checkpoint_uri: str | None = None
+    device: Literal["cpu", "cuda", "mps"] = "cpu"
+
+    max_workers: int = 4
+
+    chunk_window_beats: float = 32.0
+    chunk_stride_beats: float = 24.0
+    max_src_tokens: int = 8192
+    max_tgt_tokens: int = 16384
+
+    beam_width: int = 1
+    decode_temperature: float = 1.0
+    parse_gate_enabled: bool = True
+
+    log_level: str = "INFO"
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/svc-inference/inference/logging_config.py
+++ b/svc-inference/inference/logging_config.py
@@ -1,0 +1,47 @@
+"""Structured JSON logging for the inference service.
+
+Every record is emitted as one JSON line. Call sites attach per-request
+fields (request_id, latency_ms, chunk_count, beam stats, parse-gate
+failures) via ``logger.info(msg, extra={...})``; the formatter merges
+them into the JSON payload.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+
+_RESERVED = {
+    "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+    "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+    "created", "msecs", "relativeCreated", "thread", "threadName",
+    "processName", "process", "message", "taskName",
+}
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(record.created)),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        for k, v in record.__dict__.items():
+            if k in _RESERVED or k.startswith("_"):
+                continue
+            payload[k] = v
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def setup_logging(level: str = "INFO") -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level.upper())
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/svc-inference/inference/midi_pipeline.py
+++ b/svc-inference/inference/midi_pipeline.py
@@ -1,0 +1,368 @@
+"""MIDI normalizer, sliding-window chunker, and measure-boundary stitcher.
+
+The inference path:
+
+    raw MIDI bytes
+        │  normalize_midi()
+        ▼
+    NormalizedPerformance(notes, tempo_bpm, time_signature, end_sec)
+        │  chunk_performance()
+        ▼
+    list[PerfChunk]  (beat-aligned windows w/ overlap)
+        │  runner.transcribe_chunk() for each
+        ▼
+    list[ScoreChunk]  (one per chunk, scoped to its measure range)
+        │  stitch_chunks()
+        ▼
+    MusicXML bytes
+
+Both the normalizer and chunker are intentionally model-agnostic: they
+produce ``PerfNote`` values that match the ``rl_model.core.PerfNote``
+shape shown in the system diagram, so the seq2seq runner can feed them
+straight into ``midi_vocab.encode_perf`` without a re-shape step.
+"""
+from __future__ import annotations
+
+import io
+import logging
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PerfNote:
+    pitch: int
+    onset_sec: float
+    offset_sec: float
+    velocity: int
+
+
+@dataclass
+class NormalizedPerformance:
+    notes: list[PerfNote]
+    tempo_bpm: float
+    time_signature: tuple[int, int]
+    end_sec: float
+
+    @property
+    def seconds_per_beat(self) -> float:
+        return 60.0 / max(1e-6, self.tempo_bpm)
+
+    @property
+    def seconds_per_measure(self) -> float:
+        beats_per_measure = self.time_signature[0] * (4.0 / self.time_signature[1])
+        return self.seconds_per_beat * beats_per_measure
+
+
+@dataclass
+class PerfChunk:
+    index: int
+    notes: list[PerfNote]
+    start_beat: float
+    end_beat: float
+    start_measure: int
+    end_measure: int  # exclusive
+    is_overlap_head: bool = False  # first N measures overlap with previous chunk
+
+
+@dataclass
+class ScoreChunk:
+    """A transcribed chunk — music21 score fragment scoped to its measures.
+
+    ``score`` is typed as ``object`` so that this module doesn't force an
+    import of music21. Runners build the object via their own lazy
+    import, and ``stitch_chunks`` pulls music21 in only when needed.
+    """
+    chunk: PerfChunk
+    score: object
+    decode_steps: int = 0
+    rejected_tokens: int = 0
+    parse_failed: bool = False
+    notes_emitted: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Normalizer
+# ---------------------------------------------------------------------------
+
+def normalize_midi(midi_bytes: bytes) -> NormalizedPerformance:
+    """Parse raw performance MIDI into a flat PerfNote list."""
+    try:
+        import pretty_midi  # noqa: PLC0415
+    except ImportError as exc:
+        raise RuntimeError(
+            "pretty_midi is required to normalize MIDI input. "
+            "Install with `pip install pretty_midi`."
+        ) from exc
+
+    try:
+        pm = pretty_midi.PrettyMIDI(io.BytesIO(midi_bytes))
+    except Exception as exc:  # pretty_midi wraps mido errors in a grab-bag
+        raise ValueError(f"Unable to parse MIDI bytes: {exc}") from exc
+
+    notes: list[PerfNote] = []
+    for inst in pm.instruments:
+        if inst.is_drum:
+            continue
+        for n in inst.notes:
+            if n.end <= n.start:
+                continue
+            notes.append(PerfNote(
+                pitch=int(n.pitch),
+                onset_sec=float(n.start),
+                offset_sec=float(n.end),
+                velocity=int(max(1, min(127, n.velocity))),
+            ))
+    notes.sort(key=lambda n: (n.onset_sec, n.pitch))
+
+    tempo_changes = pm.get_tempo_changes()
+    tempo_bpm = float(tempo_changes[1][0]) if len(tempo_changes[1]) else 120.0
+    ts = pm.time_signature_changes
+    time_signature: tuple[int, int] = (int(ts[0].numerator), int(ts[0].denominator)) if ts else (4, 4)
+
+    end_sec = max((n.offset_sec for n in notes), default=0.0)
+    return NormalizedPerformance(
+        notes=notes,
+        tempo_bpm=tempo_bpm,
+        time_signature=time_signature,
+        end_sec=end_sec,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chunker
+# ---------------------------------------------------------------------------
+
+def chunk_performance(
+    perf: NormalizedPerformance,
+    window_beats: float,
+    stride_beats: float,
+) -> list[PerfChunk]:
+    """Slide a beat-aligned window across the performance.
+
+    Windows are rounded up to whole measures so chunks join cleanly at
+    barlines during stitching. Overlap = window - stride.
+    """
+    if window_beats <= 0 or stride_beats <= 0 or stride_beats > window_beats:
+        raise ValueError(f"invalid chunker cfg: window={window_beats} stride={stride_beats}")
+
+    beats_per_measure = perf.time_signature[0] * (4.0 / perf.time_signature[1])
+    window_measures = max(1, int(round(window_beats / beats_per_measure)))
+    stride_measures = max(1, int(round(stride_beats / beats_per_measure)))
+    overlap_measures = max(0, window_measures - stride_measures)
+
+    sec_per_beat = perf.seconds_per_beat
+    total_beats = perf.end_sec / sec_per_beat if sec_per_beat > 0 else 0.0
+    total_measures = max(1, int(total_beats / beats_per_measure) + 1)
+
+    chunks: list[PerfChunk] = []
+    start_measure = 0
+    idx = 0
+    while start_measure < total_measures:
+        end_measure = min(total_measures, start_measure + window_measures)
+        start_beat = start_measure * beats_per_measure
+        end_beat = end_measure * beats_per_measure
+        start_sec = start_beat * sec_per_beat
+        end_sec = end_beat * sec_per_beat
+
+        chunk_notes = [
+            n for n in perf.notes
+            if n.onset_sec >= start_sec and n.onset_sec < end_sec
+        ]
+        chunks.append(PerfChunk(
+            index=idx,
+            notes=chunk_notes,
+            start_beat=start_beat,
+            end_beat=end_beat,
+            start_measure=start_measure,
+            end_measure=end_measure,
+            is_overlap_head=(idx > 0 and overlap_measures > 0),
+        ))
+        idx += 1
+        if end_measure >= total_measures:
+            break
+        start_measure += stride_measures
+
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Stitcher
+# ---------------------------------------------------------------------------
+
+def stitch_chunks(
+    chunks: list[ScoreChunk],
+    perf: NormalizedPerformance,
+    title: str = "Untitled",
+    composer: str = "",
+) -> bytes:
+    """Merge per-chunk music21 scores at measure boundaries → MusicXML bytes.
+
+    Strategy: take measures from each chunk, skipping the overlap head of
+    chunks after the first so we don't double-emit shared measures. The
+    stitched score is a fresh Score with one part populated by measures
+    in original order.
+
+    Falls back to a minimal hand-rolled MusicXML body if music21 isn't
+    installed so tests / container builds without the optional dep still
+    get valid output.
+    """
+    try:
+        from music21 import clef, metadata, meter, note, stream, tempo  # noqa: PLC0415
+    except ImportError:
+        log.warning("music21 not installed — emitting minimal stub MusicXML")
+        return _minimal_musicxml(chunks, perf, title, composer)
+
+    beats_per_measure = perf.time_signature[0] * (4.0 / perf.time_signature[1])
+    overlap_measures_from = _detect_overlap(chunks)
+
+    merged = stream.Score()
+    merged.metadata = metadata.Metadata()
+    merged.metadata.title = title or "Untitled"
+    merged.metadata.composer = composer or ""
+
+    part = stream.Part()
+    part.append(clef.TrebleClef())
+    part.append(meter.TimeSignature(f"{perf.time_signature[0]}/{perf.time_signature[1]}"))
+    part.append(tempo.MetronomeMark(number=perf.tempo_bpm))
+
+    parse_failures = 0
+    for sc in chunks:
+        if sc.parse_failed:
+            parse_failures += 1
+            continue
+        skip_measures = overlap_measures_from if sc.chunk.index > 0 else 0
+        try:
+            _append_chunk_measures(sc, part, skip_measures, beats_per_measure, note)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("stitch: chunk %d append failed: %s", sc.chunk.index, exc)
+            parse_failures += 1
+
+    merged.append(part)
+
+    try:
+        import tempfile
+        from pathlib import Path
+        with tempfile.NamedTemporaryFile(suffix=".musicxml", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            merged.write("musicxml", fp=str(tmp_path))
+            return tmp_path.read_bytes()
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("music21 write failed (%s); emitting minimal stub", exc)
+        return _minimal_musicxml(chunks, perf, title, composer)
+
+
+def _detect_overlap(chunks: list[ScoreChunk]) -> int:
+    if len(chunks) < 2:
+        return 0
+    first, second = chunks[0].chunk, chunks[1].chunk
+    return max(0, first.end_measure - second.start_measure)
+
+
+def _append_chunk_measures(
+    sc: ScoreChunk,
+    part: object,
+    skip_measures: int,
+    beats_per_measure: float,
+    m21_note_mod: object,
+) -> None:
+    """Append notes from a chunk's score to the merged part.
+
+    Music21 scores from the decoder are flat note streams; we partition
+    them into measures by onset beat offset from the chunk start and
+    drop the first ``skip_measures`` to avoid double-emitting overlap.
+    """
+    chunk_score = sc.score
+    if chunk_score is None:
+        return
+    try:
+        flat_notes = list(chunk_score.flatten().notes) if hasattr(chunk_score, "flatten") else []
+    except Exception:  # noqa: BLE001
+        flat_notes = []
+
+    for n in flat_notes:
+        try:
+            offset_beats = float(n.offset)
+        except Exception:  # noqa: BLE001
+            continue
+        measure_idx = int(offset_beats // beats_per_measure)
+        if measure_idx < skip_measures:
+            continue
+        absolute_beat = sc.chunk.start_beat + offset_beats
+        try:
+            part.insert(absolute_beat, n)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            continue
+
+
+def _minimal_musicxml(
+    chunks: list[ScoreChunk],
+    perf: NormalizedPerformance,
+    title: str,
+    composer: str,
+) -> bytes:
+    from xml.sax.saxutils import escape
+
+    ts = perf.time_signature
+    divisions = 4
+
+    parts: list[str] = []
+    parts.append('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')
+    parts.append(
+        '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" '
+        '"http://www.musicxml.org/dtds/partwise.dtd">'
+    )
+    parts.append('<score-partwise version="3.1">')
+    parts.append(f'<work><work-title>{escape(title or "Untitled")}</work-title></work>')
+    parts.append(
+        f'<identification><creator type="composer">{escape(composer or "Unknown")}</creator></identification>'
+    )
+    parts.append(
+        '<part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>'
+    )
+    parts.append('<part id="P1"><measure number="1"><attributes>')
+    parts.append(f'<divisions>{divisions}</divisions>')
+    parts.append('<key><fifths>0</fifths></key>')
+    parts.append(f'<time><beats>{ts[0]}</beats><beat-type>{ts[1]}</beat-type></time>')
+    parts.append('<clef><sign>G</sign><line>2</line></clef>')
+    parts.append('</attributes>')
+    parts.append(f'<sound tempo="{perf.tempo_bpm:.2f}"/>')
+
+    note_count = 0
+    for sc in chunks:
+        if sc.parse_failed:
+            continue
+        for pn in sc.chunk.notes:
+            step, alter, octave = _midi_to_step_alter_octave(pn.pitch)
+            alter_xml = f"<alter>{alter}</alter>" if alter else ""
+            parts.append(
+                "<note>"
+                f"<pitch><step>{step}</step>{alter_xml}<octave>{octave}</octave></pitch>"
+                f"<duration>{divisions}</duration><voice>1</voice>"
+                "</note>"
+            )
+            note_count += 1
+            if note_count >= 32:
+                break
+        if note_count >= 32:
+            break
+
+    parts.append('</measure></part></score-partwise>')
+    return "".join(parts).encode("utf-8")
+
+
+_PITCH_NAMES: list[tuple[str, int]] = [
+    ("C", 0), ("C", 1), ("D", 0), ("D", 1), ("E", 0), ("F", 0),
+    ("F", 1), ("G", 0), ("G", 1), ("A", 0), ("A", 1), ("B", 0),
+]
+
+
+def _midi_to_step_alter_octave(midi: int) -> tuple[str, int, int]:
+    midi = max(0, min(127, midi))
+    octave = (midi // 12) - 1
+    step, alter = _PITCH_NAMES[midi % 12]
+    return step, alter, octave

--- a/svc-inference/inference/model.py
+++ b/svc-inference/inference/model.py
@@ -1,0 +1,283 @@
+"""Model runners — how a chunk of performance notes becomes a score.
+
+Two implementations:
+
+* ``StubModelRunner`` — no ML dependency. Translates PerfNotes directly
+  into a music21 score by snapping onsets to a 16th-note grid. Lets the
+  service boot and be tested without torch / rl_model.
+
+* ``Seq2SeqModelRunner`` — the real one. Lazy-imports ``rl_model`` at
+  ``load()`` time so the service image can ship without torch for
+  environments that only want the stub path. Runs the full diagram-§5
+  inference flow:
+
+      encode_perf → model.encode → init_decode_cache
+        → FSM-masked decode loop → vocab.decode_tokens
+        → tokenize.decode_events → music21.Score
+
+  Parse failures (the §6 "parse gate") are caught per-chunk and reported
+  in ``ScoreChunk.parse_failed`` so the service can log the failure and
+  skip that measure range instead of poisoning the whole request.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Protocol
+
+from inference.config import Settings
+from inference.midi_pipeline import PerfChunk, PerfNote, ScoreChunk
+
+log = logging.getLogger(__name__)
+
+
+class ModelRunner(Protocol):
+    name: str
+
+    def load(self) -> None: ...
+    def transcribe_chunk(self, chunk: PerfChunk) -> ScoreChunk: ...
+
+
+# ---------------------------------------------------------------------------
+# Stub runner — no ML deps
+# ---------------------------------------------------------------------------
+
+class StubModelRunner:
+    """Deterministic non-ML runner for local dev and tests.
+
+    Snaps each PerfNote onset to the nearest 16th note and emits a
+    flat music21 score. Fakes beam-search stats so the logging path
+    is exercised end-to-end.
+    """
+    name = "stub"
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._loaded = False
+
+    def load(self) -> None:
+        # No-op: stub has nothing to warm up. We still flip the flag so
+        # /health can distinguish "runner selected but not loaded yet".
+        self._loaded = True
+
+    def transcribe_chunk(self, chunk: PerfChunk) -> ScoreChunk:
+        if not self._loaded:
+            raise RuntimeError("StubModelRunner.load() was not called")
+
+        try:
+            from music21 import note, stream  # noqa: PLC0415
+        except ImportError:
+            # music21 missing → return an empty shell; stitcher will
+            # fall back to the minimal MusicXML path using chunk.notes.
+            return ScoreChunk(
+                chunk=chunk, score=None, decode_steps=0,
+                rejected_tokens=0, parse_failed=False,
+                notes_emitted=len(chunk.notes),
+            )
+
+        sec_per_beat = 60.0 / 120.0  # stub assumes 120 BPM normalization
+        s = stream.Stream()
+        for pn in chunk.notes:
+            rel_beat = max(0.0, (pn.onset_sec - chunk.start_beat * sec_per_beat) / sec_per_beat)
+            rel_beat = round(rel_beat * 4) / 4.0  # snap to 16th
+            dur_beat = max(0.25, (pn.offset_sec - pn.onset_sec) / sec_per_beat)
+            dur_beat = round(dur_beat * 4) / 4.0
+            n = note.Note(midi=pn.pitch)
+            n.quarterLength = dur_beat
+            n.volume.velocity = pn.velocity
+            s.insert(rel_beat, n)
+
+        return ScoreChunk(
+            chunk=chunk, score=s,
+            decode_steps=len(chunk.notes) * 4,  # 4 tokens/note burst
+            rejected_tokens=0,
+            parse_failed=False,
+            notes_emitted=len(chunk.notes),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Seq2Seq runner — real model
+# ---------------------------------------------------------------------------
+
+class Seq2SeqModelRunner:
+    """FSM-constrained Seq2Seq decoder wired to rl_model.
+
+    Requires the external ``rl_model`` package (separate repo) and
+    ``torch``. Loads the checkpoint once at ``load()`` time; every
+    ``transcribe_chunk`` call reuses the warm model.
+    """
+    name = "seq2seq"
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._loaded = False
+        self._model = None
+        self._grammar_cls = None
+        self._midi_vocab = None
+        self._vocab = None
+        self._tokenize_mod = None
+        self._torch = None
+        self._device = None
+
+    def load(self) -> None:
+        if self._loaded:
+            return
+        t0 = time.perf_counter()
+        try:
+            import torch  # noqa: PLC0415
+            from rl_model import grammar as grammar_mod  # noqa: PLC0415
+            from rl_model import midi_vocab, tokenize, vocab  # noqa: PLC0415
+            from rl_model.modeling.seq2seq import Seq2Seq  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError(
+                "Seq2SeqModelRunner requires `torch` and the `rl_model` package. "
+                "Install them or switch OHSHEET_INFERENCE_RUNNER=stub."
+            ) from exc
+
+        if not self.settings.checkpoint_uri:
+            raise RuntimeError(
+                "OHSHEET_INFERENCE_CHECKPOINT_URI is required for the seq2seq runner"
+            )
+
+        self._torch = torch
+        self._device = torch.device(self.settings.device)
+        self._midi_vocab = midi_vocab
+        self._vocab = vocab
+        self._tokenize_mod = tokenize
+        self._grammar_cls = grammar_mod.GrammarFSM
+
+        checkpoint = torch.load(self.settings.checkpoint_uri, map_location=self._device)
+        model = Seq2Seq.from_checkpoint(checkpoint) if hasattr(Seq2Seq, "from_checkpoint") else checkpoint["model"]
+        model.to(self._device).eval()
+        self._model = model
+        self._loaded = True
+
+        log.info(
+            "seq2seq runner loaded",
+            extra={
+                "checkpoint_uri": self.settings.checkpoint_uri,
+                "device": str(self._device),
+                "load_ms": round((time.perf_counter() - t0) * 1000, 1),
+            },
+        )
+
+    def transcribe_chunk(self, chunk: PerfChunk) -> ScoreChunk:
+        if not self._loaded:
+            raise RuntimeError("Seq2SeqModelRunner.load() was not called")
+        torch = self._torch
+        assert torch is not None
+
+        src_ids = self._encode_chunk(chunk)
+        if src_ids is None or len(src_ids) == 0:
+            return ScoreChunk(chunk=chunk, score=None, parse_failed=False)
+
+        with torch.no_grad():
+            src = torch.tensor([src_ids], dtype=torch.long, device=self._device)
+            memory, src_pad = self._model.encode(src)  # type: ignore[union-attr]
+            cache = self._model.init_decode_cache(memory, src_pad, self.settings.max_tgt_tokens)  # type: ignore[union-attr]
+
+            fsm = self._grammar_cls()  # type: ignore[misc]
+            ys: list[int] = [self._vocab.BOS_ID]  # type: ignore[union-attr]
+            rejected = 0
+            eos_id = getattr(self._vocab, "EOS_ID", None)
+
+            for step in range(self.settings.max_tgt_tokens):
+                logits = self._model.decode_step_cached(  # type: ignore[union-attr]
+                    torch.tensor([[ys[-1]]], device=self._device),
+                    cache,
+                )
+                logits = logits[0, -1] / max(1e-6, self.settings.decode_temperature)
+                mask = fsm.legal_mask(ys)
+                if mask is not None:
+                    mask_t = torch.as_tensor(mask, device=logits.device, dtype=torch.bool)
+                    rejected += int((~mask_t).sum().item())
+                    logits = logits.masked_fill(~mask_t, float("-inf"))
+                next_id = int(torch.argmax(logits).item())
+                ys.append(next_id)
+                fsm.advance(next_id)
+                if eos_id is not None and next_id == eos_id:
+                    break
+
+        events = self._vocab.decode_tokens(ys)  # type: ignore[union-attr]
+
+        parse_failed = False
+        score = None
+        try:
+            score = self._tokenize_mod.decode_events(events)  # type: ignore[union-attr]
+        except Exception as exc:  # parse gate
+            if self.settings.parse_gate_enabled:
+                parse_failed = True
+                log.warning(
+                    "parse_gate_failure",
+                    extra={
+                        "chunk_index": chunk.index,
+                        "decode_steps": len(ys),
+                        "exc": str(exc),
+                    },
+                )
+            else:
+                raise
+
+        return ScoreChunk(
+            chunk=chunk,
+            score=score,
+            decode_steps=len(ys),
+            rejected_tokens=rejected,
+            parse_failed=parse_failed,
+            notes_emitted=len(chunk.notes),
+        )
+
+    def _encode_chunk(self, chunk: PerfChunk) -> list[int] | None:
+        """Call rl_model.midi_vocab.encode_perf on the chunk's PerfNotes."""
+        if not chunk.notes:
+            return []
+        try:
+            ids = self._midi_vocab.encode_perf([  # type: ignore[union-attr]
+                _as_rl_perfnote(n) for n in chunk.notes
+            ])
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "encode_perf failed",
+                extra={"chunk_index": chunk.index, "exc": str(exc)},
+            )
+            return None
+        if len(ids) > self.settings.max_src_tokens:
+            log.warning(
+                "chunk exceeds max_src_tokens — truncating",
+                extra={"chunk_index": chunk.index, "src_len": len(ids)},
+            )
+            ids = ids[: self.settings.max_src_tokens]
+        return list(ids)
+
+
+def _as_rl_perfnote(pn: PerfNote) -> object:
+    """Adapt our PerfNote to whatever shape rl_model.midi_vocab expects.
+
+    The diagram shows rl_model.core.PerfNote as (pitch, on/off, vel);
+    our fields (pitch, onset_sec, offset_sec, velocity) match that shape
+    so the adapter is a straight namedtuple-style call. We import
+    lazily to avoid pulling rl_model into module load.
+    """
+    try:
+        from rl_model.core import PerfNote as RlPerfNote  # noqa: PLC0415
+        return RlPerfNote(
+            pitch=pn.pitch,
+            onset=pn.onset_sec,
+            offset=pn.offset_sec,
+            velocity=pn.velocity,
+        )
+    except Exception:  # noqa: BLE001 — rl_model variants may differ
+        return pn
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def create_runner(settings: Settings) -> ModelRunner:
+    if settings.runner == "stub":
+        return StubModelRunner(settings)
+    if settings.runner == "seq2seq":
+        return Seq2SeqModelRunner(settings)
+    raise ValueError(f"unknown runner: {settings.runner!r}")

--- a/svc-inference/tests/conftest.py
+++ b/svc-inference/tests/conftest.py
@@ -1,0 +1,5 @@
+"""Make the `inference` package importable without installing the wheel."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/svc-inference/tests/fixtures.py
+++ b/svc-inference/tests/fixtures.py
@@ -1,0 +1,28 @@
+"""Tiny MIDI fixture helpers — keeps tests independent of on-disk assets."""
+from __future__ import annotations
+
+
+def make_sample_midi(num_notes: int = 8) -> bytes:
+    """Build a minimal single-track MIDI file in-memory using pretty_midi."""
+    import pretty_midi
+
+    pm = pretty_midi.PrettyMIDI(initial_tempo=120.0)
+    inst = pretty_midi.Instrument(program=0, name="Piano")
+    step = 0.25  # 8th notes at 120 BPM
+    for i in range(num_notes):
+        start = i * step
+        inst.notes.append(pretty_midi.Note(
+            velocity=80, pitch=60 + (i % 12),
+            start=start, end=start + step * 0.9,
+        ))
+    pm.instruments.append(inst)
+
+    import tempfile
+    from pathlib import Path
+    with tempfile.NamedTemporaryFile(suffix=".mid", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        pm.write(str(tmp_path))
+        return tmp_path.read_bytes()
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/svc-inference/tests/test_app.py
+++ b/svc-inference/tests/test_app.py
@@ -1,0 +1,95 @@
+"""HTTP tests — health, /transcribe happy path, concurrency non-blocking."""
+import asyncio
+import time
+
+import httpx
+import pytest
+from inference.app import app
+from inference.midi_pipeline import PerfChunk, ScoreChunk
+from inference.model import StubModelRunner
+
+from tests.fixtures import make_sample_midi
+
+
+@pytest.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app), httpx.AsyncClient(transport=transport, base_url="http://inf") as c:
+        yield c
+
+
+async def test_health(client):
+    r = await client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["runner"] == "stub"
+
+
+async def test_transcribe_happy_path(client):
+    midi = make_sample_midi(num_notes=8)
+    r = await client.post(
+        "/transcribe",
+        content=midi,
+        headers={"content-type": "application/octet-stream"},
+    )
+    assert r.status_code == 200
+    assert "musicxml" in r.headers.get("content-type", "")
+    assert r.content.startswith(b"<?xml")
+    assert b"score-partwise" in r.content
+    assert r.headers.get("x-request-id")
+
+
+async def test_transcribe_rejects_empty_body(client):
+    r = await client.post("/transcribe", content=b"")
+    assert r.status_code == 400
+
+
+async def test_transcribe_rejects_bad_midi(client):
+    r = await client.post("/transcribe", content=b"not a midi file")
+    assert r.status_code == 400
+
+
+class _BlockingStubRunner(StubModelRunner):
+    """Sleeps inside transcribe_chunk to simulate slow tensor ops.
+
+    The point of this test is to prove the event loop isn't blocked:
+    if /transcribe held the loop, N concurrent requests would take
+    N × delay seconds total. With run_in_executor, they overlap.
+    """
+    BLOCK_SECONDS = 0.4
+
+    def transcribe_chunk(self, chunk: PerfChunk) -> ScoreChunk:
+        time.sleep(self.BLOCK_SECONDS)
+        return super().transcribe_chunk(chunk)
+
+
+async def test_concurrent_requests_do_not_serialize(client):
+    """Load-test: 4 concurrent requests should finish in < 2 × single latency.
+
+    The stub runner is swapped in-place for a version that sleeps 0.4s
+    per chunk. With max_workers=4 (default) the 4 requests should run
+    in parallel, not serially.
+    """
+    original = app.state.runner
+    app.state.runner = _BlockingStubRunner(app.state.settings)
+    app.state.runner.load()
+    try:
+        midi = make_sample_midi(num_notes=4)
+        n_concurrent = 4
+
+        async def one():
+            r = await client.post("/transcribe", content=midi)
+            assert r.status_code == 200
+
+        t0 = time.perf_counter()
+        await asyncio.gather(*(one() for _ in range(n_concurrent)))
+        elapsed = time.perf_counter() - t0
+
+        # Serial would be ~n * 0.4 = 1.6s. Concurrent should be ~0.4-0.8s.
+        # Allow generous headroom for CI variance.
+        assert elapsed < (n_concurrent * _BlockingStubRunner.BLOCK_SECONDS) * 0.75, (
+            f"requests appear to be serialized: {elapsed:.2f}s for {n_concurrent} reqs"
+        )
+    finally:
+        app.state.runner = original

--- a/svc-inference/tests/test_midi_pipeline.py
+++ b/svc-inference/tests/test_midi_pipeline.py
@@ -1,0 +1,48 @@
+"""Unit tests for the MIDI normalizer, chunker, and stitcher."""
+from inference.midi_pipeline import (
+    ScoreChunk,
+    chunk_performance,
+    normalize_midi,
+    stitch_chunks,
+)
+
+from tests.fixtures import make_sample_midi
+
+
+def test_normalize_midi_extracts_notes():
+    perf = normalize_midi(make_sample_midi(num_notes=6))
+    assert len(perf.notes) == 6
+    assert perf.time_signature == (4, 4)
+    assert perf.tempo_bpm > 0
+    # Onsets strictly increasing
+    assert [n.onset_sec for n in perf.notes] == sorted(n.onset_sec for n in perf.notes)
+
+
+def test_chunker_covers_all_notes_with_overlap():
+    perf = normalize_midi(make_sample_midi(num_notes=64))  # ~16s at 120 BPM
+    chunks = chunk_performance(perf, window_beats=8.0, stride_beats=4.0)
+    assert len(chunks) >= 2
+    # Every note onset should land in at least one chunk
+    covered = {id(n) for c in chunks for n in c.notes}
+    assert len(covered) == len(perf.notes)
+    # Chunks after the first overlap with the previous one
+    assert chunks[1].start_measure < chunks[0].end_measure
+
+
+def test_chunker_rejects_bad_config():
+    perf = normalize_midi(make_sample_midi(num_notes=4))
+    try:
+        chunk_performance(perf, window_beats=4.0, stride_beats=8.0)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for stride > window")
+
+
+def test_stitch_minimal_fallback_produces_valid_xml_header():
+    # Use a dummy ScoreChunk with score=None so the minimal path runs
+    perf = normalize_midi(make_sample_midi(num_notes=4))
+    chunks = chunk_performance(perf, window_beats=16.0, stride_beats=8.0)
+    score_chunks = [ScoreChunk(chunk=c, score=None) for c in chunks]
+    out = stitch_chunks(score_chunks, perf)
+    assert out.startswith(b"<?xml")
+    assert b"score-partwise" in out


### PR DESCRIPTION
## Summary

Implements [GAU-109](https://linear.app/gauntletai-kevin/issue/GAU-109/inference-microservice-fastapi-wrapper-for-engraver-model) — a standalone FastAPI inference microservice (`svc-inference/`) that wraps the `rl_model` Seq2Seq transformer for performance-MIDI → MusicXML transcription. Matches the flow in `docs/system_diagram.pdf` §5 (grammar-constrained decode).

- **Request path:** `normalize_midi` → `chunk_performance` (beat-aligned sliding window w/ overlap) → `runner.transcribe_chunk` ×N → `stitch_chunks` (music21 merge at measure boundaries) → MusicXML bytes.
- **Two runners:**
  - `StubModelRunner` — no ML deps, ships by default, lets the service boot and be tested without torch/`rl_model`.
  - `Seq2SeqModelRunner` — lazy-imports `rl_model` + torch; runs `encode` → `init_decode_cache` → FSM-masked `decode_step_cached` loop → `vocab.decode_tokens` → `tokenize.decode_events`. Parse gate wraps `decode_events` per-chunk so a bad chunk logs + skips instead of poisoning the whole request.
- **Concurrency:** lifespan owns a bounded `ThreadPoolExecutor`; `/transcribe` offloads the full synchronous pipeline via `run_in_executor` so PyTorch tensor ops and the constrained decode loop never block the event loop.
- **Observability:** JSON-line logs, per-request `latency_ms`, `chunk_count`, `beam_width`, `decode_steps`, `rejected_tokens`, `parse_gate_failures`.
- **Config:** `OHSHEET_INFERENCE_*` env vars (`RUNNER`, `CHECKPOINT_URI`, `DEVICE`, `MAX_WORKERS`, chunk sizes, `BEAM_WIDTH`, etc.).

## Out of scope (per ticket)

- Training loop, reward computation, dataset management.
- Autoscaling / GPU provisioning.
- Swapping the service into `backend/workers/engrave.py` — that's a follow-up integration ticket.
- `Seq2SeqModelRunner` requires the external `rl_model` package + a checkpoint, neither of which is in-repo yet. Until they land, run with `OHSHEET_INFERENCE_RUNNER=stub` (default).

## Test plan

- [x] `GET /health` returns runner + device status
- [x] `POST /transcribe` happy path → valid MusicXML with `score-partwise` root
- [x] `POST /transcribe` with empty body → 400
- [x] `POST /transcribe` with non-MIDI bytes → 400
- [x] Concurrency non-blocking: 4 parallel requests with a 0.4s-per-chunk blocking stub finish in < 75% of serial time (proves `run_in_executor` path isn't serialized on the event loop)
- [x] Normalizer preserves all notes and detects tempo / time signature
- [x] Chunker covers every note with overlap between adjacent chunks; rejects `stride > window`
- [x] Stitcher minimal-fallback path produces valid MusicXML header when music21 is unavailable
- [x] `ruff check svc-inference/` clean
- [x] 9/9 pytest passing locally

Targeted at `qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)