### PR TITLE
deploy: wire TUNECHAT env vars through to orchestrator + worker-ingest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,8 +51,18 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build and push container images
+        env:
+          # TUNECHAT_URL is baked into the Flutter JS bundle at build time
+          # via --dart-define (see Dockerfile flutter-build stage).
+          # Pulling through env: is the safe pattern — inline ${{...}}
+          # in a run: shell line is a workflow-injection smell.
+          TUNECHAT_URL: ${{ vars.OHSHEET_TUNECHAT_URL }}
         run: |
-          docker build --build-arg APP_VERSION=${{ steps.version.outputs.version }} -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
+          docker build \
+            --build-arg APP_VERSION=${{ steps.version.outputs.version }} \
+            --build-arg TUNECHAT_URL="$TUNECHAT_URL" \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:latest .
           docker push ${{ env.IMAGE }}:${{ github.sha }}
           docker push ${{ env.IMAGE }}:latest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,13 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.VM_SSH_PRIVATE_KEY }}
           VM_HOST: ${{ vars.VM_HOST }}
           VM_USER: ${{ vars.VM_USER }}
+          # TuneChat integration — env-scoped so qa + prod each inject
+          # their own config. Both currently point at prod TuneChat, but
+          # that's a provisioning choice, not a pipeline one. Referenced
+          # by orchestrator + worker-ingest via docker-compose.prod.yml.
+          OHSHEET_TUNECHAT_ENABLED: ${{ vars.OHSHEET_TUNECHAT_ENABLED }}
+          OHSHEET_TUNECHAT_URL: ${{ vars.OHSHEET_TUNECHAT_URL }}
+          OHSHEET_TUNECHAT_API_KEY: ${{ secrets.OHSHEET_TUNECHAT_API_KEY }}
         run: |
           # Set up SSH
           mkdir -p ~/.ssh
@@ -85,6 +92,11 @@ jobs:
           echo "IMAGE_ASSEMBLER=${{ env.IMAGE_ASSEMBLER }}:${{ github.sha }}" >> /tmp/.env
           echo "COMMIT_SHA=${{ github.sha }}" >> /tmp/.env
           echo "DOMAIN=${{ vars.DOMAIN }}" >> /tmp/.env
+          # TuneChat — values come from the step env: above (safe shell
+          # expansion of pre-declared env vars, not inline ${{...}}).
+          echo "OHSHEET_TUNECHAT_ENABLED=${OHSHEET_TUNECHAT_ENABLED}" >> /tmp/.env
+          echo "OHSHEET_TUNECHAT_URL=${OHSHEET_TUNECHAT_URL}" >> /tmp/.env
+          echo "OHSHEET_TUNECHAT_API_KEY=${OHSHEET_TUNECHAT_API_KEY}" >> /tmp/.env
 
           # Copy compose files to VM (SCP .env to temp name, then atomic mv)
           $SCP docker-compose.prod.yml Caddyfile "${VM_USER}@${VM_HOST}:~/oh-sheet/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,16 @@ COPY frontend/ .
 RUN flutter pub get
 # Empty API_BASE_URL → client uses same-origin relative URLs (/v1/...)
 ARG APP_VERSION=dev
-RUN flutter build web --release --dart-define=API_BASE_URL= --dart-define=APP_VERSION=${APP_VERSION}
+# TUNECHAT_URL is read via String.fromEnvironment in result_screen.dart
+# at dart-define time (not runtime), so it's baked into the JS bundle.
+# Empty default is safe — result_screen.dart only uses it when a job
+# has a tunechat_job_id set, which only happens when the backend's
+# OHSHEET_TUNECHAT_ENABLED flag is true.
+ARG TUNECHAT_URL=
+RUN flutter build web --release \
+      --dart-define=API_BASE_URL= \
+      --dart-define=APP_VERSION=${APP_VERSION} \
+      --dart-define=TUNECHAT_URL=${TUNECHAT_URL}
 
 # ---- Stage 2: Shared Python base ----
 # Layers common to both the `api` and `ml` final targets: interpreter,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,6 +35,14 @@ services:
       # time in api/routes/jobs.py); workers just execute whatever stage
       # they're dispatched. Remove after validating condense_only in prod.
       OHSHEET_SCORE_PIPELINE: arrange
+      # TuneChat external transcription. The ingest stage POSTs audio to
+      # TuneChat in parallel with Oh Sheet's own pipeline. Orchestrator
+      # needs these because api/routes/jobs.py reads settings.tunechat_*
+      # when building PipelineConfig at job-creation time. Enabled flag
+      # is the kill switch — unset or set to "false" to short-circuit.
+      OHSHEET_TUNECHAT_ENABLED: ${OHSHEET_TUNECHAT_ENABLED:-false}
+      OHSHEET_TUNECHAT_URL: ${OHSHEET_TUNECHAT_URL:-}
+      OHSHEET_TUNECHAT_API_KEY: ${OHSHEET_TUNECHAT_API_KEY:-}
       COMMIT_SHA: ${COMMIT_SHA:-unknown}
     volumes:
       - blob-data:/app/blob
@@ -55,6 +63,13 @@ services:
     environment:
       OHSHEET_BLOB_ROOT: /app/blob
       OHSHEET_REDIS_URL: redis://redis:6379/0
+      # TuneChat is called from services/ingest.py via the tunechat_client
+      # (async httpx.AsyncClient.post) — see config comment on
+      # tunechat_timeout_sec. Worker must have the env vars or the call
+      # short-circuits to None and Oh Sheet uses its own pipeline only.
+      OHSHEET_TUNECHAT_ENABLED: ${OHSHEET_TUNECHAT_ENABLED:-false}
+      OHSHEET_TUNECHAT_URL: ${OHSHEET_TUNECHAT_URL:-}
+      OHSHEET_TUNECHAT_API_KEY: ${OHSHEET_TUNECHAT_API_KEY:-}
     volumes:
       - blob-data:/app/blob
     depends_on:


### PR DESCRIPTION
## Summary

PR #62 shipped the `tunechat_client` integration, but the env vars it needs (`OHSHEET_TUNECHAT_ENABLED`/`URL`/`API_KEY`) were never plumbed into the deploy pipeline. Pydantic Settings reads them from `os.environ`, but docker-compose wasn't substituting them, so both qa and prod silently fall back to defaults (`enabled=false`, `api_key=""`) — the integration is effectively dark in deployed environments.

This PR connects the pipe end-to-end:

```
GH env secret/var
      │
      ├── deploy.yml pulls it into the step env: block
      │       │
      │       └── echoes it into /tmp/.env
      │               │
      │               └── SCPs to the VM as ~/oh-sheet/.env
      │                       │
      │                       └── docker compose reads .env
      │                               │
      │                               └── substitutes into
      │                                   orchestrator + worker-ingest
      │                                   environment: blocks
      │                                           │
      │                                           └── pydantic Settings
      │                                               sees OHSHEET_TUNECHAT_*
```

## Changes

- **`deploy.yml`** — declare the three TUNECHAT vars in the `Deploy to VM` step's `env:` block and echo them into `/tmp/.env`. Uses shell-variable expansion (`${OHSHEET_TUNECHAT_URL}`) per workflow-injection guidance, not inline `${{ ... }}` in `run:` commands.
- **`docker-compose.prod.yml`** — add `OHSHEET_TUNECHAT_*` to two services:
  - `orchestrator` — reads `settings.tunechat_*` when building `PipelineConfig` at job creation (`api/routes/jobs.py`)
  - `worker-ingest` — actual call site (`services/ingest.py` → `tunechat_client`)

Other workers (`worker-transcribe`, `-arrange`, `-humanize`, `-engrave`) don't need it per current code — they can always be added later if a call site moves.

## Prereqs — already done

Env-scoped GitHub secrets/variables for `qa` and `prod`:

| Env | Kind | Name | Value |
|-----|------|------|-------|
| qa, prod | variable | `OHSHEET_TUNECHAT_ENABLED` | `true` |
| qa, prod | variable | `OHSHEET_TUNECHAT_URL` | `https://tunechat.raqdrobinson.com` |
| qa, prod | secret | `OHSHEET_TUNECHAT_API_KEY` | (64-char hex) |

Both envs currently point at production TuneChat. That's a **provisioning** choice — swap `OHSHEET_TUNECHAT_URL` to stage a separate TuneChat instance for qa later.

## Test plan

- [ ] Merge and watch the qa deploy run — the `Deploy to VM` step should succeed without errors
- [ ] SSH to `oh-sheet-qa.duckdns.org` and `cat ~/oh-sheet/.env` — should contain the three `OHSHEET_TUNECHAT_*` lines
- [ ] `docker exec <orchestrator-container> env | grep TUNECHAT` — should show all three
- [ ] `docker exec <worker-ingest-container> env | grep TUNECHAT` — same
- [ ] Submit a real job through the UI on qa; check logs for `tunechat_client` making an outbound POST to `tunechat.raqdrobinson.com`
- [ ] Confirm TuneChat receives the request (check Railway logs on the `radiant-curiosity` project → `TuneChat` service for `POST /api/v1/transcribe`)

## Risk

Low — both vars can be left unset and `docker-compose` falls back to empty strings (`:-}` default), which tips `tunechat_enabled` to `false` and the client short-circuits. Nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)