### PR TITLE
fix(deploy): remove literal ${{ in YAML comments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           # TUNECHAT_URL is baked into the Flutter JS bundle at build time
           # via --dart-define (see Dockerfile flutter-build stage).
-          # Pulling through env: is the safe pattern — inline ${{...}}
+          # Pulling through env: is the safe pattern — inline expressions
           # in a run: shell line is a workflow-injection smell.
           TUNECHAT_URL: ${{ vars.OHSHEET_TUNECHAT_URL }}
         run: |
@@ -103,7 +103,7 @@ jobs:
           echo "COMMIT_SHA=${{ github.sha }}" >> /tmp/.env
           echo "DOMAIN=${{ vars.DOMAIN }}" >> /tmp/.env
           # TuneChat — values come from the step env: above (safe shell
-          # expansion of pre-declared env vars, not inline ${{...}}).
+          # expansion of pre-declared env vars, not inline expressions).
           echo "OHSHEET_TUNECHAT_ENABLED=${OHSHEET_TUNECHAT_ENABLED}" >> /tmp/.env
           echo "OHSHEET_TUNECHAT_URL=${OHSHEET_TUNECHAT_URL}" >> /tmp/.env
           echo "OHSHEET_TUNECHAT_API_KEY=${OHSHEET_TUNECHAT_API_KEY}" >> /tmp/.env


### PR DESCRIPTION
## Summary
- GitHub Actions expression parser doesn't skip YAML comments — the literal `${{...}}` in two comments added by #70 was parsed as an invalid expression, causing the deploy workflow to fail with `Unexpected symbol: ...`
- Replaced `${{...}}` with the word "expressions" in both comments

## Validation
- `gh workflow run deploy.yml --ref fix/deploy-yaml-comment-expressions` succeeded (no parse error): https://github.com/Oh-Sheet-Team/oh-sheet/actions/runs/24546279839

🤖 Generated with [Claude Code](https://claude.com/claude-code)