### PR TITLE
fix(deploy): tighten docker prune to until=1h to stop qa VM disk pressure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,14 +119,22 @@ jobs:
           # pre-pull prune, stale tagged images from prior deploys
           # accumulate and fill /var/lib/containerd, causing `compose
           # pull` to abort with "no space left on device" — see run
-          # 24407031842 / job 71295904329. `-a` also removes unused
-          # *tagged* images (plain `-f` only touches dangling ones); the
-          # `until=24h` filter keeps the currently-running image safe
-          # from reclamation. The post-pull prune then reclaims the
-          # just-superseded previous deploy, capped at `until=1h` so a
-          # quick rollback within the hour still has layers to pull.
+          # 24407031842 / job 71295904329, and again on run 24547994092
+          # after two back-to-back deploys exceeded the old 24h window.
+          #
+          # `-a` also removes unused *tagged* images (plain `-f` only
+          # touches dangling ones); the `until=1h` filter keeps the
+          # currently-running image safe from reclamation while still
+          # freeing anything from the previous hour's deploy churn.
+          #
+          # Rollback tradeoff: with a 1h pre-pull window, rolling back
+          # to a deploy >1h old requires re-pulling from Artifact
+          # Registry (not a re-tag of a local image). Acceptable for qa
+          # where deploy velocity > rollback-without-rebuild grace. If
+          # this workflow ever targets a production VM with stricter
+          # rollback needs, bump this back up (or branch on env name).
           $SSH "cd ~/oh-sheet && \
-                sudo docker image prune -af --filter 'until=24h' && \
+                sudo docker image prune -af --filter 'until=1h' && \
                 sudo docker builder prune -af && \
                 sudo docker compose pull && \
                 sudo docker compose up -d --remove-orphans && \


### PR DESCRIPTION
## Summary

Deploy [run 24547994092](https://github.com/Oh-Sheet-Team/oh-sheet/actions/runs/24547994092) (the first run after PR #71's YAML fix) failed mid-pull with:

```
failed to copy: failed to send write:
write /var/lib/containerd/…: no space left on device
```

The app image is now ~2.3GB per layer (torch + transformers from `[pop2piano]`). The current pre-pull step uses `docker image prune -af --filter 'until=24h'` which only reclaims images older than 24 hours — meaning two back-to-back deploys within a day (which is exactly what happened with PR #70 + PR #71) each pull fresh images without freeing in-between layers. Disk fills, containerd aborts.

## Change

Pre-pull prune filter: `until=24h` → `until=1h`, matching the existing post-pull filter. Also updated the block comment to capture the decision reasoning + the two incident run IDs that motivated it.

## Tradeoff

- **Saved**: The `"no space left on device"` failure class for any deploy >1h after the previous one.
- **Lost**: Same-deploy-day rollback without re-pulling from Artifact Registry. Rolling back to a >1h-old image now requires `docker compose pull` to fetch it fresh (not just re-tag a local layer).

For qa, deploy velocity outweighs rollback-without-rebuild grace. If this workflow later targets a production VM with stricter rollback guarantees, the filter can be bumped back up — or branched on `github.ref_name` to give qa and prod different windows.

## Test plan

- [ ] Merge → triggers `Deploy to VM` on qa — expect success this time
- [ ] SSH into qa VM and `df -h /var/lib/containerd` before/after next deploy to confirm disk reclamation is actually happening
- [ ] Verify TuneChat iframe renders on `oh-sheet-qa.duckdns.org` results page (the whole point of the preceding PR chain)

## Related

- Unblocks PR #70's TuneChat plumbing (already merged but not effectively deployed)
- Complements PR #71's YAML validation fix (also already merged)
- One manual `docker system prune` on the VM may be needed BEFORE merging this to give the next deploy enough headroom to complete the initial pull — after that, this filter keeps it clean automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)