### PR TITLE
fix(ci): free disk space on runner before Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /usr/local/graalvm /usr/local/julia* \
+            /usr/share/swift /opt/hostedtoolcache/CodeQL
+          sudo docker system prune -af
+          df -h /
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Summary

- Adds a **Free disk space** step to the deploy workflow, right after checkout and before any Docker operations.
- Removes preinstalled toolchains that the build doesn't need (~25 GB reclaimed): .NET SDK, Android SDK, GraalVM, Julia, Swift, CodeQL.
- Runs `docker system prune -af` to clear stale layers on the runner.
- Prints `df -h /` so we can see available space in the build log.

## Root cause

The app Docker image is 2.3 GB+ (torch and ML deps). Building 3 images (app, decomposer, assembler) on a single `ubuntu-latest` runner exhausts the ~14 GB default free disk, causing containerd to fail with `no space left on device` during layer writes.

Failed run: https://github.com/Oh-Sheet-Team/oh-sheet/actions/runs/24547994092

## Test plan

- [ ] Merge and verify the next qa deploy succeeds
- [ ] Check the `df -h /` output in the "Free disk space" step shows ~30+ GB available

🤖 Generated with [Claude Code](https://claude.com/claude-code)