### PR TITLE
fix(ci): aggressive VM disk cleanup before docker pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,24 +121,18 @@ jobs:
           $SCP /tmp/.env "${VM_USER}@${VM_HOST}:~/oh-sheet/.env.tmp"
           $SSH "mv ~/oh-sheet/.env.tmp ~/oh-sheet/.env && mv ~/oh-sheet/docker-compose.prod.yml ~/oh-sheet/docker-compose.yml"
 
-          # Reclaim disk BEFORE pulling the new image. The app image ships
-          # heavy ML deps (torch/transformers via the [pop2piano] extra),
-          # so a single layer can exceed 1.6 GB. Without an aggressive
-          # pre-pull prune, stale tagged images from prior deploys
-          # accumulate and fill /var/lib/containerd, causing `compose
-          # pull` to abort with "no space left on device" — see run
-          # 24407031842 / job 71295904329. `-a` also removes unused
-          # *tagged* images (plain `-f` only touches dangling ones); the
-          # `until=24h` filter keeps the currently-running image safe
-          # from reclamation. The post-pull prune then reclaims the
-          # just-superseded previous deploy, capped at `until=1h` so a
-          # quick rollback within the hour still has layers to pull.
+          # Aggressively reclaim VM disk BEFORE pulling new images.
+          # The app image ships heavy ML deps (torch via [pop2piano])
+          # with a single layer exceeding 1.6 GB. `docker system prune
+          # -af` removes all unused images, build cache, and stopped
+          # containers — images backing running containers are safe.
+          # After pull + restart the old images become unused and the
+          # post-pull prune catches them immediately.
           $SSH "cd ~/oh-sheet && \
-                sudo docker image prune -af --filter 'until=24h' && \
-                sudo docker builder prune -af && \
+                sudo docker system prune -af && \
                 sudo docker compose pull && \
                 sudo docker compose up -d --remove-orphans && \
-                sudo docker image prune -af --filter 'until=1h'"
+                sudo docker system prune -af"
 
       - name: Verify deployment
         env:


### PR DESCRIPTION
## Summary

PR #74 fixed the runner-side disk exhaustion (build+push now succeeds), but the **VM** ran out of disk during `docker compose pull` — the `until=24h` filter on `docker image prune` was too conservative and let recent deploy images accumulate.

**Change:** replace `docker image prune -af --filter 'until=24h'` + `docker builder prune -af` with `docker system prune -af` (both pre-pull and post-pull). This removes all unused images, build cache, stopped containers, and dangling volumes. Images backing running containers are safe from prune.

Failed run: https://github.com/Oh-Sheet-Team/oh-sheet/actions/runs/24570921209

## Test plan

- [ ] Merge and verify the next qa deploy succeeds end-to-end (both build and VM pull)