### PR TITLE
feat(engrave): integrate ML inference API for MusicXML generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,7 @@ jobs:
           OHSHEET_TUNECHAT_ENABLED: ${{ vars.OHSHEET_TUNECHAT_ENABLED }}
           OHSHEET_TUNECHAT_URL: ${{ vars.OHSHEET_TUNECHAT_URL }}
           OHSHEET_TUNECHAT_API_KEY: ${{ secrets.OHSHEET_TUNECHAT_API_KEY }}
+          OHSHEET_ML_API_URL: ${{ vars.OHSHEET_ML_API_URL }}
         run: |
           # Set up SSH
           mkdir -p ~/.ssh
@@ -115,6 +116,7 @@ jobs:
           echo "OHSHEET_TUNECHAT_ENABLED=${OHSHEET_TUNECHAT_ENABLED}" >> /tmp/.env
           echo "OHSHEET_TUNECHAT_URL=${OHSHEET_TUNECHAT_URL}" >> /tmp/.env
           echo "OHSHEET_TUNECHAT_API_KEY=${OHSHEET_TUNECHAT_API_KEY}" >> /tmp/.env
+          echo "OHSHEET_ML_API_URL=${OHSHEET_ML_API_URL}" >> /tmp/.env
 
           # Copy compose files to VM (SCP .env to temp name, then atomic mv)
           $SCP docker-compose.prod.yml Caddyfile "${VM_USER}@${VM_HOST}:~/oh-sheet/"

--- a/backend/config.py
+++ b/backend/config.py
@@ -38,6 +38,13 @@ class Settings(BaseSettings):
     # not appear when you run the API server.
     log_level: str = "INFO"
 
+    # ---- ML inference API (engraver replacement) ----------------------------
+    # When set, the engrave stage POSTs the rendered MIDI to this URL's
+    # /transcribe endpoint and uses the returned MusicXML instead of the
+    # local music21 render. Falls back to music21 on error.
+    ml_api_url: str | None = None
+    ml_api_timeout_sec: int = 60
+
     # ---- Basic Pitch transcription -----------------------------------------
     # Tunable knobs passed through to basic_pitch.inference.predict(). Defaults
     # mirror upstream (basic_pitch.constants.DEFAULT_*). The ONNX model ships

--- a/backend/services/engrave.py
+++ b/backend/services/engrave.py
@@ -801,6 +801,41 @@ def _render_pdf_bytes(musicxml_bytes: bytes) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# ML API integration
+# ---------------------------------------------------------------------------
+
+def _transcribe_via_ml_api(midi_bytes: bytes) -> bytes | None:
+    """POST MIDI to the ML inference API, return MusicXML or None on failure."""
+    from backend.config import settings  # noqa: PLC0415
+
+    if not settings.ml_api_url:
+        return None
+    if midi_bytes == _STUB_MIDI:
+        return None
+
+    import httpx  # noqa: PLC0415
+
+    url = f"{settings.ml_api_url.rstrip('/')}/transcribe"
+    try:
+        resp = httpx.post(
+            url,
+            content=midi_bytes,
+            headers={"Content-Type": "application/octet-stream"},
+            timeout=settings.ml_api_timeout_sec,
+        )
+        resp.raise_for_status()
+        body = resp.content
+        if body and b"score-partwise" in body:
+            log.info("engrave: ML API returned %d bytes of MusicXML", len(body))
+            return body
+        log.warning("engrave: ML API response missing score-partwise — falling back to local")
+        return None
+    except Exception as exc:  # noqa: BLE001
+        log.warning("engrave: ML API call failed (%s) — falling back to local render", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Service
 # ---------------------------------------------------------------------------
 
@@ -851,9 +886,14 @@ def _engrave_sync(
         )
 
     midi_bytes = _render_midi_bytes(perf)
-    musicxml_bytes, chord_symbols_rendered = _render_musicxml_bytes(
-        score, perf, title, composer,
-    )
+    ml_musicxml = _transcribe_via_ml_api(midi_bytes)
+    if ml_musicxml is not None:
+        musicxml_bytes = ml_musicxml
+        chord_symbols_rendered = 0
+    else:
+        musicxml_bytes, chord_symbols_rendered = _render_musicxml_bytes(
+            score, perf, title, composer,
+        )
     pdf_bytes = _render_pdf_bytes(musicxml_bytes)
     return pdf_bytes, musicxml_bytes, midi_bytes, chord_symbols_rendered
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -146,6 +146,7 @@ services:
     environment:
       OHSHEET_BLOB_ROOT: /app/blob
       OHSHEET_REDIS_URL: redis://redis:6379/0
+      OHSHEET_ML_API_URL: ${OHSHEET_ML_API_URL:-}
     volumes:
       - blob-data:/app/blob
     depends_on:


### PR DESCRIPTION
## Summary

Wires the oh-sheet engraver stage to call the ML inference API (oh-sheet-ml-api on Cloud Run) for MusicXML generation, with automatic fallback to the existing music21 render on any error.

### Changes

- backend/config.py: new ml_api_url and ml_api_timeout_sec settings (OHSHEET_ML_API_URL, OHSHEET_ML_API_TIMEOUT_SEC)
- backend/services/engrave.py: _transcribe_via_ml_api() POSTs the rendered MIDI to {ml_api_url}/transcribe, validates the response contains score-partwise, falls back to local music21 on any failure
- docker-compose.prod.yml: passes OHSHEET_ML_API_URL to the engrave worker
- deploy.yml: threads OHSHEET_ML_API_URL from GitHub environment vars through to the VM .env

### ML API deployment

The API is live at https://oh-sheet-ml-api-362092173569.us-central1.run.app (Cloud Run, stub runner). The OHSHEET_ML_API_URL environment variable has been set on the qa GitHub environment.

### Behavior

- OHSHEET_ML_API_URL unset: existing music21 path, no change
- OHSHEET_ML_API_URL set: POSTs MIDI, gets MusicXML back; falls back to music21 on any error

## Test plan

- [x] ML API /health returns 200
- [x] ML API /transcribe returns valid MusicXML for sample MIDI
- [x] _transcribe_via_ml_api returns None when ml_api_url is unset (no-op)
- [x] _transcribe_via_ml_api returns MusicXML bytes when URL is set
- [ ] QA deploy succeeds with the env var wired through
- [ ] End-to-end: upload audio on QA -> engrave stage uses ML API -> MusicXML in output
