### PR TITLE
feat(cover-search): add @pbossonn to PIANO_MODERATE_CHANNELS

### DIFF
--- a/backend/services/cover_search.py
+++ b/backend/services/cover_search.py
@@ -145,6 +145,7 @@ PIANO_MODERATE_CHANNELS: tuple[str, ...] = (
     "matty on the keys",
     "flying fingers",
     "piano covers - topic",
+    "pbossonn",             # @pbossonn — added by product owner request
 )
 
 # Tier 3 — virtuoso / concert-level arrangements. Defined here for


### PR DESCRIPTION
## Summary

Adds \`pbossonn\` to \`PIANO_MODERATE_CHANNELS\` in \`backend/services/cover_search.py\` so @pbossonn's covers receive the +50 channel-allowlist bonus during cover search scoring.

Entry follows the existing convention: lowercase, no \`@\` prefix, matched as a substring of yt-dlp's \`channel\` field.

## Tier choice

Placed in the **moderate** tier as a reasonable default. If post-merge audits show this channel is consistently beginner-easy or virtuoso-advanced, moving it one tier up or down is a one-line diff:

- \`PIANO_EASY_CHANNELS\` (tier 1) — gets an extra +10 easy-tier bonus
- \`PIANO_MODERATE_CHANNELS\` (tier 2) — current placement
- \`PIANO_ADVANCED_CHANNELS\` (tier 3) — for concert-level arrangements

All three tiers are currently part of the active \`COVER_CHANNEL_ALLOWLIST\` so the immediate effect (channel bonus in scoring) is the same regardless of tier.

## Test plan

- [ ] Existing cover_search tests pass (no logic change, only list addition)
- [ ] Live query with any @pbossonn-covered song shows the \`(+50 from allowlist)\` score component in \`dryrun_cover_search.py\` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)