### PR TITLE
fix(frontend-v2): WS lifecycle + drop dead title source + TUNECHAT_TIMEOUT plumbing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,11 @@ jobs:
           OHSHEET_TUNECHAT_ENABLED: ${{ vars.OHSHEET_TUNECHAT_ENABLED }}
           OHSHEET_TUNECHAT_URL: ${{ vars.OHSHEET_TUNECHAT_URL }}
           OHSHEET_TUNECHAT_API_KEY: ${{ secrets.OHSHEET_TUNECHAT_API_KEY }}
+          # Long YouTube tracks (up to ~20 min) need a client timeout
+          # higher than the default 300 s — TuneChat can take 6-10 min
+          # to transcribe a 10-min audio file. 900 s is recommended for
+          # qa / prod. Unset falls back to 300 s (backend/config.py).
+          OHSHEET_TUNECHAT_TIMEOUT_SEC: ${{ vars.OHSHEET_TUNECHAT_TIMEOUT_SEC }}
           # Anthropic API — used by worker-refine for LLM metadata enrichment.
           OHSHEET_ANTHROPIC_API_KEY: ${{ secrets.OHSHEET_ANTHROPIC_API_KEY }}
           # Base URL of oh-sheet-ml-pipeline engraver service. The engrave
@@ -151,6 +156,7 @@ jobs:
           echo "OHSHEET_TUNECHAT_ENABLED=${OHSHEET_TUNECHAT_ENABLED}" >> /tmp/.env
           echo "OHSHEET_TUNECHAT_URL=${OHSHEET_TUNECHAT_URL}" >> /tmp/.env
           echo "OHSHEET_TUNECHAT_API_KEY=${OHSHEET_TUNECHAT_API_KEY}" >> /tmp/.env
+          echo "OHSHEET_TUNECHAT_TIMEOUT_SEC=${OHSHEET_TUNECHAT_TIMEOUT_SEC}" >> /tmp/.env
           # Anthropic — worker-refine LLM metadata enrichment.
           echo "OHSHEET_ANTHROPIC_API_KEY=${OHSHEET_ANTHROPIC_API_KEY}" >> /tmp/.env
           echo "OHSHEET_ENGRAVER_SERVICE_URL=${OHSHEET_ENGRAVER_SERVICE_URL}" >> /tmp/.env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,6 +43,11 @@ services:
       OHSHEET_TUNECHAT_ENABLED: ${OHSHEET_TUNECHAT_ENABLED:-false}
       OHSHEET_TUNECHAT_URL: ${OHSHEET_TUNECHAT_URL:-}
       OHSHEET_TUNECHAT_API_KEY: ${OHSHEET_TUNECHAT_API_KEY:-}
+      # Client-side timeout for the httpx POST to TuneChat. 300 s default
+      # is short for 10+ min tracks — tuned higher on qa/prod via the
+      # deploy.yml → .env pipeline. Default falls through to
+      # backend/config.py's 300 s if the env var is unset.
+      OHSHEET_TUNECHAT_TIMEOUT_SEC: ${OHSHEET_TUNECHAT_TIMEOUT_SEC:-300}
       # Engraver service URL — backend.jobs.runner (living in this container)
       # always routes audio/midi engrave jobs to this URL. No local fallback.
       # REQUIRED: ``${VAR:?msg}`` makes docker compose refuse to start when
@@ -86,6 +91,11 @@ services:
       OHSHEET_TUNECHAT_ENABLED: ${OHSHEET_TUNECHAT_ENABLED:-false}
       OHSHEET_TUNECHAT_URL: ${OHSHEET_TUNECHAT_URL:-}
       OHSHEET_TUNECHAT_API_KEY: ${OHSHEET_TUNECHAT_API_KEY:-}
+      # Client-side timeout for the httpx POST to TuneChat. 300 s default
+      # is short for 10+ min tracks — tuned higher on qa/prod via the
+      # deploy.yml → .env pipeline. Default falls through to
+      # backend/config.py's 300 s if the env var is unset.
+      OHSHEET_TUNECHAT_TIMEOUT_SEC: ${OHSHEET_TUNECHAT_TIMEOUT_SEC:-300}
       # YouTube bot-detection bypass — worker-ingest is where the actual
       # yt-dlp download happens (services/ingest.py::_download_youtube_sync).
       # Same bind-mount as orchestrator for cover_search probes that also

--- a/frontend-v2/src/api.js
+++ b/frontend-v2/src/api.js
@@ -75,17 +75,80 @@ function buildWsUrl(path) {
   return path;
 }
 
+/**
+ * Subscribe to a job's event stream over WebSocket.
+ *
+ * The caller's `onEvent` receives each parsed event frame as-is. When
+ * the socket drops before a terminal event (job_succeeded / job_failed)
+ * has been seen, we synthesize a local `job_failed`-shaped event with
+ * a retryable error message so the UI can land in a recoverable state
+ * instead of spinning forever on the last "working:..." phase.
+ *
+ * Terminal events seen during normal flow (job_succeeded/failed) flip
+ * the `sawTerminal` flag so the same close/error handlers become a
+ * no-op — we only synthesize when the socket actually dropped early.
+ *
+ * @param {string} jobId
+ * @param {(event: object) => void} onEvent
+ * @returns {() => void} unsubscribe function (closes the socket; safe
+ *   to call multiple times; once called, subsequent close events are
+ *   treated as intentional and no synthesized error fires)
+ */
 export function subscribeToJob(jobId, onEvent) {
   const ws = new WebSocket(buildWsUrl(`/v1/jobs/${jobId}/ws`));
+  let sawTerminal = false;
+  let unsubscribed = false;
+
   ws.onmessage = (ev) => {
     try {
       const parsed = JSON.parse(ev.data);
+      if (parsed && (parsed.type === "job_succeeded" || parsed.type === "job_failed")) {
+        sawTerminal = true;
+      }
       onEvent(parsed);
     } catch {
       // Ignore malformed frames — server should never send non-JSON.
     }
   };
+
+  // Fires once per socket; both onclose and onerror can lead here
+  // (Chrome fires onerror THEN onclose on network drops; Firefox often
+  // just onclose with code 1006). De-duplicated via the `closed` flag.
+  let closed = false;
+  const handleEarlyClose = (message) => {
+    if (closed) return;
+    closed = true;
+    if (unsubscribed || sawTerminal) return;
+    try {
+      onEvent({
+        job_id: jobId,
+        type: "job_failed",
+        stage: null,
+        message,
+        progress: null,
+        data: { synthesized: true, reason: "ws_early_close" },
+      });
+    } catch {
+      // swallow — subscriber failure shouldn't crash the WS cleanup
+    }
+  };
+
+  ws.onclose = (ev) => {
+    // A graceful close (1000) after a terminal event is normal cleanup.
+    // Anything else (1006 abnormal, server-initiated close mid-job,
+    // proxy timeout) should surface as a retryable error to the user.
+    handleEarlyClose(
+      ev && ev.code === 1000
+        ? "Connection closed"
+        : "Connection lost — try again",
+    );
+  };
+  ws.onerror = () => {
+    handleEarlyClose("Connection error — try again");
+  };
+
   return () => {
+    unsubscribed = true;
     try {
       ws.close();
     } catch {

--- a/frontend-v2/src/api.test.js
+++ b/frontend-v2/src/api.test.js
@@ -235,4 +235,60 @@ describe("subscribeToJob", () => {
     unsub();
     expect(ws.closed).toBe(true);
   });
+
+  it("synthesizes a retryable job_failed when the socket drops before terminal", () => {
+    // If the WS closes with an abnormal code (1006 network drop, or
+    // anything non-1000) before we've seen job_succeeded/job_failed,
+    // the UI would otherwise spin forever on the last "working:..."
+    // phase. The subscriber must surface a job_failed so the state
+    // machine can transition to an error/retryable phase.
+    const onEvent = vi.fn();
+    subscribeToJob("j1", onEvent);
+    const ws = instances[0];
+    ws.onclose({ code: 1006 });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    const evt = onEvent.mock.calls[0][0];
+    expect(evt.type).toBe("job_failed");
+    expect(evt.job_id).toBe("j1");
+    expect(evt.message).toMatch(/connection lost|try again/i);
+    expect(evt.data.synthesized).toBe(true);
+  });
+
+  it("does NOT synthesize job_failed after a real job_succeeded event", () => {
+    // Terminal event received → subsequent close is normal cleanup,
+    // not a failure. Synthesizing here would double-emit and confuse
+    // the reducer (the real job_succeeded already transitioned the UI
+    // to Complete).
+    const onEvent = vi.fn();
+    subscribeToJob("j1", onEvent);
+    const ws = instances[0];
+    ws._fireMessage({ job_id: "j1", type: "job_succeeded", data: {} });
+    onEvent.mockClear();
+    ws.onclose({ code: 1000 });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT synthesize job_failed after unsubscribe (user-initiated close)", () => {
+    // The unsubscribe fn calls ws.close(), which in the mock fires
+    // onclose. That must not synthesize an error — the user asked to
+    // stop listening, they don't want a spurious "Connection lost".
+    const onEvent = vi.fn();
+    const unsub = subscribeToJob("j1", onEvent);
+    unsub();
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("synthesizes job_failed on WS error event too (not just close)", () => {
+    // Firefox often fires only onclose with code 1006; Chrome fires
+    // onerror THEN onclose. Both paths must land in the same error
+    // state, and the dedupe (closed flag) must prevent double-emit.
+    const onEvent = vi.fn();
+    subscribeToJob("j1", onEvent);
+    const ws = instances[0];
+    ws.onerror(new Event("error"));
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    // Follow-up onclose after onerror must NOT emit a second event.
+    ws.onclose({ code: 1006 });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend-v2/src/main.js
+++ b/frontend-v2/src/main.js
@@ -70,6 +70,12 @@ store.onChange((phase) => {
 // ── Handlers bridge views → api ─────────────────────────────────
 const handlers = {
   onSourceChange(source) {
+    // If the user tabs between sources while a job is in flight, the
+    // old WS would otherwise keep delivering events after we've
+    // already transitioned back to idle — and a late job_succeeded
+    // would clobber the fresh idle state with a stale Complete phase.
+    // Close the socket first so the subscriber is a no-op.
+    if (unsubscribeWs) { unsubscribeWs(); unsubscribeWs = null; }
     store.setPhase({ name: "idle", source });
   },
 
@@ -91,8 +97,6 @@ const handlers = {
       } else if (formData.source === "midi") {
         const ref = await api.uploadMidi(formData.file);
         jobPayload = { midi: ref, title: formData.title, artist: formData.artist };
-      } else if (formData.source === "title") {
-        jobPayload = { title: formData.title, artist: formData.artist };
       } else if (formData.source === "youtube") {
         jobPayload = {
           title: formData.url,

--- a/frontend-v2/src/views.js
+++ b/frontend-v2/src/views.js
@@ -219,15 +219,10 @@ function idleBody(source, handlers) {
     artistInput = a.input;
     wrap.appendChild(t.wrap);
     wrap.appendChild(a.wrap);
-  } else if (source === "title") {
-    const t = field("Song title", "search");
-    const a = field("Artist (optional)");
-    titleInput = t.input;
-    artistInput = a.input;
-    wrap.appendChild(t.wrap);
-    wrap.appendChild(a.wrap);
   } else {
-    // youtube
+    // youtube (default — also the fallback for any unknown source
+    // value, since the segmented picker only exposes audio/midi/
+    // youtube after PR #83's UI simplification)
     const u = field("YouTube URL", "play_circle");
     const a = field("Artist (optional)");
     urlInput = u.input;
@@ -279,12 +274,8 @@ function idleBody(source, handlers) {
       payload.file = file;
       if (titleInput && titleInput.value) payload.title = titleInput.value;
       if (artistInput && artistInput.value) payload.artist = artistInput.value;
-    } else if (source === "title") {
-      const title = titleInput && titleInput.value.trim();
-      if (!title) return;
-      payload.title = title;
-      if (artistInput && artistInput.value) payload.artist = artistInput.value;
     } else {
+      // youtube (and fallback for any unknown source)
       const url = urlInput && urlInput.value.trim();
       if (!url) return;
       // Client-side guard: non-video YouTube URLs (search pages,


### PR DESCRIPTION
## Summary

Two commits from this morning's PR #83 code review + a demo-day blocker.

### Commit 1: \`fix(frontend-v2): WS lifecycle + drop dead title source branches\`

Addresses three 🟡 issues from the PR #83 review:

1. **Dead code: \"title\" source removed.** The segmented picker only exposes audio/midi/youtube after #83, so the \`source === \"title\"\` branches in views.js (idleBody + submit) and main.js (onSubmit) were unreachable. The title FIELD as an optional input on audio/midi uploads is preserved — only title-as-source-type is gone.

2. **WS subscribeToJob now handles onclose + onerror.** api.js synthesizes a retryable \`{type: \"job_failed\"}\` event when the socket drops before a terminal event. Without this, a network blip / proxy timeout / backend restart left the UI stuck in the last \"working:...\" phase forever. Dedupe via a \`closed\` flag so Chrome's onerror-then-onclose sequence doesn't double-emit; Firefox's onclose-only path also works. Unsubscribe + terminal events mark the flow as intentional so no spurious error fires during normal cleanup.

3. **onSourceChange now closes the in-flight WS.** main.js' onSourceChange reset the phase to idle but left the old unsubscribeWs alive — a late job_succeeded from the previous job would clobber the fresh idle state with a stale Complete phase.

### Commit 2: \`feat(deploy): plumb OHSHEET_TUNECHAT_TIMEOUT_SEC through to containers\`

Demo-day blocker surfaced this morning while testing long tracks locally:

- TuneChat takes 6–10 min to transcribe a 10-min audio file
- oh-sheet's httpx client timeout defaults to **300 s (5 min)**
- Past 5 min, the client gives up, runner.py falls through to local engrave, which hard-fails for \`title_lookup\` jobs (PR #79's \"no fallback engraver\")
- User-facing error: \"title_lookup job reached the engrave stage without a TuneChat result\" — looks like TuneChat is broken, but it's actually a 5-min client impatience

Plumbs \`OHSHEET_TUNECHAT_TIMEOUT_SEC\` through three layers:

1. **GitHub env-scoped variable** — set to \`900\` on qa environment (done via \`gh variable set\` out-of-band)
2. **\`.github/workflows/deploy.yml\`** — reads the var, writes to the VM's \`.env\`
3. **\`docker-compose.prod.yml\`** — both orchestrator + worker-ingest read from the host \`.env\` with a 300 s fallback

Fallback to 300 s in compose means the plumbing is **safe to deploy without the variable set** — behaviour matches today's default. Once set, the deploy propagates the higher timeout.

### Verified locally

- 10-min WAV (111 MB, 48kHz stereo) uploaded through TuneChat (Multer cap also raised — separate TuneChat-repo change), transcribed in 6m13s, job reports \`succeeded\` with \`tunechat_job_id\` populated
- 65/65 frontend-v2 tests passing (+4 new WS lifecycle cases)

## Test plan

- [x] \`cd frontend-v2 && npm test\` — 65/65 passing
- [x] Local e2e with a 10-min track → TuneChat fast-path succeeds end-to-end (was timing out at 300s before this PR)
- [ ] Post-merge: qa deploys, smoke-test a long-track URL → expect \`job_succeeded\` with \`tunechat_job_id\` inside 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)