### PR TITLE
fix(frontend-v2): drop late WS frames after unsubscribe

### DIFF
--- a/frontend-v2/src/api.js
+++ b/frontend-v2/src/api.js
@@ -100,6 +100,12 @@ export function subscribeToJob(jobId, onEvent) {
   let unsubscribed = false;
 
   ws.onmessage = (ev) => {
+    // Late-frame guard: between unsubscribe() calling ws.close() and the
+    // browser actually tearing down the socket, a queued frame can still
+    // fire and overwrite a fresh idle phase via the reducer. Chromium
+    // cancels pending tasks synchronously in practice, but the WebSocket
+    // spec doesn't require it (RFC 6455 §7.1.1) — cheap to harden.
+    if (unsubscribed) return;
     try {
       const parsed = JSON.parse(ev.data);
       if (parsed && (parsed.type === "job_succeeded" || parsed.type === "job_failed")) {
@@ -120,6 +126,11 @@ export function subscribeToJob(jobId, onEvent) {
     closed = true;
     if (unsubscribed || sawTerminal) return;
     try {
+      // stage/progress are intentionally null — this event is synthesized
+      // client-side, not emitted by the pipeline. The reducer (state.js)
+      // only reads `message`, so null fields are harmless today; the
+      // `data.synthesized` flag is the signal for any future consumer
+      // that wants to distinguish a real failure from a WS drop.
       onEvent({
         job_id: jobId,
         type: "job_failed",

--- a/frontend-v2/src/api.test.js
+++ b/frontend-v2/src/api.test.js
@@ -278,6 +278,22 @@ describe("subscribeToJob", () => {
     expect(onEvent).not.toHaveBeenCalled();
   });
 
+  it("drops late frames that arrive after unsubscribe", () => {
+    // Between unsubscribe() calling ws.close() and the browser tearing
+    // down the socket, a queued frame can still fire onmessage. That
+    // frame must not reach the subscriber — otherwise a stale late
+    // job event could clobber the fresh phase the caller just set
+    // (e.g. on source-tab switch, where main.js unsubscribes and then
+    // resets to idle).
+    const onEvent = vi.fn();
+    const unsub = subscribeToJob("j1", onEvent);
+    const ws = instances[0];
+    unsub();
+    onEvent.mockClear(); // ignore any close-path side effects
+    ws._fireMessage({ job_id: "j1", type: "stage_progress", stage: "ingest", progress: 0.5 });
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
   it("synthesizes job_failed on WS error event too (not just close)", () => {
     // Firefox often fires only onclose with code 1006; Chrome fires
     // onerror THEN onclose. Both paths must land in the same error


### PR DESCRIPTION
## Summary
- Guards \`ws.onmessage\` on the existing \`unsubscribed\` flag so late frames queued between \`ws.close()\` and browser teardown can't clobber a freshly-set phase.
- Adds a comment on the synthesized \`job_failed\` event's null \`stage\`/\`progress\` fields so future reducer changes don't silently deref them.

## Follow-up to
PR #85 review — the reviewer flagged the late-message window as a minor hardening nit. This lands it.

## Test plan
- [x] \`npm test\` — 66/66 passing (new test: unsubscribe → fire message → assert no dispatch)
- [ ] Manual: switch source tabs mid-job on qa, confirm idle stays idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)