### PR TITLE
chore: refresh stale Flutter refs + document TuneChat env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,16 @@ OHSHEET_ANTHROPIC_API_KEY=
 # OHSHEET_REFINE_BUDGET_SEC=300
 # OHSHEET_REFINE_CALL_TIMEOUT_SEC=120
 
+# --- TuneChat integration (ingest → transcribe via external service) ---
+# OHSHEET_TUNECHAT_ENABLED=false
+# OHSHEET_TUNECHAT_URL=https://tunechat.fly.dev
+# OHSHEET_TUNECHAT_API_KEY=
+# httpx client timeout (seconds) for the orchestrator → TuneChat POST.
+# Default 300 is fine for short tracks; raise to 900 for long-track
+# transcription (10-min audio takes 6-10 min on TuneChat). Deploy sets
+# this via the env-scoped GitHub variable of the same name.
+# OHSHEET_TUNECHAT_TIMEOUT_SEC=300
+
 # --- Core infra ---
 # OHSHEET_REDIS_URL=redis://localhost:6379/0
 # OHSHEET_BLOB_ROOT=./blob

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,8 @@ from backend.api.routes import artifacts, health, jobs, stages, uploads, ws
 from backend.config import settings
 from backend.contracts import SCHEMA_VERSION
 
-# Flutter web build output — present in the Docker image at /app/static.
+# frontend-v2 (vanilla-JS + Vite) build output — present in the Docker
+# image at /app/static (see Dockerfile stage `frontend-build`).
 _STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
 
 


### PR DESCRIPTION
## Summary
- \`backend/main.py\`: \`_STATIC_DIR\` comment updated from "Flutter web build output" to point at the Vite / frontend-v2 build stage. Correctness only — no behavior change.
- \`.env.example\`: documents \`OHSHEET_TUNECHAT_{ENABLED,URL,API_KEY}\` + \`TIMEOUT_SEC\` knob added in PR #85.

## Follow-up to
PR #86 review (stale comment) + PR #85 review (operational docs).

Makefile + CLAUDE.md still reference Flutter — those are dev-facing only and get their own tracking issues post-demo.

## Test plan
- [x] Comment-only diff + env doc, no runtime impact
- [ ] Local \`git grep -n "Flutter"\` now returns only dev-facing files (Makefile, CLAUDE.md, \`frontend/\` tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)