### PR TITLE
feat(frontend-v2): widen results card + fullscreen button on TuneChat iframe

### DIFF
--- a/frontend-v2/src/style.css
+++ b/frontend-v2/src/style.css
@@ -223,11 +223,49 @@ body[data-phase="submitting"] .tagline { display: none; }
   height: min(70vh, 720px); background: var(--surface);
   border: 2px solid var(--stroke); border-radius: 20px;
   margin-bottom: 16px; overflow: hidden;
+  /* position:relative anchors the fullscreen overlay button. */
+  position: relative;
 }
 .iframe-stub iframe {
   width: 100%; height: 100%; border: 0; display: block;
 }
 .iframe-stub.tunechat { height: min(80vh, 760px); }
+
+/* Fullscreen overlay button — top-right corner of the iframe wrap,
+   matching YouTube / Vimeo / Figma convention. Hover-reveals on
+   desktop so the chrome stays minimal; always visible on touch. */
+.fullscreen-btn {
+  position: absolute;
+  top: 12px; right: 12px;
+  width: 36px; height: 36px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity .15s ease, background .15s ease;
+  z-index: 2;
+}
+.fullscreen-btn .material-symbols-rounded { font-size: 20px; color: #fff; }
+.iframe-stub:hover .fullscreen-btn,
+.fullscreen-btn:focus-visible { opacity: 1; }
+.fullscreen-btn:hover { background: rgba(0, 0, 0, 0.75); }
+/* When the iframe itself is fullscreen, the button rides along in
+   the top-right of the fullscreen viewport. */
+.iframe-stub iframe:fullscreen { background: var(--surface); }
+
+/* Desktop results page — let the card breathe so OSMD can lay staves
+   out at a readable width. Typical "reading width" territory; the card
+   still caps at 90vw so there's visual margin on ultrawides. */
+body[data-phase="complete"] .card {
+  width: min(1200px, 90vw);
+  padding: 16px;
+}
+body[data-phase="complete"] .iframe-stub.tunechat {
+  height: min(85vh, 900px);
+}
 .inline-render {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   color: var(--on-surface-variant); gap: 8px;
@@ -364,4 +402,7 @@ body[data-phase="submitting"] .tagline { display: none; }
 /* Touch targets — ensure 44×44 on any touch device */
 @media (hover: none) {
   .btn-outlined, .btn-filled, .btn-text, .seg, .assist-chip { min-height: 44px; }
+  /* Hover-reveal doesn't work on touch — always show the fullscreen
+     overlay on phones/tablets, and upsize it to hit the 44×44 target. */
+  .fullscreen-btn { opacity: 1; width: 44px; height: 44px; }
 }

--- a/frontend-v2/src/views.js
+++ b/frontend-v2/src/views.js
@@ -419,10 +419,40 @@ function completeBody(job) {
       // allow= hints for AudioContext autoplay on first gesture inside
       // the iframe (Chrome/Firefox respect; Safari uses user-gesture heuristic)
       allow: "autoplay; clipboard-write",
+      // allowfullscreen enables the Fullscreen API path below; without
+      // it, iframe.requestFullscreen() rejects on Safari.
+      allowfullscreen: "true",
+    });
+    // Fullscreen toggle. Uses the browser Fullscreen API — Escape key
+    // handling, iOS Safari chrome hiding, and screen-reader mode
+    // announcements all come for free. The button sits as an overlay
+    // in the top-right corner of the iframe wrap (matching YouTube /
+    // Vimeo / Figma convention) so the semantic is "expand this
+    // frame", not "another action on this result".
+    const fullscreenBtn = el("button", {
+      class: "fullscreen-btn",
+      type: "button",
+      "aria-label": "Toggle fullscreen",
+      title: "Fullscreen",
+    }, icon("fullscreen"));
+    fullscreenBtn.addEventListener("click", () => {
+      // Exit if already fullscreen, otherwise enter. Swallow the
+      // returned promise — failures are surfaced by the browser as
+      // permission errors, and we don't want to pop an app-level
+      // error toast for what's essentially a UI affordance.
+      try {
+        if (document.fullscreenElement) {
+          document.exitFullscreen();
+        } else if (typeof frame.requestFullscreen === "function") {
+          frame.requestFullscreen();
+        }
+      } catch {
+        // Older browsers / sandboxed iframes — silent no-op.
+      }
     });
     // .iframe-stub.tunechat triggers the fullscreen-ish mobile CSS
     // where the iframe fills the viewport and the card sheds its padding.
-    wrap.appendChild(el("div", { class: "iframe-stub tunechat" }, frame));
+    wrap.appendChild(el("div", { class: "iframe-stub tunechat" }, frame, fullscreenBtn));
   } else {
     wrap.appendChild(
       el(

--- a/frontend-v2/src/views.test.js
+++ b/frontend-v2/src/views.test.js
@@ -244,6 +244,42 @@ describe("renderPhase — complete (with tunechat_job_id)", () => {
     expect(text).toContain("MusicXML");
     expect(text).toContain("MIDI");
   });
+
+  it("renders a fullscreen button inside the iframe wrap", () => {
+    // Overlay lives in the iframe container, not in the downloads row,
+    // so the semantic is "expand this frame" (like YouTube) not
+    // "another download action". Convention > discoverability-in-context.
+    const wrap = container.querySelector(".iframe-stub.tunechat");
+    expect(wrap).toBeTruthy();
+    const btn = wrap.querySelector(".fullscreen-btn");
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute("aria-label")).toMatch(/fullscreen/i);
+  });
+
+  it("fullscreen button calls requestFullscreen on the iframe", () => {
+    const iframe = container.querySelector("iframe");
+    const spy = vi.fn().mockResolvedValue(undefined);
+    iframe.requestFullscreen = spy;
+    // No existing fullscreen element — click should enter fullscreen.
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => null,
+    });
+    container.querySelector(".fullscreen-btn").click();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fullscreen button calls exitFullscreen when already fullscreen", () => {
+    const iframe = container.querySelector("iframe");
+    const exitSpy = vi.fn().mockResolvedValue(undefined);
+    document.exitFullscreen = exitSpy;
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => iframe,
+    });
+    container.querySelector(".fullscreen-btn").click();
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("renderPhase — complete (without tunechat_job_id)", () => {


### PR DESCRIPTION
## Summary
Two complementary fixes so the embedded TuneChat iframe on the results page renders at a readable width on desktop:

1. **Widen the card on complete** — CSS-only, hooks off the existing \`body[data-phase="complete"]\`. Card jumps from 560px to \`min(1200px, 90vw)\`; iframe height from 80vh→85vh. Reading-width territory.
2. **Fullscreen overlay button** — top-right corner of the iframe (YouTube / Vimeo / Figma convention). Uses the browser Fullscreen API (Escape-to-exit, iOS Safari chrome hiding, SR mode announcements for free). Hover-reveal on desktop, always-visible + 44×44 on touch.

## Screenshots (desktop)
Before: iframe pinned to 560px card → OSMD staves wrap at 2-3 measures/line.
After: iframe renders at ~1200px → matches the \`/embed\` URL's layout.

## Test plan
- [x] \`npm test\` — 68/68 (3 new: renders fullscreen button, enters FS on click, exits FS when already FS)
- [x] \`npm run build\` — CSS 10.73 kB (up from 10.00 kB), JS 12.04 kB
- [ ] Manual: qa job complete → card widens, iframe fills → fullscreen button hover-reveals → click → iframe goes fullscreen → Esc exits
- [ ] Manual mobile: fullscreen button always visible, 44×44 hit target

🤖 Generated with [Claude Code](https://claude.com/claude-code)