### PR TITLE
fix(frontend-v2): address PR #89 review — fullscreen wrapper + test cleanup

### DIFF
--- a/frontend-v2/src/style.css
+++ b/frontend-v2/src/style.css
@@ -223,9 +223,11 @@ body[data-phase="submitting"] .tagline { display: none; }
   height: min(70vh, 720px); background: var(--surface);
   border: 2px solid var(--stroke); border-radius: 20px;
   margin-bottom: 16px; overflow: hidden;
-  /* position:relative anchors the fullscreen overlay button. */
-  position: relative;
 }
+/* Only the iframe-stub gets position:relative — it anchors the
+   absolutely-positioned fullscreen overlay button. .inline-render
+   has no overlay children so it doesn't need a stacking context. */
+.iframe-stub { position: relative; }
 .iframe-stub iframe {
   width: 100%; height: 100%; border: 0; display: block;
 }
@@ -252,9 +254,11 @@ body[data-phase="submitting"] .tagline { display: none; }
 .iframe-stub:hover .fullscreen-btn,
 .fullscreen-btn:focus-visible { opacity: 1; }
 .fullscreen-btn:hover { background: rgba(0, 0, 0, 0.75); }
-/* When the iframe itself is fullscreen, the button rides along in
-   the top-right of the fullscreen viewport. */
-.iframe-stub iframe:fullscreen { background: var(--surface); }
+/* When the iframe-stub is fullscreen, its iframe child fills the
+   viewport and the overlay button rides along (both are inside the
+   wrapper that goes fullscreen, not the iframe alone). */
+.iframe-stub:fullscreen { background: var(--surface); }
+.iframe-stub:fullscreen iframe { height: 100%; width: 100%; }
 
 /* Desktop results page — let the card breathe so OSMD can lay staves
    out at a readable width. Typical "reading width" territory; the card

--- a/frontend-v2/src/views.js
+++ b/frontend-v2/src/views.js
@@ -435,6 +435,12 @@ function completeBody(job) {
       "aria-label": "Toggle fullscreen",
       title: "Fullscreen",
     }, icon("fullscreen"));
+    // Target the WRAPPER, not the iframe, so the button stays visible
+    // in fullscreen mode and the click-to-exit path is reachable.
+    // Requesting fullscreen on the iframe alone would hide the button
+    // (the button is its sibling, not a descendant), leaving Escape
+    // as the only exit.
+    const iframeStub = el("div", { class: "iframe-stub tunechat" }, frame, fullscreenBtn);
     fullscreenBtn.addEventListener("click", () => {
       // Exit if already fullscreen, otherwise enter. Swallow the
       // returned promise — failures are surfaced by the browser as
@@ -443,8 +449,8 @@ function completeBody(job) {
       try {
         if (document.fullscreenElement) {
           document.exitFullscreen();
-        } else if (typeof frame.requestFullscreen === "function") {
-          frame.requestFullscreen();
+        } else if (typeof iframeStub.requestFullscreen === "function") {
+          iframeStub.requestFullscreen();
         }
       } catch {
         // Older browsers / sandboxed iframes — silent no-op.
@@ -452,7 +458,7 @@ function completeBody(job) {
     });
     // .iframe-stub.tunechat triggers the fullscreen-ish mobile CSS
     // where the iframe fills the viewport and the card sheds its padding.
-    wrap.appendChild(el("div", { class: "iframe-stub tunechat" }, frame, fullscreenBtn));
+    wrap.appendChild(iframeStub);
   } else {
     wrap.appendChild(
       el(

--- a/frontend-v2/src/views.test.js
+++ b/frontend-v2/src/views.test.js
@@ -256,26 +256,49 @@ describe("renderPhase — complete (with tunechat_job_id)", () => {
     expect(btn.getAttribute("aria-label")).toMatch(/fullscreen/i);
   });
 
-  it("fullscreen button calls requestFullscreen on the iframe", () => {
+  // Fullscreen tests capture+restore document.fullscreenElement so the
+  // mock doesn't leak into later suites. Also mocks exitFullscreen
+  // since happy-dom doesn't ship it by default.
+  let fsDescriptor;
+  beforeEach(() => {
+    fsDescriptor = Object.getOwnPropertyDescriptor(document, "fullscreenElement");
+  });
+  afterEach(() => {
+    if (fsDescriptor) {
+      Object.defineProperty(document, "fullscreenElement", fsDescriptor);
+    } else {
+      delete document.fullscreenElement;
+    }
+    delete document.exitFullscreen;
+  });
+
+  it("fullscreen button calls requestFullscreen on the WRAPPER, not the iframe", () => {
+    // Target must be the .iframe-stub wrapper, not the iframe itself —
+    // requesting on the iframe would hide the button (the button is
+    // the iframe's sibling, not its child) making click-to-exit
+    // unreachable. See PR #89 review.
+    const wrap = container.querySelector(".iframe-stub.tunechat");
     const iframe = container.querySelector("iframe");
-    const spy = vi.fn().mockResolvedValue(undefined);
-    iframe.requestFullscreen = spy;
-    // No existing fullscreen element — click should enter fullscreen.
+    const wrapSpy = vi.fn().mockResolvedValue(undefined);
+    const iframeSpy = vi.fn().mockResolvedValue(undefined);
+    wrap.requestFullscreen = wrapSpy;
+    iframe.requestFullscreen = iframeSpy;
     Object.defineProperty(document, "fullscreenElement", {
       configurable: true,
       get: () => null,
     });
     container.querySelector(".fullscreen-btn").click();
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(wrapSpy).toHaveBeenCalledTimes(1);
+    expect(iframeSpy).not.toHaveBeenCalled();
   });
 
   it("fullscreen button calls exitFullscreen when already fullscreen", () => {
-    const iframe = container.querySelector("iframe");
+    const wrap = container.querySelector(".iframe-stub.tunechat");
     const exitSpy = vi.fn().mockResolvedValue(undefined);
     document.exitFullscreen = exitSpy;
     Object.defineProperty(document, "fullscreenElement", {
       configurable: true,
-      get: () => iframe,
+      get: () => wrap,
     });
     container.querySelector(".fullscreen-btn").click();
     expect(exitSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
Three follow-ups from the PR #89 review (approved with notes). Landing as a separate PR since #89 already merged.

1. **Fullscreen targets wrapper, not iframe.** \`frame.requestFullscreen()\` hid the overlay button (its sibling in the DOM), making click-to-exit unreachable — Escape was the only way out. Now targets \`.iframe-stub\` so both iframe and button ride into fullscreen together. Exit path is reachable.

2. **Test hygiene.** \`Object.defineProperty(document, "fullscreenElement", ...)\` overrides are now captured in \`beforeEach\` and restored in \`afterEach\` — no more mock leak into subsequent test suites. Also cleans up \`document.exitFullscreen\`.

3. **Nit: scoped \`position: relative\` to \`.iframe-stub\` only.** \`.inline-render\` has no overlay children, doesn't need a stacking context.

Bonus: updated the \`:fullscreen\` CSS rule from \`.iframe-stub iframe:fullscreen\` to \`.iframe-stub:fullscreen\` to match the new target, plus a child iframe sizing rule for fullscreen mode.

The updated test now asserts \`wrap.requestFullscreen\` is called AND \`iframe.requestFullscreen\` is NOT — locks in the contract so a future regression re-targeting the iframe fails loudly.

## Test plan
- [x] \`npm test\` — 69/69 passing (32 views tests unchanged count; 2 fullscreen tests updated)
- [x] \`npm run build\` — green
- [ ] Manual on qa: click fullscreen → both iframe and button visible → click button again → exits fullscreen without needing Escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)