### PR TITLE
chore: two 🟢 review follow-ups — bracket loop + paste gate

### DIFF
--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -206,8 +206,18 @@ def _maybe_swap_for_cover_sync(
         artist = None
     # Strip trailing parens like "(Official Video)", "(Piano Cover)",
     # "[Audio]" — they pollute the sheet music title but don't change
-    # what song it is.
-    title = re.sub(r"\s*[\(\[][^)\]]+[\)\]]\s*$", "", title).strip() or title
+    # what song it is. Loop until stable so stacked tags like
+    # "Song [Remastered] (Official Video) [4K]" get all three stripped;
+    # the anchored `$` regex only matches the rightmost bracket per
+    # pass, so a single re.sub call isn't enough.
+    while True:
+        stripped = re.sub(r"\s*[\(\[][^)\]]+[\)\]]\s*$", "", title).strip()
+        if not stripped or stripped == title:
+            # Either the title is now empty (don't over-strip — keep the
+            # last non-empty form as fallback) or no more brackets to
+            # remove. Exit the loop either way.
+            break
+        title = stripped
 
     try:
         match = find_clean_source(

--- a/frontend-v2/src/views.js
+++ b/frontend-v2/src/views.js
@@ -250,8 +250,18 @@ function idleBody(source, handlers) {
       }
     });
     wrap.appendChild(a.wrap);
-    // Auto-paste from clipboard if it contains a YouTube URL.
-    if (!urlInput.value) tryPasteYoutube(urlInput);
+    // Auto-paste from clipboard on first focus, not during render.
+    // Safari requires a user gesture for navigator.clipboard.readText()
+    // — calling it during render throws a silent NotAllowedError,
+    // and Chrome/Firefox show a permission prompt with no gesture in
+    // flight. Gating on focus means "the user just clicked/tabbed
+    // into the URL field" is the gesture we piggyback on.
+    let pasteAttempted = false;
+    urlInput.addEventListener("focus", () => {
+      if (pasteAttempted || urlInput.value) return;
+      pasteAttempted = true;
+      tryPasteYoutube(urlInput);
+    });
   }
 
   wrap.appendChild(spacer(8));

--- a/frontend-v2/src/views.test.js
+++ b/frontend-v2/src/views.test.js
@@ -30,6 +30,61 @@ function findButtonByText(root, text) {
   );
 }
 
+describe("renderPhase — clipboard paste gating", () => {
+  // Safari (and to a lesser extent Chrome/Firefox) require a user
+  // gesture before navigator.clipboard.readText() resolves. Calling
+  // it during initial render throws a silent NotAllowedError. The
+  // auto-paste should only fire when the user actually interacts
+  // with the URL input (first focus).
+  let readTextMock;
+  let origClipboard;
+  beforeEach(() => {
+    readTextMock = vi.fn().mockResolvedValue("");
+    origClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText: readTextMock },
+    });
+  });
+  afterEach(() => {
+    if (origClipboard === undefined) {
+      delete navigator.clipboard;
+    } else {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: origClipboard,
+      });
+    }
+  });
+
+  it("does NOT read clipboard during initial render (no user gesture yet)", () => {
+    renderPhase(container, { name: "idle", source: "youtube" }, handlers);
+    expect(readTextMock).not.toHaveBeenCalled();
+  });
+
+  it("reads clipboard when the URL input receives focus (gesture)", () => {
+    renderPhase(container, { name: "idle", source: "youtube" }, handlers);
+    const urlInput = [...container.querySelectorAll("input[type='text']")].find(
+      (i) => (i.placeholder || "").toLowerCase().includes("youtube"),
+    );
+    urlInput.dispatchEvent(new Event("focus", { bubbles: true }));
+    expect(readTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads clipboard at most once per render even on repeated focuses", () => {
+    // Once we've tried to auto-fill, don't nag the user on every
+    // subsequent focus — they can paste manually if they want.
+    renderPhase(container, { name: "idle", source: "youtube" }, handlers);
+    const urlInput = [...container.querySelectorAll("input[type='text']")].find(
+      (i) => (i.placeholder || "").toLowerCase().includes("youtube"),
+    );
+    urlInput.dispatchEvent(new Event("focus", { bubbles: true }));
+    urlInput.dispatchEvent(new Event("blur", { bubbles: true }));
+    urlInput.dispatchEvent(new Event("focus", { bubbles: true }));
+    expect(readTextMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("renderPhase — idle / youtube", () => {
   beforeEach(() => {
     renderPhase(container, { name: "idle", source: "youtube" }, handlers);

--- a/tests/test_ingest_cover_search.py
+++ b/tests/test_ingest_cover_search.py
@@ -548,6 +548,33 @@ class TestMetadataFromCoverSearchWinsOverDownload:
         assert result.metadata.title == "Bohemian Rhapsody"
         assert result.metadata.artist == "Queen"
 
+    def test_multiple_trailing_brackets_are_all_stripped(self, service):
+        # YouTube uploaders frequently stack multiple parenthetical tags:
+        #   "Song [Remastered] (Official Video)"
+        #   "Song (Live at Wembley) [4K HDR]"
+        # The old single-pass regex only stripped the last bracket. This
+        # test locks in the loop-until-stable behavior so ALL trailing
+        # provenance tags get removed, no matter how many the uploader
+        # packed in.
+        bundle = _make_bundle(prefer_clean_source=True)
+
+        with (
+            patch("backend.services.ingest.probe_youtube_metadata") as mock_probe,
+            patch("backend.services.ingest.find_clean_source") as mock_find,
+            patch("backend.services.ingest._download_youtube_sync") as mock_dl,
+        ):
+            mock_probe.return_value = (
+                "Queen - Bohemian Rhapsody [Remastered] (Official Video) [4K HDR]",
+                "Queen",
+            )
+            mock_find.return_value = None
+            mock_dl.side_effect = lambda url, _bs: _fake_downloaded_audio(url)
+
+            result = asyncio.run(service.run(bundle))
+
+        assert result.metadata.title == "Bohemian Rhapsody"
+        assert result.metadata.artist == "Queen"
+
     def test_extracted_values_survive_when_no_swap_happens(self, service):
         # Even when cover_search finds no match (returns None), the
         # extracted title/artist should still propagate — they're


### PR DESCRIPTION
## Summary
Two small, independent follow-ups from the 🟢 (non-blocking) review notes on PRs #83 / #85. Bundled into one PR since each is tiny and they touch different layers (backend regex + frontend clipboard).

### 1. \`fix(ingest)\`: strip ALL trailing brackets, not just the last
\`backend/services/ingest.py:210\` — the single \`re.sub\` pass only stripped the rightmost anchored bracket. Stacked tags like \`"Song [Remastered] (Official Video) [4K]"\` still polluted the sheet header. Now loops until stable.

### 2. \`fix(frontend-v2)\`: gate clipboard auto-paste behind URL-input focus
\`frontend-v2/src/views.js:254\` — \`navigator.clipboard.readText()\` fired during initial render, which throws a silent \`NotAllowedError\` on Safari (no user gesture) and surfaces a permission prompt on Chrome/Firefox. Now fires on the URL input's first focus event (a real gesture), with a \`pasteAttempted\` flag preventing re-polls on repeat focus.

## Test plan
- [x] \`.venv/bin/pytest tests/test_ingest_cover_search.py\` — 19/19 (1 new: \`test_multiple_trailing_brackets_are_all_stripped\`)
- [x] \`npm test\` — 72/72 (3 new in "clipboard paste gating" describe)
- [x] \`npm run build\` — green
- [ ] Manual on qa: Safari desktop → idle YouTube view should not prompt for clipboard; click into URL field → if clipboard has a YouTube URL, it auto-fills; if not, silence
- [ ] Manual on qa: paste \`Queen - Bohemian Rhapsody [Remastered] (Official Video)\` into the URL field → result page title renders as \`Bohemian Rhapsody\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)