### PR TITLE
fix(frontend-v2): move fullscreen button to bottom-right (collision with TuneChat chrome)

### DIFF
--- a/frontend-v2/src/style.css
+++ b/frontend-v2/src/style.css
@@ -233,12 +233,17 @@ body[data-phase="submitting"] .tagline { display: none; }
 }
 .iframe-stub.tunechat { height: min(80vh, 760px); }
 
-/* Fullscreen overlay button — top-right corner of the iframe wrap,
-   matching YouTube / Vimeo / Figma convention. Hover-reveals on
-   desktop so the chrome stays minimal; always visible on touch. */
+/* Fullscreen overlay button — bottom-right corner of the iframe wrap.
+   Originally placed top-right (YouTube/Vimeo convention), but the
+   TuneChat embed renders its own Play/Pause/Stop controls in the
+   same top-right region, causing a visual collision on hover. The
+   iframe's bottom-right is only occupied by small attribution text,
+   so the overlay can live there without fighting for pixels with
+   interactive chrome. Hover-reveals on desktop; always visible on
+   touch. */
 .fullscreen-btn {
   position: absolute;
-  top: 12px; right: 12px;
+  bottom: 12px; right: 12px;
   width: 36px; height: 36px;
   display: inline-flex; align-items: center; justify-content: center;
   background: rgba(0, 0, 0, 0.55);


### PR DESCRIPTION
## Summary
Fixes a visual collision spotted on qa post-merge of #89: our fullscreen overlay button (anchored top-right) was overlapping TuneChat's own Play/Pause button (also top-right of its embed iframe).

**Before:** two buttons visibly stacked in the top-right on hover.
**After:** our button sits bottom-right, where the iframe only has small attribution text.

## Why not top-left or outside the iframe?
- Top-left collides with TuneChat's \`Sheet | Piano roll\` tabs
- Outside the iframe loses the "expand this frame" semantic
- Bottom-right is the only corner with no interactive chrome in the TuneChat embed — attribution text doesn't compete for clicks

One-line CSS change: \`top: 12px\` → \`bottom: 12px\`. All other behavior preserved (hover-reveal, 44×44 touch target, wrapper-goes-fullscreen from #90).

## Test plan
- [x] \`npm test\` — 69/69 passing, no test changes needed (placement-only)
- [x] \`npm run build\` — green
- [ ] Manual on qa: complete a job → hover over iframe → fullscreen button in bottom-right, no overlap with Play/Pause → click → iframe+button go fullscreen → click again to exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)