### PR TITLE
feat(demo): YouTube-only landing + fix PDF/MusicXML/MIDI downloads via TuneChat proxy

### DIFF
--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -37,11 +37,12 @@ ArtifactKind = Literal["pdf", "musicxml", "midi", "transcription_midi"]
 # when the TuneChat field is empty (e.g. audio_upload / midi_upload paths
 # that never touch TuneChat). ``transcription_midi`` has no TuneChat
 # counterpart — it's the pre-engrave MIDI from Oh Sheet's own pipeline.
+_MUSICXML_MIME = "application/vnd.recordare.musicxml+xml"
 _KIND_INFO: dict[str, tuple[str, str | None, str, str]] = {
-    "pdf":                ("pdf_uri",                "tunechat_pdf_url",      "application/pdf",                       "sheet.pdf"),
-    "musicxml":           ("musicxml_uri",           "tunechat_musicxml_url", "application/vnd.recordare.musicxml+xml", "score.musicxml"),
-    "midi":               ("humanized_midi_uri",     "tunechat_midi_url",     "audio/midi",                            "humanized.mid"),
-    "transcription_midi": ("transcription_midi_uri", None,                    "audio/midi",                            "transcription.mid"),
+    "pdf":                ("pdf_uri",                "tunechat_pdf_url",      "application/pdf", "sheet.pdf"),
+    "musicxml":           ("musicxml_uri",           "tunechat_musicxml_url", _MUSICXML_MIME,    "score.musicxml"),
+    "midi":               ("humanized_midi_uri",     "tunechat_midi_url",     "audio/midi",      "humanized.mid"),
+    "transcription_midi": ("transcription_midi_uri", None,                    "audio/midi",      "transcription.mid"),
 }
 
 # httpx timeout for the TuneChat proxy fetch. Short because the file

--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -4,11 +4,20 @@ The pipeline contracts return ``file://`` URIs in ``EngravedOutput`` so the
 worker layer can stay storage-agnostic. Browsers and mobile apps can't fetch
 those URIs directly, so this route resolves the kind → URI for a finished
 job, reads the bytes via the BlobStore, and streams them back over HTTP.
+
+For the TuneChat-fast-path (title_lookup jobs routed through the external
+TuneChat engraver), artifacts live on TuneChat's server rather than in our
+blob store — ``EngravedOutput.tunechat_*_url`` holds the full https URL.
+This endpoint proxies those downloads so the client-facing URL shape
+(``/v1/artifacts/{job}/{kind}``) stays consistent regardless of which
+engraver produced the bytes.
 """
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Literal
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
@@ -16,17 +25,28 @@ from backend.api.deps import get_blob_store, get_job_manager
 from backend.jobs.manager import JobManager
 from backend.storage.local import LocalBlobStore
 
+log = logging.getLogger(__name__)
+
 router = APIRouter()
 
 ArtifactKind = Literal["pdf", "musicxml", "midi", "transcription_midi"]
 
-# kind → (uri attribute on EngravedOutput, media type, downloaded filename suffix)
-_KIND_INFO: dict[str, tuple[str, str, str]] = {
-    "pdf":                ("pdf_uri",                "application/pdf",                       "sheet.pdf"),
-    "musicxml":           ("musicxml_uri",           "application/vnd.recordare.musicxml+xml", "score.musicxml"),
-    "midi":               ("humanized_midi_uri",     "audio/midi",                            "humanized.mid"),
-    "transcription_midi": ("transcription_midi_uri", "audio/midi",                            "transcription.mid"),
+# kind → (local-URI attribute, TuneChat-URL attribute, media type, filename suffix)
+# The TuneChat URL field is checked FIRST — when populated, we proxy the
+# download from TuneChat's server. Falls back to the local blob-store URI
+# when the TuneChat field is empty (e.g. audio_upload / midi_upload paths
+# that never touch TuneChat). ``transcription_midi`` has no TuneChat
+# counterpart — it's the pre-engrave MIDI from Oh Sheet's own pipeline.
+_KIND_INFO: dict[str, tuple[str, str | None, str, str]] = {
+    "pdf":                ("pdf_uri",                "tunechat_pdf_url",      "application/pdf",                       "sheet.pdf"),
+    "musicxml":           ("musicxml_uri",           "tunechat_musicxml_url", "application/vnd.recordare.musicxml+xml", "score.musicxml"),
+    "midi":               ("humanized_midi_uri",     "tunechat_midi_url",     "audio/midi",                            "humanized.mid"),
+    "transcription_midi": ("transcription_midi_uri", None,                    "audio/midi",                            "transcription.mid"),
 }
+
+# httpx timeout for the TuneChat proxy fetch. Short because the file
+# already exists on TuneChat's disk — this is just a LAN-ish transfer.
+_PROXY_TIMEOUT_SEC = 30.0
 
 
 @router.get("/artifacts/{job_id}/{kind}")
@@ -53,8 +73,35 @@ def download_artifact(
             detail=f"Job {job_id} is {record.status}; artifacts unavailable.",
         )
 
-    attr, media_type, suffix = _KIND_INFO[kind]
-    uri = getattr(record.result, attr)
+    local_attr, tunechat_attr, media_type, suffix = _KIND_INFO[kind]
+    filename = f"{job_id}-{suffix}"
+    disposition = "inline" if inline else f'attachment; filename="{filename}"'
+
+    # TuneChat-first: when the job was engraved by TuneChat the local
+    # blob URI is empty — fall through to the hosted URL.
+    tunechat_url = getattr(record.result, tunechat_attr) if tunechat_attr else None
+    if tunechat_url:
+        try:
+            with httpx.Client(timeout=_PROXY_TIMEOUT_SEC, follow_redirects=True) as client:
+                response = client.get(tunechat_url)
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            log.warning(
+                "artifacts: TuneChat proxy fetch failed for %s/%s (%s): %s",
+                job_id, kind, tunechat_url, exc,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=f"Failed to fetch {kind!r} artifact from upstream.",
+            ) from exc
+        return Response(
+            content=response.content,
+            media_type=media_type,
+            headers={"Content-Disposition": disposition},
+        )
+
+    # Local-blob-store path (audio_upload / midi_upload pipelines).
+    uri = getattr(record.result, local_attr)
     if not uri:
         # Optional artifacts won't exist for every variant:
         #   * transcription_midi — absent on midi_upload / stub paths
@@ -75,8 +122,6 @@ def download_artifact(
             detail=f"Failed to read artifact: {exc}",
         ) from exc
 
-    filename = f"{job_id}-{suffix}"
-    disposition = "inline" if inline else f'attachment; filename="{filename}"'
     return Response(
         content=data,
         media_type=media_type,

--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import logging
 from typing import Annotated, Literal
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
 from backend.api.deps import get_blob_store, get_job_manager
+from backend.config import settings
 from backend.jobs.manager import JobManager
 from backend.storage.local import LocalBlobStore
 
@@ -48,6 +50,35 @@ _KIND_INFO: dict[str, tuple[str, str | None, str, str]] = {
 # httpx timeout for the TuneChat proxy fetch. Short because the file
 # already exists on TuneChat's disk — this is just a LAN-ish transfer.
 _PROXY_TIMEOUT_SEC = 30.0
+
+
+def _is_allowed_proxy_target(url: str) -> bool:
+    """SSRF defense: only allow proxy fetches to the configured TuneChat
+    base URL (scheme + host + port). The URL in ``tunechat_*_url`` comes
+    from TuneChat's API response — if TuneChat were ever compromised or
+    misconfigured to return a URL pointing at an internal service (AWS
+    IMDS, a DB admin panel, etc.), we'd happily proxy it without this
+    check. Strict equality of (scheme, hostname, port) is enough since
+    we ship a single TuneChat deployment per environment; multi-tenant
+    would need an allowlist.
+    """
+    try:
+        target = urlparse(url)
+        allowed = urlparse(settings.tunechat_url)
+    except ValueError:
+        return False
+    if not target.hostname or not allowed.hostname:
+        return False
+    return (
+        target.scheme == allowed.scheme
+        and target.hostname == allowed.hostname
+        and (target.port or _default_port(target.scheme))
+        == (allowed.port or _default_port(allowed.scheme))
+    )
+
+
+def _default_port(scheme: str) -> int | None:
+    return {"http": 80, "https": 443}.get(scheme)
 
 
 @router.get("/artifacts/{job_id}/{kind}")
@@ -82,11 +113,28 @@ def download_artifact(
     # blob URI is empty — fall through to the hosted URL.
     tunechat_url = getattr(record.result, tunechat_attr) if tunechat_attr else None
     if tunechat_url:
+        # SSRF guard — only proxy to the configured TuneChat host. See
+        # _is_allowed_proxy_target for rationale. Refuse with 502 so the
+        # client sees an "upstream issue" rather than a 500 (which would
+        # suggest an Oh Sheet bug).
+        if not _is_allowed_proxy_target(tunechat_url):
+            log.warning(
+                "artifacts: refused to proxy %s/%s — target host not in allowlist",
+                job_id, kind,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="Upstream artifact host is not allowed.",
+            )
         try:
             with httpx.Client(timeout=_PROXY_TIMEOUT_SEC, follow_redirects=True) as client:
                 response = client.get(tunechat_url)
                 response.raise_for_status()
         except httpx.HTTPError as exc:
+            # NOTE: we log `tunechat_url` directly. Today those are path-
+            # only URLs (no query string) so this is safe. If TuneChat
+            # ever switches to signed URLs with ?token=... credentials,
+            # strip the query before logging — see TuneChatResult.
             log.warning(
                 "artifacts: TuneChat proxy fetch failed for %s/%s (%s): %s",
                 job_id, kind, tunechat_url, exc,

--- a/backend/jobs/runner.py
+++ b/backend/jobs/runner.py
@@ -339,6 +339,14 @@ class PipelineRunner:
                                         humanized_midi_uri="",
                                         tunechat_job_id=tc_result.job_id,
                                         tunechat_preview_image_url=tc_result.preview_image_url,
+                                        # Capture the hosted artifact URLs so
+                                        # /v1/artifacts/{job}/{kind} can proxy
+                                        # downloads (see artifacts.py). Without
+                                        # these the download chips 404 on every
+                                        # TuneChat-fast-path job.
+                                        tunechat_midi_url=tc_result.midi_url,
+                                        tunechat_musicxml_url=tc_result.musicxml_url,
+                                        tunechat_pdf_url=tc_result.pdf_url,
                                     )
                                 else:
                                     log.warning("tunechat-only: returned None, falling back to Oh Sheet pipeline")

--- a/backend/services/tunechat_client.py
+++ b/backend/services/tunechat_client.py
@@ -22,10 +22,20 @@ log = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class TuneChatResult:
-    """The two things Oh Sheet needs from TuneChat."""
+    """What Oh Sheet captures from TuneChat's transcribe response.
+
+    Artifact URLs (midi / musicxml / pdf) point at files hosted on
+    TuneChat's server — e.g. ``https://tunechat.raqdrobinson.com/pipeline/<id>/notation.mid``.
+    They may be None for any individual kind (TuneChat sometimes
+    produces MusicXML + MIDI but no PDF if MuseScore fails; the PDF
+    field being None is the signal to not offer that download).
+    """
 
     job_id: str
     preview_image_url: str | None
+    midi_url: str | None = None
+    musicxml_url: str | None = None
+    pdf_url: str | None = None
 
 
 async def transcribe_via_tunechat(
@@ -72,8 +82,18 @@ async def transcribe_via_tunechat(
             result = TuneChatResult(
                 job_id=data["jobId"],
                 preview_image_url=data.get("previewImageUrl"),
+                midi_url=data.get("fullMidiUrl"),
+                musicxml_url=data.get("fullMusicxmlUrl"),
+                pdf_url=data.get("fullPdfUrl"),
             )
-            log.info("tunechat: success job_id=%s has_image=%s", result.job_id, result.preview_image_url is not None)
+            log.info(
+                "tunechat: success job_id=%s has_image=%s has_midi=%s has_xml=%s has_pdf=%s",
+                result.job_id,
+                result.preview_image_url is not None,
+                result.midi_url is not None,
+                result.musicxml_url is not None,
+                result.pdf_url is not None,
+            )
             return result
 
     except httpx.TimeoutException:

--- a/frontend-v2/src/views.js
+++ b/frontend-v2/src/views.js
@@ -37,9 +37,15 @@ function isYoutubeVideoUrl(s) {
   return typeof s === "string" && YOUTUBE_VIDEO_RE.test(s.trim());
 }
 
+// Demo-day scope (Apr 20): YouTube is the only source routed through
+// TuneChat for transcription. Audio + MIDI uploads still exist in the
+// backend but aren't plumbed through the TuneChat fast-path yet, and
+// we don't want the landing page advertising options we can't run on
+// stage. The segmented picker auto-hides when SOURCES has <= 1 entry
+// (see `segmented()`), so reducing to a single entry is enough to
+// kill the picker entirely without touching CSS or the branch logic
+// in `idleBody()`. Re-adding audio/midi later is a 2-line restore.
 const SOURCES = [
-  { key: "audio", label: "Audio" },
-  { key: "midi", label: "MIDI" },
   { key: "youtube", label: "YouTube" },
 ];
 
@@ -89,6 +95,11 @@ function icon(name) {
 // ── sub-components ───────────────────────────────────────────────────
 
 function segmented(activeSource, onSourceChange) {
+  // Auto-hide when only one source is available — a segmented picker
+  // with a single button is UX noise, not a choice. Callers can still
+  // unconditionally append the returned node; `null` is tolerated by
+  // appendChild() below.
+  if (SOURCES.length <= 1) return null;
   const wrap = el("div", { class: "segmented" });
   for (const src of SOURCES) {
     const isActive = src.key === activeSource;
@@ -175,7 +186,10 @@ function tryPasteYoutube(input) {
 
 function idleBody(source, handlers) {
   const wrap = el("div", { class: "body" });
-  wrap.appendChild(segmented(source, handlers.onSourceChange));
+  // segmented() returns null when SOURCES.length <= 1 (auto-hide);
+  // native appendChild() rejects null, so guard the call.
+  const picker = segmented(source, handlers.onSourceChange);
+  if (picker) wrap.appendChild(picker);
 
   let fileInput = null;
   let selectedFile = null;

--- a/frontend-v2/src/views.test.js
+++ b/frontend-v2/src/views.test.js
@@ -35,19 +35,13 @@ describe("renderPhase — idle / youtube", () => {
     renderPhase(container, { name: "idle", source: "youtube" }, handlers);
   });
 
-  it("renders a segmented picker with 3 buttons", () => {
-    const segs = container.querySelectorAll(".segmented .seg");
-    expect(segs.length).toBe(3);
-    const texts = [...segs].map((s) => s.textContent.replace(/\s+/g, " ").trim());
-    expect(texts.some((t) => t.includes("Audio"))).toBe(true);
-    expect(texts.some((t) => t.includes("MIDI"))).toBe(true);
-    expect(texts.some((t) => t.includes("YouTube"))).toBe(true);
-  });
-
-  it("marks the YouTube tab active", () => {
-    const active = container.querySelector(".segmented .seg.on");
-    expect(active).toBeTruthy();
-    expect(active.textContent.trim()).toBe("YouTube");
+  // Demo scope (Apr 20): audio + midi sources are hidden, so SOURCES
+  // has length 1 and the segmented picker auto-hides. Old assertions
+  // about 3 buttons / "marks YouTube tab active" don't apply until
+  // audio/midi come back. Keep this test to lock in the auto-hide
+  // behavior — if SOURCES ever grows, the picker should reappear.
+  it("does NOT render a segmented picker when only one source is defined", () => {
+    expect(container.querySelector(".segmented")).toBeNull();
   });
 
   it("renders a URL input (no file picker)", () => {
@@ -78,13 +72,10 @@ describe("renderPhase — idle / youtube", () => {
     expect(arg.url).toBe("https://youtu.be/abc");
   });
 
-  it("fires onSourceChange('audio') when Audio tab clicked", () => {
-    const audioTab = [...container.querySelectorAll(".segmented .seg")].find(
-      (s) => s.textContent.includes("Audio"),
-    );
-    audioTab.click();
-    expect(handlers.onSourceChange).toHaveBeenCalledWith("audio");
-  });
+  // Demo scope: no Audio tab exists anymore, so the tab-click test is
+  // skipped until audio/midi are restored to SOURCES. The onSourceChange
+  // handler wiring itself is unchanged — still covered by the
+  // segmented() unit when SOURCES.length > 1.
 
   it("does NOT fire onSubmit when URL is empty", () => {
     findButtonByText(container, "Let's go!").click();
@@ -92,7 +83,13 @@ describe("renderPhase — idle / youtube", () => {
   });
 });
 
-describe("renderPhase — idle / audio", () => {
+// Demo scope (Apr 20): audio + midi sources are hidden from the UI
+// for demo. The views.js branches still render correctly if the
+// source IS set to "audio" / "midi" (the segmented picker is just
+// gated separately), so these tests are skipped rather than deleted
+// — restoring the feature post-demo means flipping .skip → .describe
+// in one edit plus restoring SOURCES in views.js.
+describe.skip("renderPhase — idle / audio", () => {
   beforeEach(() => {
     renderPhase(container, { name: "idle", source: "audio" }, handlers);
   });
@@ -134,7 +131,7 @@ describe("renderPhase — idle / audio", () => {
   });
 });
 
-describe("renderPhase — idle / midi", () => {
+describe.skip("renderPhase — idle / midi", () => {
   beforeEach(() => {
     renderPhase(container, { name: "idle", source: "midi" }, handlers);
   });
@@ -150,7 +147,9 @@ describe("renderPhase — idle / midi", () => {
 describe("renderPhase — idle / title (legacy source, treated as youtube fallback)", () => {
   it("still renders a form body even for unknown sources", () => {
     renderPhase(container, { name: "idle", source: "title" }, handlers);
-    expect(container.querySelector(".segmented")).toBeTruthy();
+    // Sentinel switched from .segmented (auto-hidden post-demo-cut)
+    // to the body wrapper that idleBody() always emits.
+    expect(container.querySelector(".body")).toBeTruthy();
   });
 });
 
@@ -366,9 +365,20 @@ describe("renderPhase — error", () => {
 describe("renderPhase — atomic swap", () => {
   it("clears previous content when called again", () => {
     renderPhase(container, { name: "idle", source: "youtube" }, handlers);
-    expect(container.querySelector(".segmented")).toBeTruthy();
+    // Post-demo-cut: the segmented picker is hidden (SOURCES has 1
+    // entry). Use the YouTube URL input placeholder as the idle-phase
+    // sentinel instead — it's stable across the source-picker cut.
+    expect(
+      [...container.querySelectorAll("input")].some(
+        (i) => (i.placeholder || "").toLowerCase().includes("youtube"),
+      ),
+    ).toBe(true);
     renderPhase(container, { name: "submitting" }, handlers);
-    expect(container.querySelector(".segmented")).toBeNull();
+    expect(
+      [...container.querySelectorAll("input")].some(
+        (i) => (i.placeholder || "").toLowerCase().includes("youtube"),
+      ),
+    ).toBe(false);
     expect(container.querySelector("svg.m3-spinner")).toBeTruthy();
   });
 });

--- a/shared/shared/contracts.py
+++ b/shared/shared/contracts.py
@@ -365,6 +365,16 @@ class EngravedOutput(BaseModel):
     # TuneChat's rendered score for display in Oh Sheet's result screen.
     tunechat_job_id: str | None = None
     tunechat_preview_image_url: str | None = None
+    # Artifact URLs hosted on TuneChat's server. When Oh Sheet's
+    # pipeline skipped local engraving (TuneChat-only path), these
+    # are the only place the rendered artifacts exist. The artifacts
+    # endpoint (backend/api/routes/artifacts.py) proxies downloads
+    # through these when ``pdf_uri`` / ``musicxml_uri`` / ``humanized_midi_uri``
+    # are empty, so /v1/artifacts/{job}/{kind} keeps working
+    # regardless of which engraver produced the files.
+    tunechat_midi_url: str | None = None
+    tunechat_musicxml_url: str | None = None
+    tunechat_pdf_url: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -96,8 +96,8 @@ def _install_tunechat_job(client, *, pdf: str | None, musicxml: str | None, midi
     """Submit a midi job and patch its EngravedOutput to look like a
     TuneChat-fast-path result: empty blob URIs + populated tunechat URLs.
     Returns the job_id."""
-    from backend.jobs.manager import JobManager
     from backend.api.deps import get_job_manager
+    from backend.jobs.manager import JobManager
 
     job_id = _submit_midi_job(client)
     _wait_for_succeeded(client, job_id)
@@ -123,8 +123,6 @@ def _install_tunechat_job(client, *, pdf: str | None, musicxml: str | None, midi
 def test_artifact_proxies_musicxml_from_tunechat(client, monkeypatch):
     """When tunechat_musicxml_url is set, the endpoint proxies the fetch
     and returns the bytes with Content-Disposition: attachment."""
-    import httpx
-
     upstream_body = b"<?xml version='1.0'?><score-partwise/>"
 
     class FakeResponse:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -82,3 +82,139 @@ def test_artifact_job_not_yet_succeeded(client):
     assert response.status_code in (200, 409)
     if response.status_code == 409:
         assert "artifacts unavailable" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# TuneChat proxy — used for jobs that went through the TuneChat-only fast
+# path. Local blob URIs are empty strings in that case; the endpoint must
+# fall through to the tunechat_*_url field and stream the file back with
+# Content-Disposition so the client's <a download> works reliably.
+# ---------------------------------------------------------------------------
+
+
+def _install_tunechat_job(client, *, pdf: str | None, musicxml: str | None, midi: str | None) -> str:
+    """Submit a midi job and patch its EngravedOutput to look like a
+    TuneChat-fast-path result: empty blob URIs + populated tunechat URLs.
+    Returns the job_id."""
+    from backend.jobs.manager import JobManager
+    from backend.api.deps import get_job_manager
+
+    job_id = _submit_midi_job(client)
+    _wait_for_succeeded(client, job_id)
+
+    # Reach into the in-memory JobManager used by this TestClient app.
+    manager: JobManager = client.app.dependency_overrides.get(
+        get_job_manager, get_job_manager
+    )()
+    record = manager.get(job_id)
+    assert record is not None and record.result is not None
+    record.result = record.result.model_copy(update={
+        "musicxml_uri": "",
+        "humanized_midi_uri": "",
+        "pdf_uri": None,
+        "tunechat_job_id": "tc-fake-123",
+        "tunechat_pdf_url": pdf,
+        "tunechat_musicxml_url": musicxml,
+        "tunechat_midi_url": midi,
+    })
+    return job_id
+
+
+def test_artifact_proxies_musicxml_from_tunechat(client, monkeypatch):
+    """When tunechat_musicxml_url is set, the endpoint proxies the fetch
+    and returns the bytes with Content-Disposition: attachment."""
+    import httpx
+
+    upstream_body = b"<?xml version='1.0'?><score-partwise/>"
+
+    class FakeResponse:
+        status_code = 200
+        content = upstream_body
+        def raise_for_status(self): pass
+
+    class FakeClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, url):
+            assert url == "https://tunechat.example/pipeline/tc-fake-123/score.musicxml"
+            return FakeResponse()
+
+    monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", FakeClient)
+
+    job_id = _install_tunechat_job(
+        client,
+        pdf="https://tunechat.example/pipeline/tc-fake-123/sheet.pdf",
+        musicxml="https://tunechat.example/pipeline/tc-fake-123/score.musicxml",
+        midi="https://tunechat.example/pipeline/tc-fake-123/notation.mid",
+    )
+    response = client.get(f"/v1/artifacts/{job_id}/musicxml")
+    assert response.status_code == 200
+    assert response.content == upstream_body
+    assert response.headers["content-type"] == "application/vnd.recordare.musicxml+xml"
+    # Critical: the <a download> attribute is unreliable across cross-origin
+    # redirects, so we set Content-Disposition server-side to force the
+    # download regardless of the user's browser.
+    assert "attachment" in response.headers["content-disposition"]
+    assert ".musicxml" in response.headers["content-disposition"]
+
+
+def test_artifact_proxies_pdf_from_tunechat(client, monkeypatch):
+    class FakeResponse:
+        status_code = 200
+        content = b"%PDF-1.4 fake"
+        def raise_for_status(self): pass
+
+    class FakeClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, url): return FakeResponse()
+
+    monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", FakeClient)
+
+    job_id = _install_tunechat_job(
+        client,
+        pdf="https://tunechat.example/pipeline/tc-fake-123/sheet.pdf",
+        musicxml=None,
+        midi=None,
+    )
+    response = client.get(f"/v1/artifacts/{job_id}/pdf")
+    assert response.status_code == 200
+    assert response.content.startswith(b"%PDF")
+    assert response.headers["content-type"] == "application/pdf"
+
+
+def test_artifact_falls_back_to_blob_when_no_tunechat_url(client):
+    """Audio/midi-upload paths never set tunechat_*_url — the old blob-
+    store code path must still work unchanged."""
+    job_id = _submit_midi_job(client)
+    _wait_for_succeeded(client, job_id)
+    response = client.get(f"/v1/artifacts/{job_id}/musicxml")
+    assert response.status_code == 200
+    assert b"score-partwise" in response.content
+
+
+def test_artifact_upstream_failure_returns_502(client, monkeypatch):
+    """If the TuneChat proxy fetch fails (network, 5xx, timeout), the
+    endpoint returns 502 rather than 500 — distinguishes upstream
+    trouble from a missing/corrupt local artifact."""
+    import httpx
+
+    class FakeClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, url):
+            raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", FakeClient)
+
+    job_id = _install_tunechat_job(
+        client,
+        pdf=None,
+        musicxml="https://tunechat.example/pipeline/tc-fake-123/score.musicxml",
+        midi=None,
+    )
+    response = client.get(f"/v1/artifacts/{job_id}/musicxml")
+    assert response.status_code == 502

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -135,16 +135,16 @@ def test_artifact_proxies_musicxml_from_tunechat(client, monkeypatch):
         def __enter__(self): return self
         def __exit__(self, *a): return False
         def get(self, url):
-            assert url == "https://tunechat.example/pipeline/tc-fake-123/score.musicxml"
+            assert url == "http://localhost:3000/pipeline/tc-fake-123/score.musicxml"
             return FakeResponse()
 
     monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", FakeClient)
 
     job_id = _install_tunechat_job(
         client,
-        pdf="https://tunechat.example/pipeline/tc-fake-123/sheet.pdf",
-        musicxml="https://tunechat.example/pipeline/tc-fake-123/score.musicxml",
-        midi="https://tunechat.example/pipeline/tc-fake-123/notation.mid",
+        pdf="http://localhost:3000/pipeline/tc-fake-123/sheet.pdf",
+        musicxml="http://localhost:3000/pipeline/tc-fake-123/score.musicxml",
+        midi="http://localhost:3000/pipeline/tc-fake-123/notation.mid",
     )
     response = client.get(f"/v1/artifacts/{job_id}/musicxml")
     assert response.status_code == 200
@@ -173,7 +173,7 @@ def test_artifact_proxies_pdf_from_tunechat(client, monkeypatch):
 
     job_id = _install_tunechat_job(
         client,
-        pdf="https://tunechat.example/pipeline/tc-fake-123/sheet.pdf",
+        pdf="http://localhost:3000/pipeline/tc-fake-123/sheet.pdf",
         musicxml=None,
         midi=None,
     )
@@ -211,7 +211,63 @@ def test_artifact_upstream_failure_returns_502(client, monkeypatch):
     job_id = _install_tunechat_job(
         client,
         pdf=None,
-        musicxml="https://tunechat.example/pipeline/tc-fake-123/score.musicxml",
+        musicxml="http://localhost:3000/pipeline/tc-fake-123/score.musicxml",
+        midi=None,
+    )
+    response = client.get(f"/v1/artifacts/{job_id}/musicxml")
+    assert response.status_code == 502
+
+
+def test_artifact_refuses_proxy_to_foreign_host(client, monkeypatch):
+    """SSRF guard: if the tunechat_*_url points somewhere other than the
+    configured TuneChat host, refuse with 502 BEFORE firing the request.
+
+    Simulates a TuneChat response that (whether via compromise or
+    misconfiguration) returns an internal/external URL we shouldn't be
+    proxying. The httpx.Client mock raises on any .get() so the test
+    fails loudly if the guard is bypassed.
+    """
+    class ExplodeClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, url):
+            raise AssertionError(f"SSRF guard bypassed — fetched {url}")
+
+    monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", ExplodeClient)
+
+    job_id = _install_tunechat_job(
+        client,
+        pdf=None,
+        # settings.tunechat_url is http://localhost:3000 by default; this
+        # URL points at a host NOT in the allowlist (classic SSRF
+        # attempt targeting AWS IMDS).
+        musicxml="http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        midi=None,
+    )
+    response = client.get(f"/v1/artifacts/{job_id}/musicxml")
+    assert response.status_code == 502
+    assert "not allowed" in response.json()["detail"].lower()
+
+
+def test_artifact_proxy_scheme_mismatch_is_rejected(client, monkeypatch):
+    """Scheme mismatch (https target vs http configured) also blocked —
+    prevents downgrade/upgrade attacks where an attacker swaps
+    http://internal.svc for https://internal.svc expecting only host
+    matching."""
+    class ExplodeClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, url):
+            raise AssertionError("SSRF guard bypassed")
+
+    monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", ExplodeClient)
+
+    job_id = _install_tunechat_job(
+        client,
+        pdf=None,
+        musicxml="https://localhost:3000/pipeline/tc-fake-123/score.musicxml",  # https, not http
         midi=None,
     )
     response = client.get(f"/v1/artifacts/{job_id}/musicxml")


### PR DESCRIPTION
## Summary
Two demo-day blockers in one PR (independent but both urgent for tomorrow).

### 1. \`feat(frontend-v2)\`: YouTube-only landing page
Audio + MIDI source options aren't plumbed through the TuneChat fast-path, so the picker shouldn't advertise them. SOURCES reduced to \`[youtube]\`; segmented picker auto-hides when SOURCES.length <= 1. Backend endpoints + upload flow untouched — restoring post-demo is a 2-line revert.

### 2. \`fix(artifacts)\`: PDF/MusicXML/MIDI downloads were 404ing
**Root cause:** On TuneChat-fast-path jobs (the demo path), \`runner.py\` wrote \`EngravedOutput\` with empty local-blob URIs because the local engraver is skipped. The artifacts endpoint then returned 404 for every download. Meanwhile TuneChat's transcribe response *does* include the artifact URLs (\`fullMidiUrl\`, \`fullMusicxmlUrl\`, \`fullPdfUrl\`) — Oh Sheet was just throwing them away.

**Fix:** Capture the URLs in \`TuneChatResult\`, add optional fields to \`EngravedOutput\`, pass them through in \`runner.py\`, and in \`artifacts.py\` proxy the fetch via \`httpx\` when a tunechat_*_url is set. Falls back to the local blob-store path for audio/midi upload pipelines.

**Why proxy instead of 302 redirect:** the \`<a download>\` attribute is unreliable across cross-origin redirects (PDF opens inline, MIDI doesn't auto-download). Proxying lets Oh Sheet set \`Content-Disposition: attachment\` server-side so browsers always download.

## Test plan
- [x] \`npm test\` — 61/67 passing + 6 skipped (audio/midi describe blocks marked \`.skip\` with restore notes)
- [x] \`npm run build\` — green
- [x] \`.venv/bin/pytest tests/\` — 504/504 + 12 skipped (pre-existing transcribe_stems flake on qa, unrelated)
- [x] 4 new artifacts tests covering proxy-musicxml / proxy-pdf / local-fallback / upstream-502
- [ ] Manual on qa: click PDF/MusicXML/MIDI chips on a completed YouTube job → files download with correct names, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)