### PR TITLE
feat(about): add About page to frontend-v2 with team link

### DIFF
--- a/frontend-v2/assets/about.html
+++ b/frontend-v2/assets/about.html
@@ -4,18 +4,20 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>About - Oh Sheet!</title>
+<meta name="description" content="Meet the team behind Oh Sheet! — five engineers who built an AI pipeline that turns any song into playable piano sheet music." />
+<meta property="og:title" content="About - Oh Sheet!" />
+<meta property="og:description" content="Meet the team behind Oh Sheet! — five engineers who built an AI pipeline that turns any song into playable piano sheet music." />
 <meta name="theme-color" content="#FDF4E8" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700;800;900&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700;800;900&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=arrow_back,groups_2,link,schedule,school" rel="stylesheet">
+<!-- Tokens are redefined here rather than shared with src/style.css
+     because the two pages use slightly different palette values (e.g.
+     --primary is #FF6F91 here vs #EC6B7B in the main app). A shared
+     tokens.css would force alignment that the designs don't have yet. -->
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  :root {
-    --bg: #FDF4E8; --surface: #fff; --ink: #2D2D44; --ink-stroke: #2D2D44;
-    --muted: #6B6B80; --accent: #6BCB77; --primary: #FF6F91; --orange: #FFB347;
-    --teal: #4DBFBF;
-  }
   body { font-family: Roboto, sans-serif; background: var(--bg); color: var(--ink); }
   a { color: inherit; }
   .back-link {
@@ -78,11 +80,20 @@
     max-width: 960px; margin: 0 auto 32px; padding: 20px 24px;
     border: 2.5px solid var(--ink-stroke);
   }
+  /* Per-member accent modifiers — dot + linkedin link color */
+  .card--orange .card-dot { background: var(--orange); }
+  .card--orange .card-linkedin { color: var(--orange); }
+  .card--green .card-dot { background: var(--accent); }
+  .card--green .card-linkedin { color: var(--accent); }
+  .card--pink .card-dot { background: var(--primary); }
+  .card--pink .card-linkedin { color: var(--primary); }
+  .card--teal .card-dot { background: var(--teal); }
+  .card--teal .card-linkedin { color: var(--teal); }
 </style>
 </head>
 <body>
   <a href="/" class="back-link">
-    <span class="material-symbols-rounded">arrow_back</span> Back to Oh Sheet!
+    <span class="material-symbols-rounded" aria-hidden="true">arrow_back</span> Back to Oh Sheet!
   </a>
 
   <div class="hero">
@@ -90,52 +101,52 @@
     <h1>Five engineers, two weeks, one capstone: Oh Sheet.</h1>
     <p>The team came together through the GauntletAI program and built Oh Sheet as their capstone project. In just two weeks, they turned the idea into a working product that transforms songs into playable piano sheet music.</p>
     <div class="badges">
-      <span class="badge"><span class="material-symbols-rounded">groups_2</span> 5 engineers</span>
-      <span class="badge"><span class="material-symbols-rounded">school</span> GauntletAI capstone</span>
-      <span class="badge"><span class="material-symbols-rounded">schedule</span> Built in 2 weeks</span>
+      <span class="badge"><span class="material-symbols-rounded" aria-hidden="true">groups_2</span> 5 engineers</span>
+      <span class="badge"><span class="material-symbols-rounded" aria-hidden="true">school</span> GauntletAI capstone</span>
+      <span class="badge"><span class="material-symbols-rounded" aria-hidden="true">schedule</span> Built in 2 weeks</span>
     </div>
   </div>
 
-  <div class="section-title">Meet the team</div>
+  <h2 class="section-title">Meet the team</h2>
 
   <div class="team">
     <div class="team-grid">
-      <div class="card">
-        <div class="card-name"><span class="card-dot" style="background:#FFB347"></span> Jack Jiang</div>
-        <a class="card-linkedin" href="https://www.linkedin.com/in/jackbjiang/" target="_blank" style="color:#FFB347">
-          <span class="material-symbols-rounded">link</span> linkedin.com/in/jackbjiang
+      <div class="card card--orange">
+        <div class="card-name"><span class="card-dot"></span> Jack Jiang</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/jackbjiang/" target="_blank" rel="noopener noreferrer">
+          <span class="material-symbols-rounded" aria-hidden="true">link</span> linkedin.com/in/jackbjiang
         </a>
         <div class="card-blurb">Senior full-stack engineer with 8 years of experience across product development, SRE, and workflow automation. Meme enthusiast and climbing addict.</div>
       </div>
 
-      <div class="card">
-        <div class="card-name"><span class="card-dot" style="background:#6BCB77"></span> Luis Ramos</div>
-        <a class="card-linkedin" href="https://www.linkedin.com/in/luis-ramos-usa" target="_blank" style="color:#6BCB77">
-          <span class="material-symbols-rounded">link</span> linkedin.com/in/luis-ramos-usa
+      <div class="card card--green">
+        <div class="card-name"><span class="card-dot"></span> Luis Ramos</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/luis-ramos-usa" target="_blank" rel="noopener noreferrer">
+          <span class="material-symbols-rounded" aria-hidden="true">link</span> linkedin.com/in/luis-ramos-usa
         </a>
         <div class="card-blurb">Senior software engineer who architects enterprise solutions across stacks, platforms, and frameworks with an AI-first approach to development.</div>
       </div>
 
-      <div class="card">
-        <div class="card-name"><span class="card-dot" style="background:#FF6F91"></span> Raq Robinson</div>
-        <a class="card-linkedin" href="https://www.linkedin.com/in/robinsonraquel/" target="_blank" style="color:#FF6F91">
-          <span class="material-symbols-rounded">link</span> linkedin.com/in/robinsonraquel
+      <div class="card card--pink">
+        <div class="card-name"><span class="card-dot"></span> Raq Robinson</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/robinsonraquel/" target="_blank" rel="noopener noreferrer">
+          <span class="material-symbols-rounded" aria-hidden="true">link</span> linkedin.com/in/robinsonraquel
         </a>
         <div class="card-blurb">Senior full-stack engineer who blends React frontend expertise with backend and systems thinking to build scalable, secure, and accessible platforms.</div>
       </div>
 
-      <div class="card">
-        <div class="card-name"><span class="card-dot" style="background:#4DBFBF"></span> Kevin Chang</div>
-        <a class="card-linkedin" href="https://www.linkedin.com/in/kevin-chihwei-chang/" target="_blank" style="color:#4DBFBF">
-          <span class="material-symbols-rounded">link</span> linkedin.com/in/kevin-chihwei-chang
+      <div class="card card--teal">
+        <div class="card-name"><span class="card-dot"></span> Kevin Chang</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/kevin-chihwei-chang/" target="_blank" rel="noopener noreferrer">
+          <span class="material-symbols-rounded" aria-hidden="true">link</span> linkedin.com/in/kevin-chihwei-chang
         </a>
         <div class="card-blurb">Senior full-stack engineer with 13 years of startup experience building products end to end. Piano wizard, board game lover, and badminton junkie.</div>
       </div>
 
-      <div class="card">
-        <div class="card-name"><span class="card-dot" style="background:#FFB347"></span> Ross Kuehl</div>
-        <a class="card-linkedin" href="https://www.linkedin.com/in/ross-kuehl/" target="_blank" style="color:#FFB347">
-          <span class="material-symbols-rounded">link</span> linkedin.com/in/ross-kuehl
+      <div class="card card--orange">
+        <div class="card-name"><span class="card-dot"></span> Ross Kuehl</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/ross-kuehl/" target="_blank" rel="noopener noreferrer">
+          <span class="material-symbols-rounded" aria-hidden="true">link</span> linkedin.com/in/ross-kuehl
         </a>
         <div class="card-blurb">Senior backend-focused software engineer with deep expertise in Python, cloud infrastructure, and distributed systems.</div>
       </div>

--- a/frontend-v2/assets/about.html
+++ b/frontend-v2/assets/about.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>About - Oh Sheet!</title>
+<meta name="theme-color" content="#FDF4E8" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700;800;900&family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #FDF4E8; --surface: #fff; --ink: #2D2D44; --ink-stroke: #2D2D44;
+    --muted: #6B6B80; --accent: #6BCB77; --primary: #FF6F91; --orange: #FFB347;
+    --teal: #4DBFBF;
+  }
+  body { font-family: Roboto, sans-serif; background: var(--bg); color: var(--ink); }
+  a { color: inherit; }
+  .back-link {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 8px 16px; margin: 16px;
+    font-size: 14px; font-weight: 700; color: var(--muted);
+    text-decoration: none; border-radius: 999px;
+    border: 2px solid var(--ink-stroke); background: var(--surface);
+  }
+  .back-link:hover { background: #f5f0e5; }
+  .hero {
+    max-width: 960px; margin: 0 auto 32px; padding: 32px 24px;
+    background: #FFFDF8; border: 2.5px solid var(--ink-stroke);
+    border-radius: 28px; box-shadow: 0 4px 18px rgba(45,45,68,0.07);
+  }
+  .hero-badge {
+    display: inline-block; padding: 6px 14px;
+    background: #FFF0D9; border: 2px solid var(--ink-stroke);
+    border-radius: 999px; font-size: 12px; font-weight: 800;
+  }
+  .hero h1 { font-size: 28px; font-weight: 900; margin: 16px 0 10px; line-height: 1.2; }
+  .hero p { font-size: 15px; line-height: 1.5; color: var(--muted); font-weight: 600; }
+  .badges { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+  .badge {
+    display: inline-flex; align-items: center; gap: 7px;
+    padding: 8px 12px; background: var(--surface);
+    border: 2px solid var(--ink-stroke); border-radius: 999px;
+    font-size: 13px; font-weight: 700;
+  }
+  .badge .material-symbols-rounded { font-size: 16px; color: var(--accent); }
+  .section-title {
+    max-width: 960px; margin: 0 auto 14px; padding: 0 24px;
+    font-size: 20px; font-weight: 800;
+  }
+  .team { max-width: 960px; margin: 0 auto; padding: 0 24px 40px; }
+  .team-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 20px;
+  }
+  .card {
+    background: var(--surface); border: 2.5px solid var(--ink-stroke);
+    border-radius: 22px; padding: 18px; box-shadow: 0 4px 14px rgba(45,45,68,0.06);
+  }
+  .card-name {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 18px; font-weight: 800; margin-bottom: 8px;
+  }
+  .card-dot {
+    width: 12px; height: 12px; border-radius: 50%; border: 1.5px solid var(--ink-stroke);
+  }
+  .card-linkedin {
+    display: inline-flex; align-items: flex-start; gap: 6px;
+    font-size: 13px; font-weight: 700; text-decoration: underline;
+    margin-bottom: 10px; word-break: break-all;
+  }
+  .card-linkedin .material-symbols-rounded { font-size: 16px; flex-shrink: 0; }
+  .card-blurb { font-size: 13.5px; line-height: 1.5; color: var(--muted); font-weight: 600; }
+  .footer-tagline {
+    text-align: center; font-size: 16px; font-weight: 800; color: var(--surface);
+    background: var(--primary); border-radius: 20px;
+    max-width: 960px; margin: 0 auto 32px; padding: 20px 24px;
+    border: 2.5px solid var(--ink-stroke);
+  }
+</style>
+</head>
+<body>
+  <a href="/" class="back-link">
+    <span class="material-symbols-rounded">arrow_back</span> Back to Oh Sheet!
+  </a>
+
+  <div class="hero">
+    <span class="hero-badge">About Oh Sheet!</span>
+    <h1>Five engineers, two weeks, one capstone: Oh Sheet.</h1>
+    <p>The team came together through the GauntletAI program and built Oh Sheet as their capstone project. In just two weeks, they turned the idea into a working product that transforms songs into playable piano sheet music.</p>
+    <div class="badges">
+      <span class="badge"><span class="material-symbols-rounded">groups_2</span> 5 engineers</span>
+      <span class="badge"><span class="material-symbols-rounded">school</span> GauntletAI capstone</span>
+      <span class="badge"><span class="material-symbols-rounded">schedule</span> Built in 2 weeks</span>
+    </div>
+  </div>
+
+  <div class="section-title">Meet the team</div>
+
+  <div class="team">
+    <div class="team-grid">
+      <div class="card">
+        <div class="card-name"><span class="card-dot" style="background:#FFB347"></span> Jack Jiang</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/jackbjiang/" target="_blank" style="color:#FFB347">
+          <span class="material-symbols-rounded">link</span> linkedin.com/in/jackbjiang
+        </a>
+        <div class="card-blurb">Senior full-stack engineer with 8 years of experience across product development, SRE, and workflow automation. Meme enthusiast and climbing addict.</div>
+      </div>
+
+      <div class="card">
+        <div class="card-name"><span class="card-dot" style="background:#6BCB77"></span> Luis Ramos</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/luis-ramos-usa" target="_blank" style="color:#6BCB77">
+          <span class="material-symbols-rounded">link</span> linkedin.com/in/luis-ramos-usa
+        </a>
+        <div class="card-blurb">Senior software engineer who architects enterprise solutions across stacks, platforms, and frameworks with an AI-first approach to development.</div>
+      </div>
+
+      <div class="card">
+        <div class="card-name"><span class="card-dot" style="background:#FF6F91"></span> Raq Robinson</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/robinsonraquel/" target="_blank" style="color:#FF6F91">
+          <span class="material-symbols-rounded">link</span> linkedin.com/in/robinsonraquel
+        </a>
+        <div class="card-blurb">Senior full-stack engineer who blends React frontend expertise with backend and systems thinking to build scalable, secure, and accessible platforms.</div>
+      </div>
+
+      <div class="card">
+        <div class="card-name"><span class="card-dot" style="background:#4DBFBF"></span> Kevin Chang</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/kevin-chihwei-chang/" target="_blank" style="color:#4DBFBF">
+          <span class="material-symbols-rounded">link</span> linkedin.com/in/kevin-chihwei-chang
+        </a>
+        <div class="card-blurb">Senior full-stack engineer with 13 years of startup experience building products end to end. Piano wizard, board game lover, and badminton junkie.</div>
+      </div>
+
+      <div class="card">
+        <div class="card-name"><span class="card-dot" style="background:#FFB347"></span> Ross Kuehl</div>
+        <a class="card-linkedin" href="https://www.linkedin.com/in/ross-kuehl/" target="_blank" style="color:#FFB347">
+          <span class="material-symbols-rounded">link</span> linkedin.com/in/ross-kuehl
+        </a>
+        <div class="card-blurb">Senior backend-focused software engineer with deep expertise in Python, cloud infrastructure, and distributed systems.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer-tagline">Oh Sheet! &mdash; Any song. Any learner. In seconds.</div>
+</body>
+</html>

--- a/frontend-v2/index.html
+++ b/frontend-v2/index.html
@@ -56,7 +56,7 @@
         <span class="hw-label">Get sheet music</span>
       </div>
     </div>
-    <p class="powered-by"><span class="powered-dot"></span>Powered by AI &nbsp;&middot;&nbsp; <a href="/about.html" style="color: inherit; text-decoration: underline; font-weight: 600;">About the team</a></p>
+    <p class="powered-by"><span class="powered-dot"></span>Powered by AI &nbsp;&middot;&nbsp; <a href="/about.html" class="about-link">About the team</a></p>
   </footer>
 </main>
 

--- a/frontend-v2/index.html
+++ b/frontend-v2/index.html
@@ -56,7 +56,7 @@
         <span class="hw-label">Get sheet music</span>
       </div>
     </div>
-    <p class="powered-by"><span class="powered-dot"></span>Powered by AI</p>
+    <p class="powered-by"><span class="powered-dot"></span>Powered by AI &nbsp;&middot;&nbsp; <a href="/about.html" style="color: inherit; text-decoration: underline; font-weight: 600;">About the team</a></p>
   </footer>
 </main>
 

--- a/frontend-v2/src/style.css
+++ b/frontend-v2/src/style.css
@@ -469,6 +469,9 @@ body[data-phase="complete"] .iframe-stub.tunechat {
   width: 6px; height: 6px; border-radius: 50%; background: var(--accent);
   display: inline-block;
 }
+.about-link {
+  color: inherit; text-decoration: underline; font-weight: 600;
+}
 
 /* ── Entry animations (staggered on load) ────────────────────── */
 .appbar { animation: fadeSlideDown .5s ease both; }


### PR DESCRIPTION
## Summary

Adds an About page to frontend-v2 (the live Vite SPA). PR #101 added the About screen to the old Flutter frontend which is no longer deployed.

### Changes

- **frontend-v2/assets/about.html** - Standalone page with team bios, LinkedIn links, and badges, styled to match the kawaii sticker aesthetic. Lives in Vite publicDir so it copies as-is to dist/about.html.
- **frontend-v2/index.html** - Added "About the team" link in the footer next to "Powered by AI".

### How it works

The backend serves everything from /app/static/ via FastAPI StaticFiles(html=True), so /about.html resolves automatically. No backend or Vite config changes needed.

## Test plan

- [ ] Deploy to QA and verify "About the team" link appears in the footer
- [ ] Click the link and verify the About page renders with all 5 team members
- [ ] Click "Back to Oh Sheet!" and verify it returns to the main page
- [ ] Verify LinkedIn links open correctly