### PR TITLE
docs(engrave): document engrave_backend + engraver_service_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,21 @@ OHSHEET_ANTHROPIC_API_KEY=
 # this via the env-scoped GitHub variable of the same name.
 # OHSHEET_TUNECHAT_TIMEOUT_SEC=300
 
+# --- Engrave stage ---
+# Backend selection: "local" (music21 → MusicXML + LilyPond → PDF, in-process)
+# or "remote_http" (POST MIDI to the oh-sheet-ml-pipeline service). Local is
+# the default and falls through to remote_http on EngraveLocalError (e.g.
+# missing LilyPond install). See README "Engraver service" section.
+# OHSHEET_ENGRAVE_BACKEND=local
+
+# URL of the oh-sheet-ml-pipeline HTTP engraver. Used when the backend is
+# remote_http or when the local backend falls through. The service is a
+# proprietary Oh Sheet component — see github.com/Oh-Sheet-Team/oh-sheet/issues/107
+# for the open-sourcing discussion. Self-hosters can run on the local
+# backend and leave this unset.
+# OHSHEET_ENGRAVER_SERVICE_URL=http://localhost:8080
+# OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC=60
+
 # --- Core infra ---
 # OHSHEET_REDIS_URL=redis://localhost:6379/0
 # OHSHEET_BLOB_ROOT=./blob

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - **AI transcription** — Spotify's Basic Pitch detects notes from audio; optional Demucs stem separation isolates instruments first
 - **Two-hand piano arrangement** — Melody goes to right hand, bass + harmony to left hand, with intelligent voice assignment
 - **Humanized playback** — Micro-timing, velocity dynamics, pedal marks, and articulations make it sound natural
-- **Publication-quality engraving** — MIDI is sent to the `oh-sheet-ml-pipeline` HTTP engraver service, which returns MusicXML for the result screen (PDF rendering is a client-side concern)
+- **Publication-quality engraving** — Default backend is in-process music21 → MusicXML + LilyPond → PDF; falls through to the `oh-sheet-ml-pipeline` HTTP service when LilyPond is missing or the local stack errors. See [Engraver service](#engraver-service)
 - **Interactive viewer** — OSMD renders notation in the browser with Tone.js playback and cursor sync
 - **Custom piano roll** — Canvas-based visualization with color-coded hands, Y-axis note labels, and tempo-synced beat grid
 - **Real-time progress** — WebSocket events stream pipeline status with kawaii mascot animations per stage
@@ -69,6 +69,23 @@ make frontend                 # Flutter Web on Chrome
 Open the app, paste a YouTube URL, and hit **Let's go!**
 
 OpenAPI docs: [localhost:8000/docs](http://localhost:8000/docs)
+
+## Engraver service
+
+The engrave stage has two backends, controlled by `OHSHEET_ENGRAVE_BACKEND`:
+
+- **`local` (default)** — music21 emits MusicXML in-process, LilyPond renders the PDF. Reads the structured `(PianoScore, ExpressionMap)` directly so chord symbols, dynamics, pedal marks, and per-note voices survive into the score. Requires `lilypond` on `PATH` for PDF output (MusicXML still works without it). System packages: `apt-get install lilypond` (Debian/Ubuntu) or `brew install lilypond` (macOS).
+- **`remote_http`** — POSTs MIDI bytes to the `oh-sheet-ml-pipeline` HTTP engraver service at `OHSHEET_ENGRAVER_SERVICE_URL` (default `http://localhost:8080`). Returns MusicXML only — no PDF. Used when `engrave_backend=remote_http` is set explicitly, or when the `local` backend raises `EngraveLocalError` (missing LilyPond, music21 emission failure) and falls through automatically.
+
+The `oh-sheet-ml-pipeline` service is currently a hosted/proprietary Oh Sheet component — not open source, no public Docker image. Self-hosters can run on the `local` backend without it. See [#107](https://github.com/Oh-Sheet-Team/oh-sheet/issues/107) for the open-sourcing discussion.
+
+Relevant env vars (all listed in `.env.example`):
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `OHSHEET_ENGRAVE_BACKEND` | `local` | `local` or `remote_http` |
+| `OHSHEET_ENGRAVER_SERVICE_URL` | `http://localhost:8080` | URL for the `oh-sheet-ml-pipeline` service |
+| `OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC` | `60` | Per-request timeout for the HTTP engraver |
 
 ## How It Works
 
@@ -124,7 +141,8 @@ backend/
 │   ├── transcribe.py        # Basic Pitch (ONNX) + beat tracking
 │   ├── arrange.py           # Two-hand piano reduction
 │   ├── humanize.py          # Rule-based expression
-│   └── ml_engraver_client.py # HTTP client for the oh-sheet-ml-pipeline engraver (MIDI → MusicXML)
+│   ├── engrave_local.py     # music21 → MusicXML + LilyPond → PDF (default)
+│   └── ml_engraver_client.py # HTTP client for oh-sheet-ml-pipeline (remote_http fallback)
 ├── jobs/
 │   ├── manager.py           # In-memory job state + WebSocket pub/sub
 │   ├── runner.py            # Pipeline orchestration
@@ -300,7 +318,7 @@ See `CONTRIBUTING.md` for detailed guidelines.
 | Backend         | Python 3.10+, FastAPI, Pydantic v2                  |
 | Transcription   | Basic Pitch (ONNX), Demucs (stem separation)        |
 | Arrangement     | Custom Python (quantization, voice assignment)       |
-| Engraving       | oh-sheet-ml-pipeline (HTTP service: MIDI → MusicXML), pretty_midi |
+| Engraving       | music21 + LilyPond (in-process, default); oh-sheet-ml-pipeline HTTP service as fallback; pretty_midi |
 | Frontend        | Flutter 3.19+ (Web + Mobile)                        |
 | Sheet Viewer    | OpenSheetMusicDisplay (OSMD), Tone.js               |
 | Deployment      | Docker Compose, GCP VM, GitHub Actions               |


### PR DESCRIPTION
## Summary

Closes #104. Partially addresses #105 (the open-sourcing question is tracked separately in #107).

#103 made local engrave the default (music21 → MusicXML + LilyPond → PDF, with automatic fallthrough to the remote `oh-sheet-ml-pipeline` service on `EngraveLocalError`), but the docs and `.env.example` still described the prior remote-only architecture. This PR catches the docs up.

- **`.env.example`**: adds `OHSHEET_ENGRAVE_BACKEND`, `OHSHEET_ENGRAVER_SERVICE_URL`, `OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC` (commented out — defaults unchanged).
- **`README.md`**:
  - New "Engraver service" section explaining the `local` (default) and `remote_http` backends, the LilyPond install requirement for PDF, and the proprietary status of `oh-sheet-ml-pipeline` (linked to #107).
  - Features bullet (line 35) updated from "MIDI sent to the engraver service" to the local-first reality.
  - Backend file tree (line 127) now lists `engrave_local.py` alongside `ml_engraver_client.py`.
  - Tech Stack table (line 303) now lists music21 + LilyPond as the primary engraver, with the HTTP service as fallback.

This rebased branch contains only doc changes — the music21 fallback code my earlier commit added has been dropped because #103 already shipped a strictly better implementation in `backend/services/engrave_local.py`.

## Test plan

- [x] `make lint` — clean (ruff + flutter analyze)
- [ ] Spot-check: README "Engraver service" section renders correctly on github.com