### PR TITLE
docs: engraver self-hosting gap + RFC for publishing ml-pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,29 @@ OHSHEET_ANTHROPIC_API_KEY=
 # this via the env-scoped GitHub variable of the same name.
 # OHSHEET_TUNECHAT_TIMEOUT_SEC=300
 
+# --- ML engraver service (oh-sheet-ml-pipeline) ---
+# audio_upload and midi_upload jobs always route their engrave step to an
+# external HTTP service: POST {url}/engrave with raw MIDI bytes returns
+# raw MusicXML bytes. There is NO local fallback — if this service is
+# unreachable or returns a stub-sized payload, the job hard-fails.
+#
+# The service itself (`oh-sheet-ml-pipeline`) is currently a hosted-only
+# dependency: there is no public Docker image and no published source
+# yet. See GitHub issue #105 for the self-hosting gap and #107 for the
+# RFC tracking how/whether to publish it.
+#
+# Self-hosters today have three options:
+#   1. Run only the `sheet_only`/MIDI-input variants that don't reach
+#      engrave-via-ML (limited utility).
+#   2. Stand up a service that implements the same contract on :8080
+#      (POST /engrave, MIDI bytes → MusicXML bytes, > 500 bytes).
+#   3. Wait for #107 to land.
+#
+# docker-compose.prod.yml requires this var and refuses to start without
+# it. docker-compose.yml (dev) leaves it unset → defaults to localhost.
+# OHSHEET_ENGRAVER_SERVICE_URL=http://localhost:8080
+# OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC=60
+
 # --- Core infra ---
 # OHSHEET_REDIS_URL=redis://localhost:6379/0
 # OHSHEET_BLOB_ROOT=./blob

--- a/README.md
+++ b/README.md
@@ -193,6 +193,46 @@ docker compose up -d
 
 See `.github/workflows/deploy.yml` and `docker-compose.yml` for deployment details.
 
+### External engraver service (`oh-sheet-ml-pipeline`)
+
+The `engrave` stage for `audio_upload` and `midi_upload` jobs is **not**
+performed in this repo. The orchestrator POSTs the humanized MIDI to an
+external HTTP service (`POST {OHSHEET_ENGRAVER_SERVICE_URL}/engrave`,
+MIDI bytes in → MusicXML bytes out) implemented by the
+`oh-sheet-ml-pipeline` project. See `backend/services/ml_engraver_client.py`
+for the wire contract and `backend/config.py` for the settings.
+
+**There is no local fallback.** If the service is unreachable, returns
+a non-2xx, or sends back a stub-sized response (< 500 bytes), the job
+fails with `MLEngraverError`. The retry loop tries 3 attempts with
+exponential backoff for transient errors only — it is the same service,
+not a fallback path.
+
+**Self-hosting status (as of this writing):** `oh-sheet-ml-pipeline`
+is a hosted-only dependency — no public source repo, no published
+Docker image. External contributors who clone Oh Sheet cannot run the
+full audio/MIDI pipeline end-to-end yet. See
+[issue #105](https://github.com/Oh-Sheet-Team/oh-sheet/issues/105) for
+the documentation gap and
+[issue #107](https://github.com/Oh-Sheet-Team/oh-sheet/issues/107) for
+the publishing RFC.
+
+| Job variant     | Reaches ML engraver? | Self-hostable today? |
+| --------------- | -------------------- | -------------------- |
+| `audio_upload`  | Yes                  | No                   |
+| `midi_upload`   | Yes                  | No                   |
+| `title_lookup`  | Only if TuneChat fails (falls through to ML engraver) | Partial — works fully when `OHSHEET_TUNECHAT_ENABLED=true` and TuneChat resolves |
+| `full` / others | Yes                  | No                   |
+
+Until #107 ships, the practical self-hosting options are: (a) point
+`OHSHEET_ENGRAVER_SERVICE_URL` at any service that honours the contract
+above, or (b) restrict usage to TuneChat-resolved title-lookup jobs.
+
+`docker-compose.prod.yml` requires `OHSHEET_ENGRAVER_SERVICE_URL` to be
+set (`${VAR:?}` syntax — compose refuses to start without it).
+`docker-compose.yml` (dev) does not pass this through, so a local
+`make backend` defaults to `http://localhost:8080`.
+
 `make help` lists every target. Useful overrides:
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,3 +98,50 @@ Both VMs share the same firewall tag (`oh-sheet-vm`) so the existing rules on po
 | Prod        | `oh-sheet.duckdns.org`    | DuckDNS A record → `104.196.254.221` |
 
 Caddy auto-provisions Let's Encrypt certificates on first deploy for whichever hostname the `DOMAIN` env var resolves to. If you later add a new environment or rename a domain, just update the env-scoped `DOMAIN` variable — no Caddyfile change required.
+
+## External engraver service (`oh-sheet-ml-pipeline`)
+
+The orchestrator container does **not** generate MusicXML itself. The
+engrave stage POSTs the humanized MIDI to an external HTTP service —
+`oh-sheet-ml-pipeline` — and surfaces the response as the MusicXML
+artifact. See `backend/services/ml_engraver_client.py` for the wire
+contract and retry policy.
+
+### Required configuration
+
+| Var | Required? | Default | Notes |
+|-----|-----------|---------|-------|
+| `OHSHEET_ENGRAVER_SERVICE_URL` | **Yes** in prod (compose refuses to start without it via `${VAR:?}`) | `http://localhost:8080` (dev only) | Base URL; the client appends `/engrave`. |
+| `OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC` | No | `60` | Per-attempt httpx timeout. |
+
+The orchestrator retries transient failures (timeouts, 5xx, transport
+errors) up to 3 times with exponential backoff. **There is no local
+fallback** — a sustained outage fails every `audio_upload` /
+`midi_upload` job. `title_lookup` jobs are first delegated to TuneChat
+when `OHSHEET_TUNECHAT_ENABLED=true`; if TuneChat fails or is disabled
+they fall through to the ML engraver and inherit the same dependency.
+
+### Self-hosting status
+
+`oh-sheet-ml-pipeline` is currently a hosted-only dependency. No public
+source repo, no published Docker image. This is a known gap tracked in:
+
+- [#105 — document engraver self-hosting story](https://github.com/Oh-Sheet-Team/oh-sheet/issues/105) (this section addresses that)
+- [#107 — RFC: how to publish `oh-sheet-ml-pipeline`](https://github.com/Oh-Sheet-Team/oh-sheet/issues/107) (open question; see `docs/rfc-ml-pipeline-publishing.md` if/when it lands)
+
+Operators standing up Oh Sheet outside the team's GCP project today
+have to either point `OHSHEET_ENGRAVER_SERVICE_URL` at a service that
+honours the same contract (`POST /engrave`, raw MIDI in → MusicXML
+bytes out, payload > 500 bytes) or restrict use to TuneChat-resolved
+title-lookup jobs.
+
+### Operational checks
+
+- The QA/prod orchestrator logs every call as `ml_engraver: POST <url>
+  bytes_in=<n> timeout=<s>s`. A burst of `MLEngraverTimeout` /
+  `MLEngraverUpstreamError` lines is the canonical "engraver is
+  degraded" signal.
+- Stub-sized responses (< 500 bytes) raise `MLEngraverStub` rather than
+  silently returning a blank score. If you see these, the engraver
+  service is up but running its in-tree placeholder model rather than
+  the real weights — re-check the deploy on the engraver side.

--- a/docs/rfc-ml-pipeline-publishing.md
+++ b/docs/rfc-ml-pipeline-publishing.md
@@ -1,0 +1,214 @@
+# RFC: Publishing `oh-sheet-ml-pipeline`
+
+**Status:** Draft — discussion document for issue [#107](https://github.com/Oh-Sheet-Team/oh-sheet/issues/107)
+**Author:** rfc-author (engraver-docs-fix team)
+**Date:** 2026-05-08
+**Related:** #104 (env var docs), #105 (self-hosting gap), #106 (local fallback), #107 (this RFC)
+
+---
+
+## 1. Context
+
+### What the engrave stage does today
+
+Oh Sheet's pipeline ends with an **engrave** step that converts a MIDI performance into MusicXML (which downstream tools render to a PDF). In the current `main`, the engrave step is implemented as a single HTTP call:
+
+- Code: `backend/services/ml_engraver_client.py` — `engrave_midi_via_ml_service()`
+- Caller: `backend/jobs/runner.py` line 504 (inline in the orchestrator, not a Celery worker)
+- Contract: `POST {OHSHEET_ENGRAVER_SERVICE_URL}/engrave`
+  - Request: raw MIDI bytes (`Content-Type: application/octet-stream`)
+  - Response: raw MusicXML bytes (200 OK)
+  - Error model: 4xx = client error (no retry), 5xx / timeout / transport = retry up to 3× with exponential backoff (0.5s base)
+  - Stub guard: any 200 response under 500 bytes is rejected as a placeholder
+  - Per-call timeout: `OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC` (default 60s)
+
+### Deployment shape
+
+Per `docker-compose.prod.yml`:
+
+- Orchestrator container reads `OHSHEET_ENGRAVER_SERVICE_URL` (declared `${VAR:?...}` so compose refuses to start with it unset)
+- The legacy `worker-engrave` Celery worker has been retired — engrave is inline in the orchestrator
+- The default in `backend/config.py` is `http://localhost:8080`, which is only meaningful in dev
+
+### The gap (issue #105 / #107)
+
+The `oh-sheet-ml-pipeline` service that satisfies this contract is **not publicly available** — no source repo, no published image, no docs. As a result, anyone trying to self-host Oh Sheet hits a hard failure at the engrave stage. Issue #107 tracks the decision of whether and how to publish it.
+
+### Verification note (please confirm)
+
+Issue #107's introduction states *"We've shipped an opt-in `music21`-based local fallback (`OHSHEET_ENGRAVER_LOCAL_FALLBACK=1`, see #106)."* In the current `main` branch I could not find:
+
+- An `OHSHEET_ENGRAVE_BACKEND` or `OHSHEET_ENGRAVER_LOCAL_FALLBACK` setting in `backend/config.py`
+- An `engrave_local.py` module in `backend/services/`
+- Any local-fallback branch in `backend/jobs/runner.py` — line 504 calls `engrave_midi_via_ml_service` unconditionally
+- Any `OHSHEET_ENGRAVE*` entries in `.env.example`
+
+The merged PR for #105 (per its body) "dropped" a music21 fallback because #103 was supposed to have shipped a better one — but neither appears in `main` today. **This RFC therefore treats the current state as "no local fallback" and asks the maintainer to confirm before any publication decision is finalized.** If a fallback does exist on a branch I missed, the user-impact rows below should be re-rated.
+
+---
+
+## 2. The four candidate options
+
+The four outcomes named in #107, restated in our own words:
+
+| # | Option | One-line description |
+|---|--------|----------------------|
+| A | Open-source repo + image | Public GitHub repo with build instructions and a published Docker image (with weights) |
+| B | Image-only | Pre-built Docker image freely runnable, source remains private |
+| C | Plugin protocol | Document the HTTP contract; ship a reference open-source impl (e.g. music21-only, no ML) but invite third-party engravers |
+| D | Status quo | Keep the service private; document explicitly that "remote engraver" is the only supported engrave path |
+
+These are not mutually exclusive — C is in particular composable with A, B, or D.
+
+---
+
+## 3. Decision matrix
+
+Each cell is rated **Low / Medium / High** with a short rationale. Effort and cost are *higher = worse*; supportability and user-impact-positive are *higher = better*; blocking risks are listed not rated.
+
+### 3.1 One-time effort (to ship)
+
+| Option | Rating | Notes |
+|--------|--------|-------|
+| A. Repo + image | **High** | Cleanup pass on private code, license review, CI for image build, repo hygiene (CONTRIBUTING, CODE_OF_CONDUCT, security policy), public issue triage setup. |
+| B. Image only | **Medium** | Image build CI + a public registry namespace. No public source review, but still need a basic threat model since users run it. |
+| C. Plugin protocol | **Medium–High** | Spec writing (OpenAPI), reference implementation, conformance test suite. Lower if reference impl is just music21 wrapping. Higher if we also want to ship our service under the protocol. |
+| D. Status quo | **Low** | Edit README + deployment.md to clearly say "engrave requires a hosted service that is not currently public; self-hosting is not supported end-to-end." |
+
+### 3.2 Ongoing cost / maintenance
+
+| Option | Rating | Notes |
+|--------|--------|-------|
+| A. Repo + image | **High** | Issues, PRs, security disclosures, weight/image releases tied to model retrains, semver for the HTTP contract. |
+| B. Image only | **Medium** | Image release cadence, CVE patching of the base image, but no PR review burden. |
+| C. Plugin protocol | **Medium** | Spec versioning + reference impl maintenance. Compatibility breakage is the main risk — every contract change is a community-coordination event. |
+| D. Status quo | **Low** | None beyond what we already do. |
+
+### 3.3 Supportability (can the maintainer credibly back this?)
+
+| Option | Rating | Notes |
+|--------|--------|-------|
+| A. Repo + image | **Low–Medium** | Public expectations are high; "best-effort" is a hard sell once the repo is public. Needs a written support policy day one. |
+| B. Image only | **Medium** | Easier to scope: "we publish images, we patch on a cadence, no source contributions accepted." |
+| C. Plugin protocol | **High** | Maintainer only owns the contract + reference impl. Quality of any third-party engraver is its author's problem. |
+| D. Status quo | **High** | Nothing changes. |
+
+### 3.4 User impact — closes the self-hosting gap?
+
+| Option | Rating | Notes |
+|--------|--------|-------|
+| A. Repo + image | **High** | Full parity self-hosting, including the ability to fork and modify. |
+| B. Image only | **High** | Full parity self-hosting; no source access but most self-hosters don't need it. GPU requirements (if any) become the next bottleneck. |
+| C. Plugin protocol | **Medium** | Solves the "I can self-host" question. Does not solve the "I can self-host with parity output quality" question unless someone publishes a parity-quality plugin (which, today, only the maintainer could). |
+| D. Status quo | **Low** | Honest about the gap, but does not close it. Without a local fallback (see §1), self-hosters have no working engrave path at all. |
+
+### 3.5 Blocking risks
+
+| Option | Risks |
+|--------|-------|
+| A. Repo + image | Model-weight licensing (open question Q1). Threat model for code+image (Q3). Security disclosure inbox needed. |
+| B. Image only | Model-weight redistribution (Q1) — even without source, distributing weights triggers licensing review. Threat model for the running container (Q3). |
+| C. Plugin protocol | Risk of fragmentation: multiple incompatible plugins, version-skew bugs reported as Oh Sheet bugs. Reference impl quality sets the floor — too weak and the protocol looks like a fig leaf. |
+| D. Status quo | Continued community frustration (#105-class issues will keep arriving). Reputational risk of an "open source" project that can't be self-hosted. |
+
+---
+
+## 4. Open questions from #107 — what we'd need to answer them
+
+For each question, what would unblock a decision and a concrete first step.
+
+### Q1. Model weights & licensing
+
+**To decide we need:**
+- Provenance audit of training data (what corpora, under what terms)
+- Whether weights can be redistributed (commercial vs. research-only, attribution requirements, share-alike clauses)
+- Whether weight licensing differs from code licensing — e.g. CC-BY-NC for weights with MIT for code
+
+**First step:** Internal training-data inventory. Until that's done, this RFC cannot recommend A or B with confidence. **Flagged as an open question, not an assertion.**
+
+### Q2. Hosting cost (if we run a public demo)
+
+**To decide we need:**
+- Per-engrave compute cost (GPU seconds × hourly rate, or CPU time if not GPU)
+- Expected volume from public traffic — hard to estimate without launching
+- Abuse model: is MIDI input cheap to validate? Can a malicious payload force expensive inference?
+
+**First step:** Measure p50/p95 engrave time and resource use under current production load (we already have prod data). Multiply by a plausible 10× public-traffic factor. If the answer is small, B can include a hosted demo; if not, B is "image only, BYO compute."
+
+### Q3. Security review
+
+**To decide we need:**
+- Threat model for the engrave HTTP endpoint:
+  - **Input validation:** untrusted MIDI parsing — is the MIDI parser hardened? Memory limits on track count / event count?
+  - **Resource exhaustion:** per-request CPU/GPU caps; concurrent-request limits
+  - **Output validation:** can a crafted input cause MusicXML output that exploits downstream LilyPond/music21? (Oh Sheet itself currently consumes the MusicXML directly, so this matters even before publication.)
+  - **Supply chain:** for B/A, what's the base image, what CVEs does it carry, who patches?
+- Disclosure policy (private email vs. GitHub Security Advisories)
+
+**First step:** Half-day threat-modeling session covering the four items above. Output is a one-page SECURITY.md skeleton.
+
+### Q4. Maintenance commitment
+
+**To decide we need:**
+- Maintainer time budget — hours/week the project can sustain on public engraver issues
+- Support tiers we're willing to publish: "best-effort", "monthly image releases", "semver'd HTTP contract", "none of the above"
+- Backport policy for security fixes
+
+**First step:** Maintainer answers two questions in writing: *"How many hours/month am I willing to spend on this?"* and *"What happens to a P1 bug filed against the published image at 11pm on a Friday?"* The answers gate A vs. B vs. C.
+
+### Q5. Plugin protocol — would a contract be more useful than a service?
+
+**To decide we need:**
+- Survey: would actual self-hosters in #105 / #107 use a plugin slot, or do they want our exact engraver?
+- A draft contract (the one we already implement) — does it generalize to non-ML engravers (rules-based, pure music21, third-party SaaS)?
+- Reference implementation choice: pure music21? a thin shim over an external service? both?
+
+**First step:** Draft an OpenAPI spec for `POST /engrave` (we have all the inputs already — see §1) and circulate on #107 for feedback. **This step is cheap, useful in every option, and unblocks A/B/D as well.**
+
+---
+
+## 5. Recommended option (starting point for discussion)
+
+> This is a recommendation for *what to discuss first*, not a final decision. The maintainer (and #107 commenters) should push back freely.
+
+**Recommendation: a sequenced combination of D + C, with B as the explicit goal.**
+
+Concretely, in order:
+
+1. **Immediate (this week):** Land the issue-#105 docs (task #7) so users know the engrave path is remote-only and self-hosting is currently not supported end-to-end. Honest framing reduces pressure while bigger questions are answered. *(This corresponds to Option D as a near-term posture, not a final destination.)*
+2. **Short term (next 1–2 sprints):** Publish the `POST /engrave` HTTP contract as an OpenAPI spec in this repo (Option C step 1). This is cheap, helps every other option, and lets motivated contributors plug in *something* (even a non-ML music21 engraver) without blocking on licensing review. If a community-built music21 plugin lands, the self-hosting gap is partially closed without any decision on weight licensing.
+3. **Medium term (gated on Q1 + Q3):** Once the training-data audit and threat model are done, default-target Option B (image-only). B closes the user-impact gap without committing to a public-source maintenance burden, and it is the option where the answers to Q1 and Q3 are most likely to land in our favor.
+4. **Re-evaluate Option A only if** there's clear contributor demand and Q4 (maintenance commitment) admits an honest "yes."
+
+### Why this ordering
+
+- **D first** is not a destination, it's truth-in-advertising while we work on a real fix. The current ambiguity is itself harmful.
+- **C second** has the best cost/benefit: low effort, high optionality, useful regardless of what we eventually pick for the service.
+- **B as the eventual default** because it closes the gap that motivated #105 and #107 with the smallest ongoing cost we can credibly support.
+- **A deferred** because public source brings the highest maintenance cost and the most licensing exposure (Q1 applies to weights either way, but A also exposes training/inference code).
+
+### Why *not* to lock this in yet
+
+- Q1 (model-weight licensing) could rule out B. If weights cannot be redistributed, B and A are both off the table and the answer is "C with a non-ML reference impl, plus D."
+- Q4 (maintenance commitment) could rule out A. If the maintainer's honest answer is "<2 hours/week," then A's upkeep cost is unacceptable and B is the ceiling.
+- A reasonable counter-argument: skip C and go straight to B once Q1/Q3 clear. Worth debating on the issue.
+
+---
+
+## 6. What this RFC is not
+
+- Not a final decision. The maintainer owns option selection.
+- Not a claim about training-data licensing. Q1 is genuinely open.
+- Not a commitment to any timeline. Step 1 is the only thing already in flight (task #7).
+- Not a substitute for the threat model in Q3 — sketching what we'd review is not the same as doing the review.
+
+---
+
+## 7. Asks from commenters on #107
+
+If you're reading this from the linked issue, the most useful inputs you can leave are:
+
+1. Your self-hosting use case and which option (A/B/C/D) actually unblocks it
+2. Experience publishing model weights — pitfalls, license templates that worked
+3. Opinions on the OpenAPI-spec-first step (§5 step 2): useful, or premature?
+4. Whether you'd build/ship a plugin if the protocol were public


### PR DESCRIPTION
## Summary
- Closes documentation gap raised in #105: adds `OHSHEET_ENGRAVER_SERVICE_URL` to `.env.example`, adds an "External engraver service" subsection to `README.md` with a per-variant self-hostability matrix, and adds an operator-focused section to `docs/deployment.md`.
- Seeds the longer-term decision tracked in #107: new `docs/rfc-ml-pipeline-publishing.md` with a 4-option × 5-column decision matrix, per-question next steps for each of #107's open questions, and a tentative D→C→B recommendation framed as a starting point for discussion.

## Verification note
Both authoring agents independently verified that **no local engrave fallback exists on `main`** (no `OHSHEET_ENGRAVE_BACKEND` / `OHSHEET_ENGRAVER_LOCAL_FALLBACK` setting, no `engrave_local.py`, `runner.py:504` calls the ML service unconditionally). #107's body references one as already shipped — that doesn't match `main`. The docs in this PR describe the actual current state; if a fallback is on an unmerged branch, the README matrix and RFC user-impact rows should be re-rated after it lands.

## Test plan
- [ ] Render `README.md` and `docs/deployment.md` on GitHub to confirm tables format correctly
- [ ] Confirm `OHSHEET_ENGRAVER_SERVICE_URL` line in `.env.example` doesn't conflict with downstream tooling that reads it
- [ ] Sanity-check the RFC's "current architecture" §1 against `backend/services/ml_engraver_client.py` and `docker-compose.prod.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)