### PR TITLE
qa → main: engraver protocol v0.1 OpenAPI spec

### DIFF
--- a/docs/engraver-protocol/README.md
+++ b/docs/engraver-protocol/README.md
@@ -1,0 +1,92 @@
+# Engraver Protocol
+
+A frozen HTTP contract for a third-party engraver service. Implement
+this and Oh Sheet can route its `remote_http` engrave stage to your
+service instead of the proprietary `oh-sheet-ml-pipeline`.
+
+The current version is **v0.1** ([`openapi.yaml`](./openapi.yaml)).
+
+## Why this exists
+
+Oh Sheet has two engrave backends ([`OHSHEET_ENGRAVE_BACKEND`](../../backend/config.py)):
+
+- `local` — `music21` → MusicXML, `LilyPond` → PDF, in-process. Default.
+- `remote_http` — POST MIDI bytes to an external HTTP service that
+  returns MusicXML.
+
+The `remote_http` mode currently calls Oh Sheet's hosted, proprietary
+`oh-sheet-ml-pipeline`. Self-hosters can't run it, which leaves an
+output-quality gap relative to the hosted product (see [#107] and the
+[RFC]).
+
+This protocol freezes the HTTP contract so anyone can build their own
+engraver — a different ML model, a `music21`-only renderer, an Audiveris
+wrapper, whatever — and Oh Sheet will route to it without code changes.
+
+## Who this is for
+
+- **Self-hosters** who want output-quality parity with the hosted
+  pipeline today, before any decision lands on whether/how to publish
+  `oh-sheet-ml-pipeline` itself.
+- **Researchers** experimenting with alternative engraver models who
+  want a production pipeline to plug into.
+- **Maintainers**, as a stable target the in-tree client and tests can
+  be written against.
+
+## How Oh Sheet calls the protocol
+
+The canonical client lives at
+[`backend/services/ml_engraver_client.py`](../../backend/services/ml_engraver_client.py).
+It is the source of truth — if the spec disagrees, the spec is the bug.
+
+Configure Oh Sheet to point at your service:
+
+```bash
+export OHSHEET_ENGRAVE_BACKEND=remote_http
+export OHSHEET_ENGRAVER_SERVICE_URL=http://your-engraver:8080
+export OHSHEET_ENGRAVER_SERVICE_TIMEOUT_SEC=60   # optional
+```
+
+## Conformance checklist
+
+A v0.1-conforming implementation:
+
+1. Accepts `POST /engrave` with `Content-Type: application/octet-stream`
+   and a raw Standard MIDI File body.
+2. Returns 200 with a MusicXML 3.x document **longer than 500 bytes** on
+   success. (Oh Sheet refuses smaller 200 responses as stub
+   placeholders.)
+3. Returns a 4xx on invalid input or a deterministic engraving failure.
+   These will not be retried.
+4. Returns a 5xx on transient failure. These will be retried up to three
+   times by Oh Sheet's client with exponential backoff (0.5s base).
+5. Treats the same MIDI input as deterministic across the retry window —
+   non-deterministic output during retry surfaces as flaky downstream
+   rendering.
+
+A minimal conformance smoke test is to POST a MusicXML round-trip
+fixture's MIDI rendering and confirm the response parses as valid
+MusicXML 3.x. Oh Sheet does not currently ship a stand-alone
+conformance harness; if you build one, please open a PR.
+
+## Versioning policy
+
+- **v0.x** is unstable. Breaking changes are allowed if they unblock
+  one of the [RFC] open questions, but each one bumps the minor version
+  and is called out in the changelog below.
+- **v1.0** will be cut once a v0.x has been deployed against at least
+  one third-party engraver and one significant gap has been identified
+  and fixed (or explicitly accepted as a v1 limitation). No date
+  committed.
+- Evolution from "MIDI in / MusicXML out" to "structured `PianoScore` in"
+  is tracked as Q5 in the [RFC] and would land as v0.2+. v0.1 is the
+  byte-for-byte freeze of what the client speaks today.
+
+## Changelog
+
+- **v0.1.0** — Initial freeze. `POST /engrave`, MIDI bytes in, MusicXML
+  bytes out. Matches the contract of `oh-sheet-ml-pipeline` as of
+  [`backend/services/ml_engraver_client.py`](../../backend/services/ml_engraver_client.py).
+
+[#107]: https://github.com/Oh-Sheet-Team/oh-sheet/issues/107
+[RFC]: ../rfc-ml-pipeline-publishing.md

--- a/docs/engraver-protocol/openapi.yaml
+++ b/docs/engraver-protocol/openapi.yaml
@@ -1,0 +1,139 @@
+openapi: 3.1.0
+info:
+  title: Oh Sheet Engraver Protocol
+  version: 0.1.0
+  summary: HTTP contract for a third-party engraver service.
+  description: |
+    Oh Sheet's `engrave_backend = "remote_http"` mode (and the
+    `remote_http_fallback` route from the local backend) POSTs MIDI bytes
+    to an engraver service and expects MusicXML bytes in return.
+
+    This document freezes that contract as **v0.1** so a third party can
+    implement an engraver without having to read Oh Sheet's source. The
+    canonical client implementation is
+    [`backend/services/ml_engraver_client.py`](https://github.com/Oh-Sheet-Team/oh-sheet/blob/main/backend/services/ml_engraver_client.py);
+    if the spec and the client disagree, the client is the source of
+    truth and the spec is a bug.
+
+    **Scope of v0.1.** The contract exposes a single endpoint that takes
+    raw MIDI bytes in and returns raw MusicXML bytes out. It does *not*
+    yet pass the structured `PianoScore` / `ExpressionMap` types that
+    flow through the rest of Oh Sheet's pipeline — that evolution is
+    tracked as Q5 in the parent
+    [RFC](../rfc-ml-pipeline-publishing.md) and would land as v0.2+.
+  contact:
+    name: Oh Sheet
+    url: https://github.com/Oh-Sheet-Team/oh-sheet
+  license:
+    name: MIT
+    url: https://github.com/Oh-Sheet-Team/oh-sheet/blob/main/LICENSE
+
+servers:
+  - url: http://localhost:8080
+    description: Default `OHSHEET_ENGRAVER_SERVICE_URL` for local development.
+
+paths:
+  /engrave:
+    post:
+      summary: Convert MIDI bytes to MusicXML.
+      description: |
+        The request body is a raw Standard MIDI File (SMF), sent as
+        `application/octet-stream`. The response body is a MusicXML 3.x
+        document, sent as `application/vnd.recordare.musicxml+xml`.
+
+        **Idempotency.** Implementations SHOULD treat the same MIDI input
+        as deterministic — Oh Sheet's client retries transient failures
+        (timeout, 5xx) up to three times with exponential backoff, and a
+        non-deterministic output during retry would surface as flaky
+        downstream rendering.
+
+        **Stub-detection.** Oh Sheet's client refuses any 200 response
+        whose body is shorter than 500 bytes, treating it as the in-tree
+        placeholder skeleton rather than a real transcription. A
+        conforming implementation MUST therefore return either a real
+        MusicXML document of substantive size or an error status — never
+        a tiny 200 placeholder.
+      operationId: engrave
+      requestBody:
+        required: true
+        description: Raw Standard MIDI File bytes.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              description: SMF (Standard MIDI File) bytes. No multipart wrapping.
+      responses:
+        "200":
+          description: Engraving succeeded. Body is a MusicXML document.
+          content:
+            application/vnd.recordare.musicxml+xml:
+              schema:
+                type: string
+                format: binary
+                description: |
+                  MusicXML 3.x document. Must be longer than 500 bytes
+                  (see "Stub-detection" above).
+        "400":
+          description: |
+            The request body could not be parsed as MIDI, or violated a
+            documented input constraint (e.g. exceeded a maximum size
+            the server enforces). Deterministic — Oh Sheet's client does
+            not retry 4xx.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "invalid MIDI: unexpected EOF in track 0"
+        "413":
+          description: |
+            Request body exceeded the server's size limit. Deterministic;
+            not retried.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "MIDI input exceeds 5 MiB limit"
+        "422":
+          description: |
+            MIDI parsed but engraving failed at the model/post-processing
+            layer (e.g. empty track, unsupported time signature in this
+            implementation). Deterministic; not retried.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "no notes detected in input"
+        "500":
+          description: |
+            Unhandled server error. Oh Sheet's client treats 5xx as
+            transient and retries up to three times before surfacing.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "internal error"
+        "502":
+          description: |
+            Upstream dependency failure (e.g. inference backend
+            unreachable). Treated as transient; retried.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "503":
+          description: |
+            Service overloaded or starting up. Treated as transient;
+            retried.
+          content:
+            text/plain:
+              schema:
+                type: string
+        "504":
+          description: |
+            Request timed out at an upstream proxy. Treated as transient;
+            retried.
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/docs/rfc-ml-pipeline-publishing.md
+++ b/docs/rfc-ml-pipeline-publishing.md
@@ -58,13 +58,13 @@ Options are not mutually exclusive. C is compatible with any of A/B/D (publishin
 
 **What we'd need to know:** What's the minimum HTTP contract a third-party engraver would need to implement? `POST /engrave` with MIDI in / MusicXML out is the obvious starting point, but: do we want to pass structured `PianoScore` instead of MIDI (preserves dynamics/pedal/voices, see §1)? Versioned protocol? Capability negotiation?
 
-**First step:** Extract the current `oh-sheet-ml-pipeline` endpoint into an OpenAPI spec, freeze it as v0.1, publish under `docs/engraver-protocol/`. This is cheap and preserves optionality regardless of A/B/D outcome.
+**First step (landed):** Extracted the current `oh-sheet-ml-pipeline` endpoint into an OpenAPI spec, frozen as v0.1, published under [`docs/engraver-protocol/`](./engraver-protocol/). The structured-input evolution remains open as a v0.2+ question.
 
 ## 4. Recommendation (starting point for discussion, not a decision)
 
 Sequence: **C → consider B**.
 
-1. **Land C immediately.** Publish the HTTP contract for `POST /engrave` as an OpenAPI spec. Cost: a few hours of work. Benefit: documents the existing extension point, preserves optionality for everything else, lets a motivated self-hoster build their own engraver today.
+1. **Land C immediately.** ✅ **Done** — see [`docs/engraver-protocol/`](./engraver-protocol/) for the v0.1 OpenAPI spec and conformance notes. Documents the existing extension point, preserves optionality for everything else, lets a motivated self-hoster build their own engraver today.
 
 2. **Answer Q1 + Q3 + Q4 before committing to B or A.** Specifically:
    - Q1 (training-data audit): if any dataset blocks redistribution, A and B are blocked until re-train.


### PR DESCRIPTION
Promotes PR #113 from qa to main. Single docs-only PR landing the v0.1 OpenAPI spec for `POST /engrave` under `docs/engraver-protocol/`, plus an RFC §4 update marking option C as done.

Already merged to qa via #113. See that PR for full context. Tracks #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)