### PR TITLE
chore: infra/CI/docs cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: ruff check backend tests
 
@@ -30,6 +31,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - run: mypy
 
@@ -41,6 +43,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: 'pip'
       - name: Install fluidsynth (system)
         run: |
           sudo apt-get update -qq
@@ -107,6 +110,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: 'pip'
       - run: pip install python-semantic-release
       - name: Validate config parses correctly
         shell: bash {0}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PYTHON       ?= python3
 
 DART_DEFINE := $(if $(API_BASE_URL),--dart-define=API_BASE_URL=$(API_BASE_URL),)
 
-.PHONY: help install install-backend install-basic-pitch install-pop2piano install-demucs install-amt-apc install-eval install-frontend backend build rebuild frontend test test-backend test-e2e eval lint typecheck clean require-flutter require-port-free require-base-image
+.PHONY: help install install-backend install-basic-pitch install-pop2piano install-demucs install-amt-apc install-eval install-frontend backend build rebuild frontend test test-backend test-e2e eval eval-refine lint typecheck clean require-flutter require-port-free require-base-image
 
 help:
 	@echo "Oh Sheet — make targets"

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ as a stateless worker that takes an `OrchestratorCommand` and returns a
 - `POST /v1/stages/condense`
 - `POST /v1/stages/transform`
 - `POST /v1/stages/humanize`
-- `POST /v1/stages/engrave`
 
 ## TuneChat Integration
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,17 +1,1 @@
-# ohsheet_app
-
-A new Flutter project.
-
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+This directory hosts the legacy Flutter app for Oh Sheet. The production frontend served by the backend Docker image is the vanilla-JS SPA in `frontend-v2/` — point new work there. See the top-level `README.md` for setup and run instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
@@ -272,7 +272,7 @@ ignore = [
 "backend/contracts.py" = ["F401"]  # names re-exported for `from backend.contracts import …`
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 packages = ["backend"]
 warn_return_any = false
 warn_unused_configs = true


### PR DESCRIPTION
## Summary

Small, surgical infra/CI/docs fixes — none affect runtime behavior.

- **Makefile:** add `eval-refine` to the `.PHONY` list (target existed at line ~170 but was missing from the declaration).
- **pyproject.toml:** pin `ruff target-version` and `mypy python_version` to `py312` / `"3.12"` to match the Dockerfile runtime. Lower of CI (3.13) and prod (3.12-slim) is the safe target.
- **CI:** add `cache: 'pip'` to all four `actions/setup-python@v5` invocations in `.github/workflows/ci.yml` (backend-lint, backend-typecheck, backend-test, semantic-release-config) for faster installs.
- **README.md:** drop the stale `POST /v1/stages/engrave` bullet — that endpoint isn't registered in `backend/api/routes/stages.py`. The actual exposed stages are ingest / transcribe / arrange / condense / transform / humanize. (Note: the original task description suggested removing condense/transform too; verifying against `stages.py` showed those endpoints DO exist, so I left them and only removed `engrave`.)
- **frontend/README.md:** replace the generic `flutter create` boilerplate with a short note explaining this is the legacy Flutter app and pointing readers at `frontend-v2/` (the production SPA, which the Dockerfile actually builds and serves) and the top-level README.

## Test plan

- [x] `make lint` passes locally (ruff + flutter analyze, both clean)
- [ ] CI green on this PR
- [ ] Visual sanity-check the README diff renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)