### PR TITLE
chore: frontend null-safety + a11y fixes

### DIFF
--- a/frontend-v2/src/main.js
+++ b/frontend-v2/src/main.js
@@ -61,11 +61,13 @@ let unsubscribeWs = null; // close the previous job's WS on each re-submit
 // (e.g. the "Turn any song..." tagline is irrelevant once the job's
 // done — target `body[data-phase="complete"]` in style.css to hide it).
 store.onChange((phase) => {
-  card.classList.add("morph");
-  setTimeout(() => card.classList.remove("morph"), 450);
+  if (card) {
+    card.classList.add("morph");
+    setTimeout(() => card.classList.remove("morph"), 450);
+  }
   swapMascot(phase);
   document.body.setAttribute("data-phase", phase.name);
-  renderPhase(card, phase, handlers);
+  if (card) renderPhase(card, phase, handlers);
 });
 
 // ── Handlers bridge views → api ─────────────────────────────────

--- a/frontend-v2/src/style.css
+++ b/frontend-v2/src/style.css
@@ -257,7 +257,7 @@ body.legal-modal-open {
   border-radius: 999px; font: inherit; background: var(--surface); color: var(--ink);
 }
 .field input::placeholder { color: var(--on-surface-variant); }
-.field input:focus { outline: none; border-color: var(--accent); }
+.field input:focus { outline: 2px solid var(--accent); outline-offset: 2px; border-color: var(--accent); }
 .field .field-icon {
   position: absolute; left: 14px; top: 50%; transform: translateY(-50%);
   color: var(--ink); pointer-events: none;

--- a/frontend/lib/screens/result_screen.dart
+++ b/frontend/lib/screens/result_screen.dart
@@ -71,9 +71,12 @@ class _ResultScreenState extends State<ResultScreen> {
     });
   }
 
-  void _download(String kind) {
+  Future<void> _download(String kind) async {
     final url = widget.api.artifactUrl(widget.job.jobId, kind);
-    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
   }
 
   @override
@@ -196,10 +199,12 @@ class _ResultScreenState extends State<ResultScreen> {
         if (_sourceUrl case final url?) ...[
           const SizedBox(height: 8),
           GestureDetector(
-            onTap: () => launchUrl(
-              Uri.parse(url),
-              mode: LaunchMode.externalApplication,
-            ),
+            onTap: () async {
+              final uri = Uri.parse(url);
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(uri, mode: LaunchMode.externalApplication);
+              }
+            },
             child: const Row(
               mainAxisSize: MainAxisSize.min,
               children: [


### PR DESCRIPTION
## Summary
Three small, independent improvements to the frontends:

- **`frontend-v2/src/main.js`** — null-guard `card` in `store.onChange` so the page doesn't crash if `#card` is missing (e.g., on a page that loads `main.js` but lacks the markup). The path was already null-safe for `mascot`; this matches.
- **`frontend-v2/src/style.css:260`** — `.field input:focus` previously set `outline: none`, removing the focus indicator. Restored a 2px outline using `--accent` (WCAG 2.4.7 — Focus Visible).
- **`frontend/lib/screens/result_screen.dart:76,200`** — Gate `launchUrl` calls with `canLaunchUrl`. Prevents silent failures and exceptions on unsupported URL schemes returned by the API. `_download` becomes async but call sites already used arrow callbacks so no other refactor needed.

## Findings skipped on review
A scout suggested several other changes that didn't hold up on inspection:
- `views.js` `urlInput && urlInput.value.trim()` already short-circuits safely.
- File picker uses a real `<button>` element — browsers handle Enter/Space natively, so adding a keydown listener would be redundant.
- The `onChanged: (_) => setState(() {})` calls in `upload_screen.dart` are NOT redundant — they drive `canSubmit` (line 192 reads `_titleController.text`) and live `errorText` for the YouTube field (line 375 reads `_youtubeValidationError`).

## Test plan
- [ ] CI lint + tests pass
- [ ] frontend-v2: focus a text input — visible accent outline appears
- [ ] frontend-v2: page renders normally (card guard is defensive only)
- [ ] Flutter: tapping a download button still opens the URL externally on devices that support it

🤖 Generated with [Claude Code](https://claude.com/claude-code)