### PR TITLE
chore: backend safety + validation fixes

### DIFF
--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -166,9 +166,12 @@ def download_artifact(
     try:
         data = blob.get_bytes(uri)
     except (FileNotFoundError, ValueError) as exc:
+        # Don't leak filesystem paths or internal error types to clients —
+        # log the full exception server-side and return a generic message.
+        log.exception("artifacts: failed to read %s/%s from blob store", job_id, kind)
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to read artifact: {exc}",
+            detail="Failed to read artifact",
         ) from exc
 
     return Response(

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -160,6 +160,10 @@ async def create_job(
         source_filename = body.audio.source_filename
     elif body.midi is not None:
         source_filename = body.midi.source_filename
+    # Normalize: strip surrounding whitespace and treat empty/whitespace-only
+    # values as absent so downstream stages see a clean optional field.
+    if source_filename is not None:
+        source_filename = source_filename.strip() or None
 
     if body.audio is not None:
         # Phase 8: cover_mode flips the variant from audio_upload to

--- a/backend/api/routes/uploads.py
+++ b/backend/api/routes/uploads.py
@@ -45,6 +45,11 @@ async def upload_audio(
             status_code=415,
             detail=f"Unsupported audio format: {ext!r}. Allowed: {sorted(AUDIO_FORMATS)}",
         )
+    if file.filename and len(file.filename) > 255:
+        raise HTTPException(
+            status_code=400,
+            detail="filename too long (max 255)",
+        )
 
     data = await file.read()
     digest = hashlib.sha256(data).hexdigest()
@@ -72,6 +77,11 @@ async def upload_midi(
         raise HTTPException(
             status_code=415,
             detail=f"Unsupported MIDI format: {ext!r}. Allowed: {sorted(MIDI_FORMATS)}",
+        )
+    if file.filename and len(file.filename) > 255:
+        raise HTTPException(
+            status_code=400,
+            detail="filename too long (max 255)",
         )
 
     data = await file.read()

--- a/backend/workers/interpret.py
+++ b/backend/workers/interpret.py
@@ -53,8 +53,13 @@ def run(job_id: str, payload_uri: str) -> str:
     blob = LocalBlobStore(settings.blob_root)
     envelope = blob.get_json(payload_uri)
 
-    txr = TranscriptionResult.model_validate(envelope["txr"])
-    prompt: str = envelope["prompt"]
+    raw_txr = envelope.get("txr")
+    if raw_txr is None:
+        raise ValueError("interpret envelope missing required field 'txr'")
+    prompt = envelope.get("prompt")
+    if prompt is None:
+        raise ValueError("interpret envelope missing required field 'prompt'")
+    txr = TranscriptionResult.model_validate(raw_txr)
     title_hint: str | None = envelope.get("title_hint")
     artist_hint: str | None = envelope.get("artist_hint")
 

--- a/backend/workers/refine.py
+++ b/backend/workers/refine.py
@@ -29,8 +29,12 @@ def run(job_id: str, payload_uri: str) -> str:
     blob = LocalBlobStore(settings.blob_root)
     raw = blob.get_json(payload_uri)
 
-    payload_type = raw["payload_type"]
-    payload_data = raw["payload"]
+    payload_type = raw.get("payload_type")
+    if payload_type is None:
+        raise ValueError("refine envelope missing required field 'payload_type'")
+    payload_data = raw.get("payload")
+    if payload_data is None:
+        raise ValueError("refine envelope missing required field 'payload'")
     title_hint = raw.get("title_hint")
     artist_hint = raw.get("artist_hint")
     filename_hint = raw.get("filename_hint")


### PR DESCRIPTION
## Summary

Small surgical hardening fixes across the backend — no behavior changes for valid inputs.

- **`backend/api/routes/artifacts.py:166-175`** — replace `f"Failed to read artifact: {exc}"` with a generic `"Failed to read artifact"` message and add `log.exception(...)` so the full exception is still captured server-side. Avoids leaking filesystem paths / internal error types in 500 responses.
- **`backend/workers/refine.py:32-40`** — validate the input envelope: use `.get()` and raise a clear `ValueError` if `payload_type` or `payload` is missing instead of letting an unhandled `KeyError` propagate.
- **`backend/workers/interpret.py:56-64`** — same treatment for the interpret envelope: explicit `ValueError` if `txr` or `prompt` is missing, matching the existing `.get()` idiom used for `title_hint`.
- **`backend/api/routes/uploads.py:48-52, 76-80`** — after the existing format check, reject filenames longer than 255 chars with `HTTPException(400, "filename too long (max 255)")`. Applied to both audio and MIDI upload endpoints.
- **`backend/api/routes/jobs.py:163-166`** — strip `source_filename` and treat empty / whitespace-only as `None`. Unset / `None` callers are unaffected.

## Test plan

- [x] `make lint` — ruff + flutter analyze pass
- [x] `pytest tests/test_artifacts.py tests/test_jobs.py tests/test_uploads.py tests/test_refine_runner.py tests/test_worker_tasks.py tests/test_pipeline_interpret.py` — 50 passed
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)