### PR TITLE
test(jobs): better message on status-poll timeout

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -76,7 +76,7 @@ def test_create_job_from_audio_runs_to_completion(client):
             break
         time.sleep(0.05)
 
-    assert status is not None
+    assert status is not None, "job polling timed out before reaching terminal state"
     assert status["status"] == "succeeded", status
     assert status["result"] is not None
     # pdf_uri is intentionally empty — the ML engraver returns MusicXML only.
@@ -282,7 +282,7 @@ def test_midi_job_condense_pipeline_emits_condense_and_transform(monkeypatch, cl
             break
         time.sleep(0.05)
 
-    assert status is not None
+    assert status is not None, "job polling timed out before reaching terminal state"
     assert status["status"] == "succeeded", status
 
     with client.websocket_connect(f"/v1/jobs/{job_id}/ws") as ws:


### PR DESCRIPTION
## Summary

Tiny test improvement: the polling loop in `test_jobs.py` (two call sites) bails out of its `while time.time() < deadline:` loop without ever seeing `succeeded`/`failed`. The next line is `assert status is not None`, which catches that case but produces a confusing failure (the response body is also non-None, just stuck in a non-terminal state). Add an explanatory message.

## Findings skipped on review
A scout pass flagged several other eval/test improvements that didn't hold up:
- `eval/harness.py:518` already computes `mean_wall_sec` from the `ok` list (errored rows excluded). The finding was based on the stub explorer report; the code already does the right thing.
- `tests/test_eval_telemetry.py:198` already has a separate `test_telemetry_client_record_returns_none_when_disabled` test that exercises `record()` on a disabled client. The lines-187-and-193 tests intentionally only check `.enabled`.
- The `celery_eager_mode` autouse fixture's teardown is already correct; adding a defensive teardown assertion would just be paranoia.

## Test plan
- [ ] CI pytest passes
- [ ] (Manual) intentionally break the pipeline-stub so polling times out — confirm the new message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)