### PR TITLE
chore: SSRF + info-leak hardening + contracts re-export

### DIFF
--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -127,7 +127,11 @@ def download_artifact(
                 detail="Upstream artifact host is not allowed.",
             )
         try:
-            with httpx.Client(timeout=_PROXY_TIMEOUT_SEC, follow_redirects=True) as client:
+            # follow_redirects=False: a redirect from TuneChat to e.g.
+            # http://169.254.169.254/ would bypass _is_allowed_proxy_target
+            # since we only check the initial URL. If TuneChat ever needs
+            # redirects, validate each hop instead.
+            with httpx.Client(timeout=_PROXY_TIMEOUT_SEC, follow_redirects=False) as client:
                 response = client.get(tunechat_url)
                 response.raise_for_status()
         except httpx.HTTPError as exc:

--- a/backend/api/routes/stages.py
+++ b/backend/api/routes/stages.py
@@ -93,12 +93,15 @@ async def _run_stage(
             cmd.job_id,
             cmd.step_id,
         )
+        # Don't ship repr(exc) to the caller — it leaks internal paths,
+        # variable contents, and traceback hints. Surface only the
+        # exception class so the orchestrator can branch on type.
         return WorkerResponse(
             schema_version=SCHEMA_VERSION,
             job_id=cmd.job_id,
             status="fatal_error",
             output_uri=None,
-            logs=repr(exc),
+            logs=type(exc).__name__,
         )
 
 

--- a/backend/contracts.py
+++ b/backend/contracts.py
@@ -3,6 +3,7 @@
 from shared.contracts import (
     SCHEMA_VERSION,
     Articulation,
+    Density,
     Difficulty,
     DynamicMarking,
     EngravedOutput,
@@ -10,6 +11,7 @@ from shared.contracts import (
     EvaluationReport,
     ExpressionMap,
     ExpressiveNote,
+    HandBalance,
     HarmonicAnalysis,
     HumanizedPerformance,
     InputBundle,

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,10 +54,15 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    # CORS: a wildcard origin combined with allow_credentials=True is
+    # actually an unsafe spec violation that modern browsers reject —
+    # so when the operator leaves the dev default of ["*"], drop
+    # credentials. Operators who pin explicit origins keep them.
+    cors_wildcard = "*" in settings.cors_origins
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins,
-        allow_credentials=True,
+        allow_credentials=not cors_wildcard,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -250,6 +250,39 @@ def test_artifact_refuses_proxy_to_foreign_host(client, monkeypatch):
     assert "not allowed" in response.json()["detail"].lower()
 
 
+def test_artifact_proxy_does_not_follow_redirects(client, monkeypatch):
+    """Defense-in-depth for SSRF: even after the host allowlist passes,
+    httpx must NOT follow upstream redirects. A redirect from TuneChat
+    to e.g. http://169.254.169.254/ would otherwise bypass the guard
+    since we only validate the initial URL.
+    """
+    captured: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+        content = b"ok"
+        def raise_for_status(self): pass
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            captured["kwargs"] = kw
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, url): return FakeResponse()
+
+    monkeypatch.setattr("backend.api.routes.artifacts.httpx.Client", FakeClient)
+
+    job_id = _install_tunechat_job(
+        client,
+        pdf=None,
+        musicxml="http://localhost:3000/pipeline/tc-fake-123/score.musicxml",
+        midi=None,
+    )
+    response = client.get(f"/v1/artifacts/{job_id}/musicxml")
+    assert response.status_code == 200
+    assert captured["kwargs"].get("follow_redirects") is False
+
+
 def test_artifact_proxy_scheme_mismatch_is_rejected(client, monkeypatch):
     """Scheme mismatch (https target vs http configured) also blocked —
     prevents downgrade/upgrade attacks where an attacker swaps


### PR DESCRIPTION
## Summary

Four small, independent hardening fixes:

### 1. SSRF: disable redirect-following on the TuneChat proxy
`backend/api/routes/artifacts.py` — `_is_allowed_proxy_target()` validates the initial URL against the configured TuneChat host (good!) but `httpx.Client(..., follow_redirects=True)` would happily follow a 30x redirect from upstream into a host that isn't on the allowlist (e.g. `http://169.254.169.254/` AWS IMDS). Setting `follow_redirects=False` closes that gap.

Added `test_artifact_proxy_does_not_follow_redirects` to lock in the behavior.

### 2. Info leak in worker stage error responses
`backend/api/routes/stages.py:101` — the catch-all on `/v1/stages/{name}` was returning `WorkerResponse(logs=repr(exc))`, surfacing exception types, file paths, and traceback fragments to whoever posts to the endpoint. Exceptions are already logged server-side via `log.exception(...)` (line 90), so the over-the-wire field is now just `type(exc).__name__`. The two tests that touch this only assert `logs is not None`, both still pass.

### 3. CORS wildcard + credentials
`backend/main.py` — `allow_origins=["*"]` with `allow_credentials=True` is both a CORS spec violation (browsers refuse to send credentials when the origin is `*`) and a footgun if any explicit origin ever gets added. When the operator leaves the dev default of `["*"]`, credentials are now dropped; explicit-origin deployments keep them.

### 4. Re-export Density / HandBalance from `backend.contracts`
`backend/contracts.py` re-exports the public contracts from `shared.contracts`. The `Difficulty` Literal alias was already there; `Density` and `HandBalance` (used in `ArrangementHints`) weren't. Pure addition — code that imports from `backend.contracts` can now type-annotate against these.

## Findings deferred
- Upload size limit needs a streaming middleware change, not a one-line `File()` arg.
- WebSocket auth on `/v1/jobs/{id}/ws` is feature-scope, not a chore fix.

## Test plan
- [x] `pytest tests/test_artifacts.py tests/test_stages.py` (20 passed locally)
- [x] `ruff check` clean
- [ ] CI: backend tests, lint, typecheck pass
- [ ] (Manual) Set `OHSHEET_CORS_ORIGINS=https://example.com` and confirm credentials are still allowed; leave default and confirm they're dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)