### PR TITLE
chore: cap upload sizes with streaming 413 to prevent memory exhaustion

### DIFF
--- a/backend/api/routes/uploads.py
+++ b/backend/api/routes/uploads.py
@@ -14,6 +14,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from backend.api.deps import get_blob_store
+from backend.config import settings
 from backend.contracts import RemoteAudioFile, RemoteMidiFile
 from backend.storage.local import LocalBlobStore
 
@@ -29,9 +30,33 @@ MIDI_FORMATS = {"mid", "midi"}
 # HTTP layer. Deeper structural validation is ingest's job.
 _MIDI_MAGIC = b"MThd"
 
+# Chunk size for streaming uploads off the wire. 1 MiB strikes a balance
+# between syscall overhead and memory pressure under concurrent uploads.
+_UPLOAD_CHUNK_BYTES = 1024 * 1024
+
 
 def _ext(filename: str) -> str:
     return filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+
+
+async def _read_capped(upload_file: UploadFile, max_bytes: int) -> bytes:
+    """Stream ``upload_file`` in chunks, aborting with 413 past ``max_bytes``.
+
+    Content-Length is client-supplied and untrusted, so the cap is enforced
+    by counting bytes as they arrive. Returning the joined bytes preserves
+    the existing handler contract — callers continue to assign to ``data``.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await upload_file.read(_UPLOAD_CHUNK_BYTES):
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"upload too large; max {max_bytes} bytes",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 @router.post("/uploads/audio", response_model=RemoteAudioFile)
@@ -46,7 +71,7 @@ async def upload_audio(
             detail=f"Unsupported audio format: {ext!r}. Allowed: {sorted(AUDIO_FORMATS)}",
         )
 
-    data = await file.read()
+    data = await _read_capped(file, settings.max_audio_upload_mb * 1024 * 1024)
     digest = hashlib.sha256(data).hexdigest()
     uri = blob.put_bytes(f"uploads/audio/{digest}.{ext}", data)
 
@@ -74,7 +99,7 @@ async def upload_midi(
             detail=f"Unsupported MIDI format: {ext!r}. Allowed: {sorted(MIDI_FORMATS)}",
         )
 
-    data = await file.read()
+    data = await _read_capped(file, settings.max_midi_upload_mb * 1024 * 1024)
 
     # Content-integrity check: the .mid/.midi extension is a hint, not
     # a guarantee. Reject anything that doesn't begin with the Standard

--- a/backend/config.py
+++ b/backend/config.py
@@ -24,6 +24,13 @@ class Settings(BaseSettings):
     # Where the LocalBlobStore writes its files. Returned URIs are file:// based.
     blob_root: Path = Path("./blob")
 
+    # Maximum upload sizes for /v1/uploads/{audio,midi}. Enforced by streaming
+    # the request body and aborting with HTTP 413 once the cumulative byte
+    # count exceeds the cap (Content-Length is not trusted). MIDI files are
+    # tiny in practice, so the MIDI cap is much smaller than the audio cap.
+    max_audio_upload_mb: int = 100
+    max_midi_upload_mb: int = 5
+
     # Redis URL for Celery broker + result backend.
     redis_url: str = "redis://localhost:6379/0"
 

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -101,6 +101,38 @@ def test_upload_midi_preserves_source_filename(client):
     assert response.json()["source_filename"] == "Chopin_Nocturne.mid"
 
 
+def test_audio_upload_rejects_oversized(client, monkeypatch):
+    # The /v1/uploads/audio endpoint streams the request body and aborts
+    # with 413 once the cumulative byte count exceeds the configured cap.
+    # Set the cap to 1 MB and post >1 MB of payload to trip it.
+    from backend.config import settings
+    monkeypatch.setattr(settings, "max_audio_upload_mb", 1)
+
+    oversized = b"ID3\x04" + b"\x00" * (2 * 1024 * 1024)  # ~2 MB
+    response = client.post(
+        "/v1/uploads/audio",
+        files={"file": ("big.mp3", oversized, "audio/mpeg")},
+    )
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"].lower()
+
+
+def test_midi_upload_rejects_oversized(client, monkeypatch):
+    # Same 413 contract for MIDI, with the dedicated MIDI cap. We don't
+    # need a valid MThd header here — the size check fires before the
+    # magic-header gate.
+    from backend.config import settings
+    monkeypatch.setattr(settings, "max_midi_upload_mb", 1)
+
+    oversized = b"MThd" + b"\x00" * (2 * 1024 * 1024)  # ~2 MB
+    response = client.post(
+        "/v1/uploads/midi",
+        files={"file": ("big.mid", oversized, "audio/midi")},
+    )
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"].lower()
+
+
 def test_upload_midi_accepts_valid_smf_header(client):
     # Regression guard: the fix must not reject real MIDI files. A
     # minimal valid SMF header starts with "MThd" + 4-byte length +


### PR DESCRIPTION
## Summary
- The `/v1/uploads/{audio,midi}` handlers previously called `await file.read()`, buffering the entire upload in memory with no cap — a malicious client could upload arbitrary gigabytes and exhaust the server.
- Replaced with `_read_capped`, which streams the upload in 1 MiB chunks and aborts with HTTP 413 once cumulative bytes exceed a configurable cap. Content-Length is not trusted; the cap is enforced by counting bytes as they arrive.
- Added two new settings (`OHSHEET_` prefix): `max_audio_upload_mb` (default 100) and `max_midi_upload_mb` (default 5; MIDIs are tiny). The MIDI magic-header check still runs after byte capture, so the existing content-integrity gate is preserved.

## Test plan
- [x] `pytest tests/test_uploads.py -v --no-cov` — 11 passed (9 existing + 2 new)
  - `test_audio_upload_rejects_oversized` — 1 MB cap, 2 MB upload, expects 413
  - `test_midi_upload_rejects_oversized` — same pattern with the MIDI cap
- [x] `ruff check backend tests` — clean
- [ ] Manual: upload a real >100 MB MP3 against a deployed instance and confirm 413

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)