### PR TITLE
chore: bound JobManager memory + scrub exception detail from JobRecord.error

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -33,6 +33,14 @@ class Settings(BaseSettings):
     # Worker timeout used by OrchestratorCommand envelopes.
     job_timeout_sec: int = 600
 
+    # Cap on the number of completed (succeeded/failed) JobRecords retained
+    # in the in-memory JobManager. When this limit is exceeded, the oldest
+    # completed records are evicted in insertion order. Running/pending jobs
+    # are never evicted. Set high enough to cover your typical
+    # status-polling window; long-running deployments without this cap
+    # accumulate JobRecords for the process lifetime.
+    max_completed_jobs: int = 1000
+
     # Logging level for ``backend.*`` (pipeline, jobs, services). The root
     # logger defaults to WARNING, so without configuration ``log.info`` would
     # not appear when you run the API server.

--- a/backend/jobs/manager.py
+++ b/backend/jobs/manager.py
@@ -10,8 +10,10 @@ import asyncio
 import logging
 import time
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass, field
 
+from backend.config import settings
 from backend.contracts import EngravedOutput, InputBundle, PipelineConfig
 from backend.jobs.events import JobEvent, JobStatus
 from backend.jobs.runner import PipelineRunner
@@ -35,6 +37,13 @@ class JobRecord:
 class JobManager:
     def __init__(self, runner: PipelineRunner) -> None:
         self._jobs: dict[str, JobRecord] = {}
+        # Ordered set of completed job_ids in insertion-of-completion order.
+        # ``OrderedDict`` is used as an insertion-ordered set (values unused);
+        # eviction pops from the front (oldest). Active subscribers' queues
+        # are independent — dropping the JobRecord here does not close their
+        # asyncio.Queues, so any pending events they already received still
+        # drain on .get().
+        self._completed_jobs: OrderedDict[str, None] = OrderedDict()
         self._runner = runner
         self._lock = asyncio.Lock()
 
@@ -110,11 +119,27 @@ class JobManager:
                 elapsed_ms,
             )
             record.status = "failed"
-            record.error = repr(exc)
+            # Surface only the exception class name to API consumers — the
+            # full traceback is captured server-side via log.exception above.
+            # Mirrors the same info-leak fix applied to /v1/stages/{name}
+            # in PR #124 (backend/api/routes/stages.py).
+            record.error = type(exc).__name__
             self._emit(
                 record,
                 JobEvent(job_id=record.job_id, type="job_failed", message=str(exc)),
             )
+        # Track completion order and evict the oldest records over the cap.
+        # Holding the lock here serializes against submit() so we never race
+        # with a concurrent insert of a new JobRecord. Active subscribers
+        # already hold their own asyncio.Queue references — evicting the
+        # JobRecord does not close those queues, so a websocket consumer
+        # still drains the events it has received.
+        async with self._lock:
+            self._completed_jobs[record.job_id] = None
+            cap = settings.max_completed_jobs
+            while len(self._completed_jobs) > cap:
+                oldest_id, _ = self._completed_jobs.popitem(last=False)
+                self._jobs.pop(oldest_id, None)
 
     # ---- queries ---------------------------------------------------------
 

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,0 +1,219 @@
+"""Unit tests for the in-memory JobManager.
+
+Exercises behaviour that doesn't need the full FastAPI route layer —
+specifically the bounded-completed-jobs eviction policy and the
+exception-surface scrubbing applied to ``JobRecord.error``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.config import settings
+from backend.contracts import (
+    EngravedOutput,
+    EngravedScoreData,
+    InputBundle,
+    InputMetadata,
+    PipelineConfig,
+)
+from backend.jobs.events import JobEvent
+from backend.jobs.manager import JobManager
+
+
+def _make_engraved_output() -> EngravedOutput:
+    return EngravedOutput(
+        metadata=EngravedScoreData(
+            includes_dynamics=False,
+            includes_pedal_marks=False,
+            includes_fingering=False,
+            includes_chord_symbols=False,
+            title="t",
+            composer="",
+        ),
+        pdf_uri="file:///fake.pdf",
+        musicxml_uri="file:///fake.xml",
+        humanized_midi_uri="file:///fake.mid",
+    )
+
+
+def _make_bundle() -> InputBundle:
+    return InputBundle(
+        metadata=InputMetadata(
+            title="t",
+            artist="a",
+            source="title_lookup",
+        ),
+    )
+
+
+def _make_config() -> PipelineConfig:
+    return PipelineConfig(variant="full")
+
+
+class _SuccessRunner:
+    """Minimal fake PipelineRunner that returns a stub EngravedOutput."""
+
+    async def run(self, *, job_id, bundle, config, on_event):  # noqa: ARG002
+        return _make_engraved_output()
+
+
+class _FailingRunner:
+    """Fake runner that raises a recognizable exception."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def run(self, *, job_id, bundle, config, on_event):  # noqa: ARG002
+        raise self._exc
+
+
+async def _wait_for(record, *, timeout: float = 2.0) -> None:
+    """Wait for a JobRecord's background task to finish."""
+    assert record.task is not None
+    await asyncio.wait_for(record.task, timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_completed_jobs_are_capped(monkeypatch):
+    """Submitting more than max_completed_jobs evicts the oldest records."""
+    cap = 5
+    monkeypatch.setattr(settings, "max_completed_jobs", cap)
+
+    manager = JobManager(_SuccessRunner())  # type: ignore[arg-type]
+
+    # Submit cap + 3 jobs and let each one complete before submitting the
+    # next so completion order is deterministic. (asyncio.create_task starts
+    # the task but only the awaited completion writes into _completed_jobs.)
+    submitted_ids: list[str] = []
+    for _ in range(cap + 3):
+        record = await manager.submit(_make_bundle(), _make_config())
+        await _wait_for(record)
+        submitted_ids.append(record.job_id)
+
+    # Only the most recent ``cap`` records should survive.
+    assert len(manager._jobs) == cap
+    surviving_ids = set(manager._jobs.keys())
+    assert surviving_ids == set(submitted_ids[-cap:])
+    # The three oldest must be gone.
+    for evicted_id in submitted_ids[:3]:
+        assert evicted_id not in manager._jobs
+        assert manager.get(evicted_id) is None
+
+
+@pytest.mark.asyncio
+async def test_running_jobs_are_not_evicted(monkeypatch):
+    """A still-running job past the cap must not be dropped from _jobs."""
+    cap = 2
+    monkeypatch.setattr(settings, "max_completed_jobs", cap)
+
+    # Block the runner on an event we control so the job stays in
+    # ``running`` state until we're ready to release it. ``started`` lets
+    # the test wait until the runner has actually entered .run() before
+    # swapping in the success runner — otherwise the long-running task
+    # might pick up the post-swap runner and complete instantly.
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    class _Blocking:
+        async def run(self, *, job_id, bundle, config, on_event):  # noqa: ARG002
+            started.set()
+            await release.wait()
+            return _make_engraved_output()
+
+    manager = JobManager(_Blocking())  # type: ignore[arg-type]
+    long_running = await manager.submit(_make_bundle(), _make_config())
+    # Park here until the blocking runner is actually inside .run().
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+
+    # Now drive cap + 1 successful jobs to completion against a separate
+    # runner. We swap the runner attribute directly — same JobManager.
+    manager._runner = _SuccessRunner()  # type: ignore[assignment]
+    completed_ids: list[str] = []
+    for _ in range(cap + 1):
+        record = await manager.submit(_make_bundle(), _make_config())
+        await _wait_for(record)
+        completed_ids.append(record.job_id)
+
+    # The long-running job is still tracked even though completed_jobs
+    # already holds cap+1 entries — eviction only removes entries that
+    # have actually completed.
+    assert long_running.job_id in manager._jobs
+    assert manager.get(long_running.job_id) is not None
+    # The oldest completed record was evicted.
+    assert completed_ids[0] not in manager._jobs
+
+    # Cleanup: release the blocking runner so the task finishes.
+    release.set()
+    await _wait_for(long_running)
+
+
+@pytest.mark.asyncio
+async def test_failed_job_records_only_exception_class_name():
+    """JobRecord.error must not leak repr(exc) — only the exception class name."""
+    secret = "DB_PASSWORD=hunter2 at /etc/secrets.json"
+    runner = _FailingRunner(RuntimeError(secret))
+    manager = JobManager(runner)  # type: ignore[arg-type]
+
+    record = await manager.submit(_make_bundle(), _make_config())
+    await _wait_for(record)
+
+    assert record.status == "failed"
+    assert record.error == "RuntimeError"
+    # The leaky bits must not appear anywhere in the surfaced error field.
+    assert secret not in (record.error or "")
+    assert "hunter2" not in (record.error or "")
+
+
+@pytest.mark.asyncio
+async def test_failed_jobs_count_against_eviction_cap(monkeypatch):
+    """Failed jobs are terminal too — they participate in eviction."""
+    cap = 3
+    monkeypatch.setattr(settings, "max_completed_jobs", cap)
+
+    manager = JobManager(_FailingRunner(RuntimeError("boom")))  # type: ignore[arg-type]
+
+    submitted_ids: list[str] = []
+    for _ in range(cap + 2):
+        record = await manager.submit(_make_bundle(), _make_config())
+        await _wait_for(record)
+        submitted_ids.append(record.job_id)
+
+    assert len(manager._jobs) == cap
+    assert set(manager._jobs.keys()) == set(submitted_ids[-cap:])
+
+
+@pytest.mark.asyncio
+async def test_subscriber_queue_drains_after_eviction(monkeypatch):
+    """A websocket subscriber holding a queue ref still drains after eviction.
+
+    The eviction logic deliberately does not touch subscribers' queues —
+    they're independent asyncio.Queue objects, so dropping the JobRecord
+    only removes the lookup entry. Already-enqueued events stay readable.
+    """
+    cap = 1
+    monkeypatch.setattr(settings, "max_completed_jobs", cap)
+
+    manager = JobManager(_SuccessRunner())  # type: ignore[arg-type]
+
+    # Submit one job, subscribe before completion, then wait for it to
+    # finish. The subscriber's queue should hold the replay events.
+    record = await manager.submit(_make_bundle(), _make_config())
+    queue = await manager.subscribe(record.job_id)
+    assert queue is not None
+    await _wait_for(record)
+
+    # Submit a second job to push the first past the cap.
+    record2 = await manager.submit(_make_bundle(), _make_config())
+    await _wait_for(record2)
+
+    # The first JobRecord is evicted from the lookup map…
+    assert manager.get(record.job_id) is None
+    # …but the original subscriber's queue is still drainable.
+    drained: list[JobEvent] = []
+    while not queue.empty():
+        drained.append(queue.get_nowait())
+    types = {ev.type for ev in drained}
+    assert "job_created" in types
+    assert "job_succeeded" in types


### PR DESCRIPTION
## Summary

Two fixes targeted at `backend/jobs/manager.py`:

### 1. Bound the in-memory `_jobs` dict

`JobManager` previously kept every `JobRecord` alive for the process lifetime. Long-running deployments leak: each completed job sits in memory until the worker is restarted.

- New setting `OHSHEET_MAX_COMPLETED_JOBS` (default `1000`) caps retained records.
- An `OrderedDict[str, None]` tracks completion order; when a job transitions to `succeeded`/`failed` we append its id and evict the oldest while over the cap.
- Eviction holds `self._lock` so we don't race `submit()`.
- Running/pending jobs are never evicted.
- Subscribers' `asyncio.Queue`s are independent of the `JobRecord`, so a websocket consumer that's already received events can still drain them after the lookup entry is gone.

### 2. Stop leaking exception detail in `JobRecord.error`

Same info-leak class as PR #124's fix for `stages.py`. `record.error = repr(exc)` was surfacing exception messages, file paths, and traceback fragments via `GET /v1/jobs/{id}` → `JobSummary.error`. Replaced with `type(exc).__name__`. Full traceback is still captured server-side via `log.exception(...)`.

## Test plan

- [x] `pytest tests/test_jobs.py tests/test_job_manager.py tests/test_pipeline_config.py -v --no-cov` (32 passed locally)
- [x] `ruff check backend tests` clean
- [x] `mypy backend/jobs/manager.py backend/config.py` clean
- [x] New tests in `tests/test_job_manager.py` cover:
  - Cap eviction with successful jobs (oldest dropped, newest survive)
  - Running jobs not evicted (long-running task held while later jobs complete past cap)
  - `record.error` is the bare class name, not `repr(exc)` content
  - Failed jobs count against the cap (terminal transitions, not just success)
  - Subscriber queue still drains after the JobRecord is evicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)