### PR TITLE
fix(runner): TuneChat synthetic events only on success branch

### DIFF
--- a/backend/jobs/runner.py
+++ b/backend/jobs/runner.py
@@ -442,14 +442,23 @@ class PipelineRunner:
                             try:
                                 from backend.services.tunechat_client import transcribe_via_tunechat
                                 audio_bytes = self.blob_store.get_bytes(audio_data["uri"])
-                                emit("ingest", "stage_completed", progress=0.25)
-                                emit("transcribe", "stage_started", progress=0.25)
                                 log.info("tunechat-only: sending audio for job_id=%s", job_id)
                                 tc_result = await transcribe_via_tunechat(
                                     audio_bytes, "audio.wav",
                                     title=title, artist=composer,
                                 )
                                 if tc_result is not None:
+                                    # Synthetic stage events only fire on the
+                                    # success path. On TuneChat failure / None
+                                    # result we fall back to the regular Oh
+                                    # Sheet pipeline below; the outer loop's
+                                    # own emit() calls become canonical.
+                                    # Previously these fired before the await,
+                                    # leaving subscribers with a phantom
+                                    # "transcribe stage_started" + duplicate
+                                    # "ingest stage_completed" on every fallback.
+                                    emit("ingest", "stage_completed", progress=0.25)
+                                    emit("transcribe", "stage_started", progress=0.25)
                                     emit("transcribe", "stage_completed", progress=0.75)
                                     emit("engrave", "stage_started", progress=0.75)
                                     emit("engrave", "stage_completed", progress=1.0)
@@ -540,7 +549,11 @@ class PipelineRunner:
                     payload_uri = self._serialize_stage_input(job_id, step, interpret_envelope)
                     output_uri = await self._dispatch_task(task_name, job_id, payload_uri, config.stage_timeout_sec)
                     enriched = self.blob_store.get_json(output_uri)
-                    txr_dict = enriched["txr"]
+                    txr_dict = enriched.get("txr")
+                    if txr_dict is None:
+                        raise RuntimeError(
+                            "interpret worker output missing required 'txr' key"
+                        )
 
                 elif step in ("arrange", "condense"):
                     if txr_dict is None:

--- a/tests/test_ml_engraver_error_propagation.py
+++ b/tests/test_ml_engraver_error_propagation.py
@@ -169,3 +169,70 @@ async def test_title_lookup_falls_through_to_local_engrave_when_tunechat_returns
     )
     assert result is not None
     assert result.musicxml_uri or result.tunechat_job_id
+
+
+@pytest.mark.asyncio
+async def test_title_lookup_tunechat_fallback_emits_no_phantom_events(
+    runner, monkeypatch,
+):
+    """Regression: when TuneChat returns None, the runner used to fire a
+    synthetic ``transcribe stage_started`` (and a duplicate ``ingest
+    stage_completed``) before the fallback, leaving subscribers with
+    a transcribe-started event that never had a matching completion.
+    On the fallback path, only the regular per-step loop events should
+    fire; synthetic events stay confined to the success branch.
+    """
+    monkeypatch.setattr(settings, "tunechat_enabled", True)
+
+    from backend.services import tunechat_client  # noqa: PLC0415
+
+    async def _tunechat_returns_none(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        tunechat_client, "transcribe_via_tunechat", _tunechat_returns_none,
+    )
+
+    events: list[tuple[str, str]] = []
+
+    def on_event(ev) -> None:
+        events.append((ev.stage or "", ev.type))
+
+    bundle = InputBundle(
+        audio=RemoteAudioFile(
+            uri="file:///fake/audio.wav",
+            format="wav",
+            sample_rate=44100,
+            duration_sec=10.0,
+            channels=1,
+        ),
+        metadata=InputMetadata(
+            title="Title Lookup Song",
+            artist="Tester",
+            source="title_lookup",
+        ),
+    )
+    config = PipelineConfig(variant="audio_upload", enable_refine=False)
+
+    await runner.run(
+        job_id="title-lookup-tunechat-fallback-events",
+        bundle=bundle,
+        config=config,
+        on_event=on_event,
+    )
+
+    started = [s for s, t in events if t == "stage_started"]
+    completed = [s for s, t in events if t == "stage_completed"]
+
+    # Every stage that started must also complete on the fallback path.
+    assert sorted(started) == sorted(completed), (
+        f"unbalanced stage events on fallback: started={started}, "
+        f"completed={completed}"
+    )
+    # No duplicate stage_completed for ingest — used to fire twice
+    # (once inside the TuneChat branch at progress=0.25 and again from
+    # the outer loop after the branch returned).
+    ingest_completed = [s for s, t in events if t == "stage_completed" and s == "ingest"]
+    assert len(ingest_completed) == 1, (
+        f"ingest stage_completed fired {len(ingest_completed)} times: {events}"
+    )


### PR DESCRIPTION
## Summary

Real WS-event ordering bug. When \`OHSHEET_TUNECHAT_ENABLED=true\` and a title_lookup job entered the TuneChat fast path, \`backend/jobs/runner.py\` emitted synthetic stage events **before** \`await transcribe_via_tunechat(...)\`. If TuneChat then returned \`None\` or raised (network blip, quota, SDK error), control fell back to the regular Oh Sheet pipeline — but subscribers had already received a \`transcribe stage_started\` event with no matching completion, plus the outer loop would re-fire \`ingest stage_completed\`, double-firing it.

A WebSocket client (the Flutter app, frontend-v2) tracking stage progress would render "transcribing..." indefinitely on every fallback.

## Fix

Move all five synthetic \`emit()\` calls inside the \`if tc_result is not None:\` branch so they only fire on the success path. The fallback now relies entirely on the outer loop's per-step events — which match how every other stage already behaves.

## Bonus

Same PR: \`enriched["txr"]\` on the interpret stage's output now uses \`.get("txr")\` + explicit \`RuntimeError\`. A malformed interpret worker payload now surfaces as \`interpret worker output missing required 'txr' key\` instead of a bare \`KeyError('txr')\` traceback (mirroring the safety guards PR #122 added to the workers themselves).

## Test plan

New regression test: \`test_title_lookup_tunechat_fallback_emits_no_phantom_events\` asserts that on a None TuneChat result, every \`stage_started\` has a matching \`stage_completed\` and \`ingest stage_completed\` fires exactly once.

- [x] \`pytest tests/test_ml_engraver_error_propagation.py tests/test_jobs.py tests/test_pipeline_config.py tests/test_celery_dispatch.py\` — 38 passed
- [x] \`ruff check\` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)