### PR TITLE
fix(eval): skip tier-inactive gates when only head metric is missing

### DIFF
--- a/eval/harness.py
+++ b/eval/harness.py
@@ -656,7 +656,30 @@ def apply_ci_gates(
             continue
 
         if not head_present:
-            # CI ran the tier but head failed to produce the metric —
+            # If the CI run didn't request this tier, the metric is
+            # legitimately absent on head; the *baseline* may still
+            # have it (captured by an earlier all-tiers run). Per the
+            # docstring contract above, only fail when the run *did*
+            # request the tier. Without this skip, a "tier3 off" CI
+            # run gating against an all-tiers baseline would mark every
+            # tier3 gate as a harness regression.
+            tier_inactive = (
+                selected_tiers is not None
+                and not _tier_active_for_key(selected_tiers, key)
+            )
+            if tier_inactive:
+                outcomes.append(GateOutcome(
+                    name=name,
+                    passed=True,
+                    head_value=None,
+                    baseline_value=float(base_v) if base_present else None,
+                    delta=None,
+                    threshold=threshold,
+                    direction=direction,
+                    message=f"skipped: tier inactive for this run ('{key}')",
+                ))
+                continue
+            # Tier was requested but head failed to produce the metric —
             # signals a harness regression. Block merge so the bug is
             # surfaced before the eval set drifts further.
             outcomes.append(GateOutcome(

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -191,6 +191,30 @@ def test_ci_gates_skip_when_tier_inactive_for_run():
     assert "tier inactive" in rt.message.lower()
 
 
+def test_ci_gates_skip_when_head_missing_but_tier_inactive():
+    """Regression: when CI's TierSelection has tier4 off but the
+    baseline payload has tier4 metrics (because it was captured by an
+    earlier nightly/all-tiers run), the gate's head_v is None but
+    base_v is a real number. Pre-fix, this surfaced as a "FAIL: head
+    missing" gate even though the run never asked for tier4 — a false
+    positive that would block PRs every time CI compared against a
+    nightly-captured baseline.
+    """
+    base = _payload({
+        "mean_tier2_chord_score": 0.50,
+        "mean_tier4_round_trip_f1_no_offset": 0.80,
+        "mean_tier4_clap_cosine": 0.60,
+    })
+    head = _payload({"mean_tier2_chord_score": 0.50})
+    report = apply_ci_gates(head, base, selected_tiers=TierSelection.ci())
+    rt = next(o for o in report.outcomes if o.name == "round_trip_regression")
+    assert rt.passed
+    assert "tier inactive" in rt.message.lower()
+    # The baseline value should still be reported on the skip outcome
+    # so reviewers can see what was on the other side of the gate.
+    assert rt.baseline_value == pytest.approx(0.80)
+
+
 # ---------------------------------------------------------------------------
 # aggregate_rows
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Real false-positive bug in \`apply_ci_gates\`. The function checks \`selected_tiers\` to decide between *skip* and *fail* on the path where **both** head and baseline lack a metric (lines 638-641), but on the head-only-missing path (line 658) it jumps straight to \`passed=False\` regardless of whether the tier was requested.

## Concrete failure

A CI run uses \`TierSelection.ci()\` (tier4=False) and gates against a baseline captured by an earlier nightly all-tiers run. Baseline has \`mean_tier4_round_trip_f1_no_offset = 0.80\`; head doesn't (CI never computes tier4). Pre-fix, the \`round_trip_regression\` gate surfaces as **"FAIL: head missing aggregate[...]; harness regression"** — a false positive that would block every PR until someone manually regenerates the baseline.

The docstring at line 615 already states the correct contract: only fail when "the run *did* request that tier."

## Fix

Mirror the existing \`tier_inactive\` check from the both-missing branch into the head-only-missing branch. If \`selected_tiers\` is provided and the metric's tier is off, skip cleanly with \`"skipped: tier inactive for this run"\`. The original fail-loud behavior is preserved when the tier IS active and head lacks the metric (real harness regression).

## Test plan

New test \`test_ci_gates_skip_when_head_missing_but_tier_inactive\` exercises exactly the failure scenario above and asserts:
- the round-trip gate passes
- the message says "tier inactive"
- the baseline value is still reported on the skip outcome (so reviewers see what was on the other side)

- [x] \`pytest tests/test_eval_harness.py\` — 23 passed
- [x] \`ruff check\` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)