### PR TITLE
fix(docker): exec uvicorn so SIGTERM reaches it as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,4 +113,10 @@ ENV PORT=8080
 
 EXPOSE ${PORT}
 
-CMD uvicorn backend.main:app --host 0.0.0.0 --port ${PORT}
+# `exec` so uvicorn replaces the shell as PID 1 and receives SIGTERM
+# directly. Cloud Run's graceful-shutdown contract sends SIGTERM to
+# PID 1 and waits up to 10s before SIGKILL; without `exec`, /bin/sh
+# would trap the signal and uvicorn would only see SIGKILL — in-flight
+# jobs cut off mid-stage and WS clients see abrupt closes. Shell form
+# (rather than exec/JSON form) is preserved so ${PORT} still expands.
+CMD exec uvicorn backend.main:app --host 0.0.0.0 --port ${PORT}


### PR DESCRIPTION
## Summary

\`Dockerfile:116\` uses shell-form CMD: \`CMD uvicorn backend.main:app ...\`. That puts \`/bin/sh -c\` at PID 1 with uvicorn as a child. Cloud Run's graceful-shutdown contract sends SIGTERM to PID 1 and waits ~10s before SIGKILL — but \`/bin/sh\` doesn't propagate SIGTERM to children by default, so uvicorn only ever sees SIGKILL.

User-visible failure: in-flight jobs are cut off mid-stage, WebSocket clients see abrupt closes mid-event, and the next deploy revision starts before the previous one finished any draining.

## Fix

Prepend \`exec\`: \`CMD exec uvicorn ...\`. The shell exec's into uvicorn so uvicorn becomes PID 1 and handles SIGTERM directly. Shell form (vs JSON-array exec form) is intentionally preserved so \`${PORT}\` still expands at runtime — Cloud Run injects PORT, and JSON exec form would NOT do shell substitution.

## Test plan
- [ ] CI passes
- [ ] (Manual, post-deploy) Run a long job, deploy a no-op change, observe that the running job completes rather than being cut off mid-stage.
- [ ] (Manual) \`docker run --rm <image>\` then \`docker stop\` and check \`docker logs\` — should see uvicorn's "Shutting down" rather than just abrupt termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)