### PR TITLE
fix(eval): graceful parse-error handling in loader's _maybe_load_* helpers

### DIFF
--- a/eval/loader.py
+++ b/eval/loader.py
@@ -32,12 +32,15 @@ them with the live pipeline output.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+log = logging.getLogger(__name__)
 
 # Paths inside ``songs/<slug>/`` for each deliverable. Constants so tests
 # and the holdout / curate scripts can reference them by name instead of
@@ -332,7 +335,14 @@ def _maybe_load_audio_metadata(songs_dir: Path) -> AudioMetadata | None:
     meta_path = songs_dir / AUDIO_METADATA_FILENAME
     if not meta_path.is_file():
         return None
-    raw = json.loads(meta_path.read_text())
+    # The whole point of the _maybe_ prefix is graceful degradation when
+    # the file is missing; treat malformed JSON the same way (warn so the
+    # eval-set author sees the corruption, but don't sink the whole load).
+    try:
+        raw = json.loads(meta_path.read_text())
+    except json.JSONDecodeError as exc:
+        log.warning("eval/loader: %s is not valid JSON (%s); skipping", meta_path, exc)
+        return None
     if not isinstance(raw, dict):
         return None
     return AudioMetadata.from_mapping(raw)
@@ -350,7 +360,11 @@ def _maybe_load_structural(songs_dir: Path) -> StructuralReference | None:
     path = songs_dir / STRUCTURAL_FILENAME
     if not path.is_file():
         return None
-    raw = yaml.safe_load(path.read_text())
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        log.warning("eval/loader: %s is not valid YAML (%s); skipping", path, exc)
+        return None
     if not isinstance(raw, dict):
         return None
     return StructuralReference.from_mapping(raw)

--- a/tests/test_eval_loader.py
+++ b/tests/test_eval_loader.py
@@ -435,3 +435,35 @@ def test_audio_metadata_handles_missing_internal_storage_uri():
         }
     )
     assert meta.internal_storage_uri is None
+
+
+# ---------------------------------------------------------------------------
+# Per-song parse-error robustness — corrupt JSON / YAML in one song must
+# not sink the whole load. The loader's docstring promises "a single
+# broken slot doesn't sink a whole load"; this used to be true only for
+# *missing* files, not malformed ones.
+# ---------------------------------------------------------------------------
+
+def test_corrupt_audio_metadata_json_returns_none_with_warning(tmp_path, caplog):
+    songs_dir = tmp_path / "songs" / "broken"
+    songs_dir.mkdir(parents=True)
+    (songs_dir / loader.AUDIO_METADATA_FILENAME).write_text("{ this is not json")
+
+    with caplog.at_level("WARNING", logger="eval.loader"):
+        result = loader._maybe_load_audio_metadata(songs_dir)
+
+    assert result is None
+    assert any("not valid JSON" in rec.message for rec in caplog.records)
+
+
+def test_corrupt_structural_yaml_returns_none_with_warning(tmp_path, caplog):
+    songs_dir = tmp_path / "songs" / "broken"
+    songs_dir.mkdir(parents=True)
+    # Unclosed flow-style mapping — yaml.safe_load raises ParserError.
+    (songs_dir / loader.STRUCTURAL_FILENAME).write_text("{key: value, [oops")
+
+    with caplog.at_level("WARNING", logger="eval.loader"):
+        result = loader._maybe_load_structural(songs_dir)
+
+    assert result is None
+    assert any("not valid YAML" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

\`eval/loader.py\`'s docstring on \`load_manifest\` promises:

> per-song validation is deferred to \`load_song\` so a single broken slot doesn't sink a whole load.

The two per-song helpers \`_maybe_load_audio_metadata\` (line 335) and \`_maybe_load_structural\` (line 353) honored this for **missing files** (returned None) and for **parsed-but-not-a-dict** (returned None) — but a syntactically broken \`source.audio.json\` or \`structural.yaml\` in **one** song would raise \`JSONDecodeError\` / \`yaml.YAMLError\` and crash the whole load (30+ songs in the real \`pop_eval_v1\`).

## Fix

Catch the parse exception in both helpers, log a warning so the corruption is visible to whoever maintains the eval set, return None.

The warning means the corruption is **reported, not silently masked** — but the failure mode shifts from "30-song eval run crashes on row 7" to "30-song eval run continues with row 7's structural reference treated as absent, plus a logged warning naming the corrupt file."

## Test plan
Two new regression tests under \`tests/test_eval_loader.py\`:
- \`test_corrupt_audio_metadata_json_returns_none_with_warning\` — writes invalid JSON, asserts None + warning logged
- \`test_corrupt_structural_yaml_returns_none_with_warning\` — writes unclosed YAML flow-style, asserts None + warning logged

\`pytest tests/test_eval_loader.py\` — 21 passed (19 previous + 2 new). \`ruff check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)