### PR TITLE
fix(ingest): per-call ytdlp cookies tmp + tolerate missing info['id']

### DIFF
--- a/backend/services/_ytdlp_utils.py
+++ b/backend/services/_ytdlp_utils.py
@@ -20,11 +20,16 @@ log = logging.getLogger(__name__)
 # tokens during a download and writes them back to disk. The deployed
 # source file is bind-mounted ``:ro`` in docker-compose.prod.yml, so
 # pointing yt-dlp directly at it crashes with
-# ``[Errno 30] Read-only file system``. We copy the source into a
-# pid-scoped tmp file on each call and hand yt-dlp the writable copy.
-# The copy is ephemeral — any rotations yt-dlp writes get overwritten
-# on the next call from the read-only source of truth.
-_TMP_COOKIES = Path(tempfile.gettempdir()) / f"ytdlp-cookies-{os.getpid()}.txt"
+# ``[Errno 30] Read-only file system``. We copy the source into a tmp
+# file per call and hand yt-dlp the writable copy. The copy is
+# ephemeral — any rotations yt-dlp writes get overwritten on the next
+# call from the read-only source of truth.
+#
+# Per-call (rather than module-level) tmp paths are required because
+# Celery workers run multiple jobs concurrently inside one process: a
+# shared path means thread B's copy can clobber thread A's rotated
+# tokens mid-download, corrupting auth and breaking the in-flight job.
+_TMP_COOKIES_PREFIX = "ytdlp-cookies-"
 
 
 def apply_ytdlp_cookies(ydl_opts: dict) -> None:
@@ -41,6 +46,11 @@ def apply_ytdlp_cookies(ydl_opts: dict) -> None:
     empty file (the default state before the OHSHEET_YTDLP_COOKIES
     secret is set) is treated as "no cookies, run anonymously." This
     makes the deploy safe whether or not cookies are provisioned.
+
+    Each call gets its own tmp cookiefile so concurrent yt-dlp downloads
+    in the same process (Celery worker fan-out) don't race on a shared
+    path. The tmp files are small and short-lived; the OS reaps /tmp on
+    reboot or via systemd-tmpfiles, so we don't bother explicit cleanup.
     """
     path_str = settings.ytdlp_cookies_path
     if not path_str:
@@ -56,14 +66,15 @@ def apply_ytdlp_cookies(ydl_opts: dict) -> None:
         return
 
     try:
-        shutil.copyfile(src, _TMP_COOKIES)
+        # mkstemp returns an open fd we don't need (we copy bytes in via
+        # shutil.copyfile against the path) — close it immediately.
+        fd, tmp_path = tempfile.mkstemp(prefix=_TMP_COOKIES_PREFIX, suffix=".txt")
+        os.close(fd)
+        shutil.copyfile(src, tmp_path)
     except OSError as exc:
         # Tmp dir full / permission-denied — yt-dlp runs without
         # cookies rather than crashing the job.
-        log.warning(
-            "ytdlp cookies: cannot copy %s to %s: %s",
-            src, _TMP_COOKIES, exc,
-        )
+        log.warning("ytdlp cookies: cannot copy %s to tmp: %s", src, exc)
         return
 
-    ydl_opts["cookiefile"] = str(_TMP_COOKIES)
+    ydl_opts["cookiefile"] = tmp_path

--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -113,10 +113,13 @@ def _download_youtube_sync(url: str, blob_store) -> tuple[RemoteAudioFile, str |
         except Exception as exc:
             raise RuntimeError(f"yt-dlp download failed for {url}: {exc}") from exc
 
-        # Find the downloaded WAV file
-        wav_path = Path(tmp_dir) / f"{info['id']}.wav"
-        if not wav_path.exists():
-            # yt-dlp may use a different naming — find any .wav in the dir
+        # Find the downloaded WAV file. Prefer ``info['id']`` when yt-dlp
+        # populates it; fall back to a glob if 'id' is absent (rare but
+        # observed on some unlisted/age-restricted videos) or if yt-dlp
+        # used a different naming convention than expected.
+        info_id = info.get("id") if isinstance(info, dict) else None
+        wav_path = Path(tmp_dir) / f"{info_id}.wav" if info_id else None
+        if wav_path is None or not wav_path.exists():
             wav_files = list(Path(tmp_dir).glob("*.wav"))
             if not wav_files:
                 raise RuntimeError(f"No WAV file produced by yt-dlp for {url}")

--- a/tests/test_ytdlp_utils.py
+++ b/tests/test_ytdlp_utils.py
@@ -157,3 +157,29 @@ def test_stat_raising_oserror_is_graceful(
     opts: dict = {}
     apply_ytdlp_cookies(opts)  # must not raise
     assert "cookiefile" not in opts
+
+
+def test_concurrent_calls_get_distinct_tmp_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Regression: two calls in the same process used to share one
+    pid-scoped tmp path, so concurrent yt-dlp downloads in one Celery
+    worker would clobber each other's rotated session tokens. Now each
+    call must get its own tmp file.
+    """
+    cookies = tmp_path / "cookies.txt"
+    cookies.write_text("# Netscape HTTP Cookie File\nfoo\tbar\n")
+    _patch_path(monkeypatch, str(cookies))
+
+    opts_a: dict = {}
+    apply_ytdlp_cookies(opts_a)
+    opts_b: dict = {}
+    apply_ytdlp_cookies(opts_b)
+
+    assert "cookiefile" in opts_a and "cookiefile" in opts_b
+    assert opts_a["cookiefile"] != opts_b["cookiefile"], (
+        "concurrent calls must not share a tmp path"
+    )
+    # Both copies still mirror the source.
+    assert Path(opts_a["cookiefile"]).read_text() == cookies.read_text()
+    assert Path(opts_b["cookiefile"]).read_text() == cookies.read_text()


### PR DESCRIPTION
## Summary

Two related ingest-robustness fixes.

### 1. ytdlp cookies tmp path was shared across concurrent calls
\`backend/services/_ytdlp_utils.py:27\` defined the cookies tmp path at module scope: \`Path(tempfile.gettempdir()) / f"ytdlp-cookies-{os.getpid()}.txt"\`. Pid-scoped sounds safe but Celery workers run **multiple ingest jobs concurrently inside one process**, so two concurrent yt-dlp downloads race on the same path:

- Thread A copies its source cookies → tmp.
- Thread A starts download (yt-dlp opens tmp, reads tokens, possibly rotates them).
- Thread B copies the (still-current) source cookies → tmp, **overwriting A's rotated tokens.**
- A and B's yt-dlp instances now disagree on the cookie state mid-download.

Fix: \`tempfile.mkstemp(prefix="ytdlp-cookies-", suffix=".txt")\` per call. The tmp files are small (a few KB) and short-lived; \`/tmp\` is reaped on reboot or by systemd-tmpfiles, so we skip explicit cleanup.

### 2. KeyError on \`info['id']\` bypassing the existing glob fallback
\`backend/services/ingest.py:117\` does \`wav_path = Path(tmp_dir) / f"{info['id']}.wav"\`. If yt-dlp's \`extract_info()\` returns a dict without \`'id'\` (rare but observed on some unlisted/age-restricted videos), this raises \`KeyError\` **before** reaching the existing glob fallback at line 118-123. Use \`info.get("id")\` and treat \`None\` as "go straight to the glob fallback".

## Test plan
- New \`test_concurrent_calls_get_distinct_tmp_paths\` regression-locks the per-call path contract.
- All 7 existing \`test_ytdlp_utils\` tests + 22 \`test_ingest_youtube\` tests still pass — 29 passed.
- \`ruff check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)