### PR TITLE
fix(midi_render): use emission counter for downbeat bar labels

### DIFF
--- a/backend/services/midi_render.py
+++ b/backend/services/midi_render.py
@@ -392,17 +392,22 @@ def _build_meta_events(
     # for MIDI meta event FF 07. Bar numbers are 1-indexed for human
     # readability when an engraver dumps them as text; engravers that
     # actually use the cue points read the *time* and ignore the label.
+    # Use a counter that only increments on emission so bar labels stay
+    # contiguous: when an audio source's first tempo_map entry is at
+    # e.g. 0.65s, downbeats earlier than that are skipped, and an
+    # ``enumerate`` index would mislabel surviving bars (bar3, bar4...
+    # for what should be bar1, bar2...).
     downbeat_count = 0
-    for i, db_sec in enumerate(downbeats or []):
+    for db_sec in downbeats or []:
         sec_in_render = float(db_sec) - initial_time_offset
         if sec_in_render < 0:
             continue
         tick = _sec_to_tick(sec_in_render)
+        downbeat_count += 1
         events.append((
             tick,
-            mido_module.MetaMessage("cue_marker", text=f"bar{i + 1}"),
+            mido_module.MetaMessage("cue_marker", text=f"bar{downbeat_count}"),
         ))
-        downbeat_count += 1
     if downbeat_count:
         features.downbeats = True
         features.downbeat_cue_count = downbeat_count

--- a/tests/test_midi_render.py
+++ b/tests/test_midi_render.py
@@ -272,6 +272,36 @@ def test_render_skips_downbeat_cues_when_field_empty():
     assert not cues
 
 
+def test_render_relabels_downbeats_after_offset_skip():
+    """Regression: when the audio path's first tempo_map entry sits at
+    e.g. t=0.5s, every downbeat earlier than that gets skipped from the
+    cue stream. Pre-fix, the surviving bars were labelled with the
+    enumerate index of the *original* sequence — so a downbeats list of
+    [0.0, 0.25, 0.5, 1.0, 1.5] with tempo_map starting at 0.5s would
+    emit 'bar3' / 'bar4' / 'bar5' instead of the contiguous 'bar1' /
+    'bar2' / 'bar3'. Engravers ignore the label (they use the time)
+    but the human-readable layer was wrong.
+    """
+    import mido  # noqa: PLC0415
+
+    # tempo_map starts at 0.5s — anything earlier than that is dropped
+    # by midi_render's offset-skip logic.
+    tempo_map = [TempoMapEntry(time_sec=0.5, beat=0.0, bpm=120.0)]
+    rendered = render_midi(
+        _perf(
+            _basic_notes(),
+            tempo_map=tempo_map,
+            downbeats=[0.0, 0.25, 0.5, 1.0, 1.5],
+        ),
+    )
+
+    mid = mido.MidiFile(file=io.BytesIO(rendered.midi_bytes))
+    cues = [m for tr in mid.tracks for m in tr if m.type == "cue_marker"]
+    # Three downbeats at or after the offset survive (0.5, 1.0, 1.5).
+    assert [c.text for c in cues] == ["bar1", "bar2", "bar3"]
+    assert rendered.features.downbeat_cue_count == 3
+
+
 def test_pedal_events_set_includes_pedal_marks_flag():
     """Sustain pedal events emit CC64 and surface on the features flag."""
     pedal = [PedalEvent(onset_beat=0.0, offset_beat=2.0, type="sustain")]


### PR DESCRIPTION
## Summary

\`backend/services/midi_render.py:396-405\` builds MIDI Cue Point text events from the downbeats list, labelling each one \`bar{i+1}\` where \`i\` is the \`enumerate\` index. But the loop ALSO skips any downbeat whose render-relative time is negative (line 398-399), and the index doesn't reset on skip — so surviving bars get the *original* downbeat's index, not their position in the rendered sequence.

## Concrete failure

The audio path's first \`tempo_map\` entry isn't always at \`t=0\` — it sits at whatever time the beat tracker found the first beat (often 0.3-1.0s in). \`midi_time_offset = tempo_map[0].time_sec\` (line 175), and downbeats earlier than that get skipped (line 398: \`if sec_in_render < 0: continue\`).

Input: \`downbeats=[0.0, 0.25, 0.5, 1.0, 1.5]\` with \`tempo_map\` starting at \`0.5s\`.
Pre-fix output: cues labelled \`bar3\`, \`bar4\`, \`bar5\` (from the original indices 2, 3, 4).
Correct output: \`bar1\`, \`bar2\`, \`bar3\`.

The comment at line 393-394 already says engravers read the time and ignore the label — so PDFs aren't visibly broken — but the label is wrong in MIDI text dumps, debug logs, and any future tool that consumes it.

## Fix

The \`downbeat_count\` variable was already in scope (used for the features flag after the loop). Drop \`enumerate\`, increment \`downbeat_count\` on emission, use it for the label.

## Test plan

New \`test_render_relabels_downbeats_after_offset_skip\`: \`tempo_map\` starts at \`0.5s\`, downbeats span before/after; assert labels are \`bar1\`/\`bar2\`/\`bar3\`. All 28 existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)